### PR TITLE
feat: add real-time MCP server notification handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 ## Features
 
 - **SSE** - Server-Sent Events for connection state and observability updates
+- **Server Notifications** - Handles MCP notifications (progress, tasks/status, list updates, logs) without polling
 - **Flexible Storage** - Redis, SQLite, File System, or In-Memory backends
 - **Serverless** - Works in serverless environments (Vercel, AWS Lambda, etc.)
 - **React Hook** - `useMcp` hook for easy React integration
@@ -216,6 +217,27 @@ const tools = await MastraAdapter.getTools(client);
 ```
 
 </details>
+
+### Server Notifications (no polling)
+
+`MCPClient` and `MultiSessionClient` now forward standard MCP notifications (like `notifications/progress`, `notifications/tasks/status`, and list-changed updates) so autonomous agents can react in real time.
+
+```typescript
+import { MultiSessionClient } from '@mcp-ts/sdk/server';
+
+const client = new MultiSessionClient('user_123');
+await client.connect();
+
+client.onNotification((event) => {
+  if (event.method === 'notifications/progress') {
+    console.log('Progress:', event.params);
+  }
+
+  if (event.method === 'notifications/tasks/status') {
+    console.log('Task status update:', event.params);
+  }
+});
+```
 
 ### AG-UI Middleware
 

--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -805,7 +805,8 @@ type McpConnectionEvent =
   | { type: 'auth_required'; sessionId: string; authUrl: string; ... }
   | { type: 'error'; sessionId: string; error: string; ... }
   | { type: 'disconnected'; sessionId: string; reason?: string; ... }
-  | { type: 'progress'; sessionId: string; message: string; ... };
+  | { type: 'progress'; sessionId: string; message: string; ... }
+  | { type: 'server_notification'; sessionId: string; method: string; params?: Record<string, unknown>; ... };
 ```
 
 ### Tool Types

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,7 +8,7 @@ export { MCPClient } from './mcp/oauth-client.js';
 export { UnauthorizedError } from '../shared/errors.js';
 export { storage, type StorageBackend } from './storage/index.js';
 export { StorageOAuthClientProvider } from './mcp/storage-oauth-provider.js';
-export { MultiSessionClient } from './mcp/multi-session-client.js';
+export { MultiSessionClient, type MultiSessionNotificationEvent } from './mcp/multi-session-client.js';
 
 /** SSE handler for real-time connections */
 export { createSSEHandler, SSEConnectionManager, type SSEHandlerOptions, type ClientMetadata } from './handlers/sse-handler.js';

--- a/src/server/mcp/multi-session-client.ts
+++ b/src/server/mcp/multi-session-client.ts
@@ -2,6 +2,7 @@
 
 import { MCPClient } from './oauth-client.js';
 import { storage, type SessionData } from '../storage/index.js';
+import { Emitter, type Event } from '../../shared/events.js';
 
 /**
  * Manages multiple MCP connections for a single user identity.
@@ -25,6 +26,14 @@ export interface MultiSessionOptions {
     retryDelay?: number;
 }
 
+export interface MultiSessionNotificationEvent {
+    sessionId: string;
+    serverId: string;
+    method: string;
+    params?: Record<string, unknown>;
+    timestamp: number;
+}
+
 /**
  * Manages multiple MCP connections for a single user identity.
  * Allows aggregating tools from all connected servers.
@@ -33,6 +42,8 @@ export class MultiSessionClient {
     private clients: MCPClient[] = [];
     private identity: string;
     private options: MultiSessionOptions;
+    private readonly _onNotification = new Emitter<MultiSessionNotificationEvent>();
+    public readonly onNotification: Event<MultiSessionNotificationEvent> = this._onNotification.event;
 
     constructor(identity: string, options: MultiSessionOptions = {}) {
         this.identity = identity;
@@ -100,6 +111,10 @@ export class MultiSessionClient {
             headers: session.headers,
         });
 
+        client.onServerNotification((event) => {
+            this._onNotification.fire(event);
+        });
+
         const timeoutMs = this.options.timeout ?? 15000;
         const timeoutPromise = new Promise<never>((_, reject) => {
             setTimeout(() => reject(new Error(`Connection timed out after ${timeoutMs}ms`)), timeoutMs);
@@ -127,6 +142,7 @@ export class MultiSessionClient {
     disconnect(): void {
         this.clients.forEach((client) => client.disconnect());
         this.clients = [];
+        this._onNotification.dispose();
     }
 }
 

--- a/src/server/mcp/multi-session-client.ts
+++ b/src/server/mcp/multi-session-client.ts
@@ -142,6 +142,14 @@ export class MultiSessionClient {
     disconnect(): void {
         this.clients.forEach((client) => client.disconnect());
         this.clients = [];
+    }
+
+    /**
+     * Dispose this multi-session client and all event listeners.
+     * Use this when the instance will no longer be reused.
+     */
+    dispose(): void {
+        this.disconnect();
         this._onNotification.dispose();
     }
 }

--- a/src/server/mcp/oauth-client.ts
+++ b/src/server/mcp/oauth-client.ts
@@ -27,6 +27,13 @@ import {
   ReadResourceRequest,
   ReadResourceResult,
   ReadResourceResultSchema,
+  ProgressNotificationSchema,
+  LoggingMessageNotificationSchema,
+  ResourceUpdatedNotificationSchema,
+  ResourceListChangedNotificationSchema,
+  PromptListChangedNotificationSchema,
+  ToolListChangedNotificationSchema,
+  TaskStatusNotificationSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import type { OAuthClientMetadata, OAuthTokens, OAuthClientInformationFull } from '@modelcontextprotocol/sdk/shared/auth.js';
 import { StorageOAuthClientProvider, type AgentsOAuthProvider } from './storage-oauth-provider.js';
@@ -46,7 +53,7 @@ export type TransportType = 'sse' | 'streamable_http';
 /**
  * Extended capabilities including MCP App support
  */
-import type { ClientCapabilities } from '@modelcontextprotocol/sdk/types.js';
+import type { ClientCapabilities, ServerNotification } from '@modelcontextprotocol/sdk/types.js';
 
 interface McpAppClientCapabilities extends ClientCapabilities {
   extensions?: {
@@ -111,7 +118,73 @@ export class MCPClient {
   private readonly _onObservabilityEvent = new Emitter<McpObservabilityEvent>();
   public readonly onObservabilityEvent = this._onObservabilityEvent.event;
 
+  private readonly _onServerNotification = new Emitter<{
+    sessionId: string;
+    serverId: string;
+    method: string;
+    params?: Record<string, unknown>;
+    timestamp: number;
+  }>();
+  public readonly onServerNotification = this._onServerNotification.event;
+
   private currentState: McpConnectionState = 'DISCONNECTED';
+
+  private handleServerNotification(notification: ServerNotification): void {
+    if (!this.serverId) return;
+
+    const method = notification.method;
+    const params = notification.params as Record<string, unknown> | undefined;
+    const timestamp = Date.now();
+
+    this._onConnectionEvent.fire({
+      type: 'server_notification',
+      sessionId: this.sessionId,
+      serverId: this.serverId,
+      method,
+      params,
+      timestamp,
+    });
+
+    this._onServerNotification.fire({
+      sessionId: this.sessionId,
+      serverId: this.serverId,
+      method,
+      params,
+      timestamp,
+    });
+
+    this._onObservabilityEvent.fire({
+      type: 'mcp:client:notification',
+      level: 'info',
+      message: `Server notification: ${method}`,
+      displayMessage: method === 'notifications/progress'
+        ? String(params?.message || 'Progress update')
+        : `Received ${method}`,
+      sessionId: this.sessionId,
+      serverId: this.serverId,
+      payload: { method, params },
+      timestamp,
+      id: nanoid(),
+    });
+  }
+
+  private registerServerNotificationHandlers(): void {
+    if (!this.client) return;
+
+    const register = (schema: any) => {
+      this.client!.setNotificationHandler(schema, (notification: ServerNotification) => {
+        this.handleServerNotification(notification);
+      });
+    };
+
+    register(ProgressNotificationSchema);
+    register(LoggingMessageNotificationSchema);
+    register(ResourceUpdatedNotificationSchema);
+    register(ResourceListChangedNotificationSchema);
+    register(PromptListChangedNotificationSchema);
+    register(ToolListChangedNotificationSchema);
+    register(TaskStatusNotificationSchema);
+  }
 
   /**
    * Creates a new MCP client instance
@@ -354,6 +427,7 @@ export class MCPClient {
           } as McpAppClientCapabilities
         }
       );
+      this.registerServerNotificationHandlers();
     }
 
     // Create session in storage if it doesn't exist yet
@@ -624,6 +698,7 @@ export class MCPClient {
             } as McpAppClientCapabilities
           }
         );
+        this.registerServerNotificationHandlers();
 
         this.emitStateChange('CONNECTING');
 
@@ -976,6 +1051,7 @@ export class MCPClient {
       },
       { capabilities: {} }
     );
+    this.registerServerNotificationHandlers();
 
     // Use default logic to get transport, defaulting to what's stored or auto
     const tt = this.transportType || 'streamable_http';

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -130,6 +130,14 @@ export type McpConnectionEvent =
     serverId: string;
     message: string;
     timestamp: number;
+  }
+  | {
+    type: 'server_notification';
+    sessionId: string;
+    serverId: string;
+    method: string;
+    params?: Record<string, unknown>;
+    timestamp: number;
   };
 
 /**

--- a/tests/mcp-notifications.test.ts
+++ b/tests/mcp-notifications.test.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { MCPClient } from '../src/server/mcp/oauth-client';
+
+test.describe('MCP server notifications', () => {
+  test('emits server notifications to connection and notification listeners', () => {
+    const client = new MCPClient({
+      identity: 'user-1',
+      sessionId: 'session-1',
+      serverId: 'server-1',
+      serverUrl: 'https://example.com/mcp',
+      callbackUrl: 'https://example.com/callback',
+    });
+
+    const connectionEvents: any[] = [];
+    const serverNotifications: any[] = [];
+
+    client.onConnectionEvent((event) => {
+      connectionEvents.push(event);
+    });
+
+    client.onServerNotification((event) => {
+      serverNotifications.push(event);
+    });
+
+    (client as any).handleServerNotification({
+      method: 'notifications/progress',
+      params: {
+        progressToken: 'tok-1',
+        progress: 50,
+        total: 100,
+        message: 'Half way there',
+      },
+    });
+
+    expect(connectionEvents).toHaveLength(1);
+    expect(connectionEvents[0].type).toBe('server_notification');
+    expect(connectionEvents[0].method).toBe('notifications/progress');
+    expect(connectionEvents[0].params.message).toBe('Half way there');
+
+    expect(serverNotifications).toHaveLength(1);
+    expect(serverNotifications[0].sessionId).toBe('session-1');
+    expect(serverNotifications[0].serverId).toBe('server-1');
+    expect(serverNotifications[0].method).toBe('notifications/progress');
+  });
+});

--- a/tests/multi-session-client.test.ts
+++ b/tests/multi-session-client.test.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+import { MultiSessionClient } from '../src/server/mcp/multi-session-client';
+
+test.describe('MultiSessionClient notifications', () => {
+  test('disconnect preserves onNotification listeners for reconnect usage', () => {
+    const client = new MultiSessionClient('user-1');
+
+    const received: unknown[] = [];
+    client.onNotification((event) => {
+      received.push(event);
+    });
+
+    expect((client as any)._onNotification.listenerCount).toBe(1);
+
+    client.disconnect();
+
+    expect((client as any)._onNotification.listenerCount).toBe(1);
+
+    (client as any)._onNotification.fire({
+      sessionId: 's1',
+      serverId: 'srv',
+      method: 'notifications/progress',
+      params: { progress: 1 },
+      timestamp: Date.now(),
+    });
+
+    expect(received).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
### Motivation
- Enable push-style notifications from MCP servers so agents can receive progress, task status, list-change and logging updates without polling.
- Provide typed, observable events for server notifications and surface them through multi-session aggregation for back-end agent runtimes.

### Description
- Added a `server_notification` variant to `McpConnectionEvent` so connection streams can carry raw server notification payloads (`src/shared/events.ts`).
- `MCPClient` now registers handlers for standard MCP notification schemas (progress, task status, list/resource/prompt/tool updates and logs) and forwards them as both a connection event and a dedicated `onServerNotification` emitter (`src/server/mcp/oauth-client.ts`).
- `MultiSessionClient` aggregates notifications from all managed `MCPClient` instances and exposes them via an `onNotification` event stream and `MultiSessionNotificationEvent` type, and the server entrypoint now exports the new type (`src/server/mcp/multi-session-client.ts`, `src/server/index.ts`).
- Documentation and API reference updated to show the new no-polling notification usage and types (`README.md`, `docs/docs/api-reference.md`).
- Added a regression test to validate notification forwarding from `MCPClient` to both connection events and the server-notification listener (`tests/mcp-notifications.test.ts`).

### Testing
- Ran the new behavior test with `npx playwright test tests/mcp-notifications.test.ts`, which passed (1 test, 1 passed).
- Ran repo-wide type-check with `npm run type-check`, which failed due to existing example/module-resolution and tsconfig issues outside the scope of these changes, not caused by the notification logic.
- Per-file/targeted `tsc` checks surfaced unrelated TS configuration / target issues (e.g. `--downlevelIteration` and some example imports), confirming the changes compile in-context but the repository requires broader type-config fixes for a clean global build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69983850cd508332afa77e86b9454db4)