### PR TITLE
fix: clean stale notification forwarders on failed connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,15 +228,22 @@ import { MultiSessionClient } from '@mcp-ts/sdk/server';
 const client = new MultiSessionClient('user_123');
 await client.connect();
 
-client.onNotification((event) => {
-  if (event.method === 'notifications/progress') {
-    console.log('Progress:', event.params);
-  }
-
-  if (event.method === 'notifications/tasks/status') {
-    console.log('Task status update:', event.params);
-  }
+const subscription = client.setNotificationHandlers({
+  onProgress: (event) => {
+    const total = event.total ?? event.progress;
+    const percent = total > 0 ? (event.progress / total) * 100 : event.progress;
+    console.log(`Progress ${percent.toFixed(1)}%`, event.message);
+  },
+  onTaskStatus: (event) => {
+    console.log('Task status update:', event.status, event.taskId);
+  },
+  onToolListChanged: () => {
+    console.log('Tools changed, refresh cache');
+  },
 });
+
+// Later if needed:
+subscription.dispose();
 ```
 
 ### AG-UI Middleware

--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -242,6 +242,33 @@ mcp.disconnect();
 
 ---
 
+**Notification Events and Handlers**
+
+`MultiSessionClient` exposes both a generic event stream and typed notification hooks:
+
+- `onNotification(event)` - raw notification stream with `method` + `params`
+- `onProgress(event)` - `notifications/progress`
+- `onLoggingMessage(event)` - `notifications/message`
+- `onToolListChanged(event)` - `notifications/tools/list_changed`
+- `onResourceListChanged(event)` - `notifications/resources/list_changed`
+- `onPromptListChanged(event)` - `notifications/prompts/list_changed`
+- `onResourceUpdated(event)` - `notifications/resources/updated`
+- `onTaskStatus(event)` - `notifications/tasks/status`
+
+You can also register a FastMCP-style callback object:
+
+```typescript
+const subscription = mcp.setNotificationHandlers({
+  onProgress: (event) => console.log(event.progress, event.total),
+  onLoggingMessage: (event) => console.log(event.level, event.data),
+  onToolListChanged: () => console.log('tool list changed'),
+});
+
+subscription.dispose();
+```
+
+---
+
 
 ### Adapters
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,7 +8,7 @@ export { MCPClient } from './mcp/oauth-client.js';
 export { UnauthorizedError } from '../shared/errors.js';
 export { storage, type StorageBackend } from './storage/index.js';
 export { StorageOAuthClientProvider } from './mcp/storage-oauth-provider.js';
-export { MultiSessionClient, type MultiSessionNotificationEvent } from './mcp/multi-session-client.js';
+export { MultiSessionClient, type MultiSessionNotificationEvent, type MultiSessionNotificationHandlers, type MultiSessionProgressEvent, type MultiSessionLoggingEvent, type MultiSessionListChangedEvent, type MultiSessionResourceUpdatedEvent, type MultiSessionTaskStatusEvent } from './mcp/multi-session-client.js';
 
 /** SSE handler for real-time connections */
 export { createSSEHandler, SSEConnectionManager, type SSEHandlerOptions, type ClientMetadata } from './handlers/sse-handler.js';

--- a/src/server/mcp/multi-session-client.ts
+++ b/src/server/mcp/multi-session-client.ts
@@ -1,8 +1,7 @@
 
-
 import { MCPClient } from './oauth-client.js';
 import { storage, type SessionData } from '../storage/index.js';
-import { Emitter, type Event } from '../../shared/events.js';
+import { Emitter, type Disposable, type Event } from '../../shared/events.js';
 
 /**
  * Manages multiple MCP connections for a single user identity.
@@ -34,6 +33,50 @@ export interface MultiSessionNotificationEvent {
     timestamp: number;
 }
 
+export interface MultiSessionProgressEvent extends MultiSessionNotificationEvent {
+    method: 'notifications/progress';
+    progress: number;
+    total?: number;
+    message?: string;
+    progressToken?: string | number;
+}
+
+export interface MultiSessionLoggingEvent extends MultiSessionNotificationEvent {
+    method: 'notifications/message';
+    level?: string;
+    data?: unknown;
+    logger?: string;
+}
+
+export interface MultiSessionListChangedEvent extends MultiSessionNotificationEvent {
+    method:
+    | 'notifications/tools/list_changed'
+    | 'notifications/resources/list_changed'
+    | 'notifications/prompts/list_changed';
+}
+
+export interface MultiSessionResourceUpdatedEvent extends MultiSessionNotificationEvent {
+    method: 'notifications/resources/updated';
+    uri?: string;
+}
+
+export interface MultiSessionTaskStatusEvent extends MultiSessionNotificationEvent {
+    method: 'notifications/tasks/status';
+    taskId?: string;
+    status?: string;
+}
+
+export interface MultiSessionNotificationHandlers {
+    onNotification?: (event: MultiSessionNotificationEvent) => void;
+    onProgress?: (event: MultiSessionProgressEvent) => void;
+    onLoggingMessage?: (event: MultiSessionLoggingEvent) => void;
+    onToolListChanged?: (event: MultiSessionListChangedEvent) => void;
+    onResourceListChanged?: (event: MultiSessionListChangedEvent) => void;
+    onPromptListChanged?: (event: MultiSessionListChangedEvent) => void;
+    onResourceUpdated?: (event: MultiSessionResourceUpdatedEvent) => void;
+    onTaskStatus?: (event: MultiSessionTaskStatusEvent) => void;
+}
+
 /**
  * Manages multiple MCP connections for a single user identity.
  * Allows aggregating tools from all connected servers.
@@ -43,7 +86,23 @@ export class MultiSessionClient {
     private identity: string;
     private options: MultiSessionOptions;
     private readonly _onNotification = new Emitter<MultiSessionNotificationEvent>();
+    private readonly _onProgress = new Emitter<MultiSessionProgressEvent>();
+    private readonly _onLoggingMessage = new Emitter<MultiSessionLoggingEvent>();
+    private readonly _onToolListChanged = new Emitter<MultiSessionListChangedEvent>();
+    private readonly _onResourceListChanged = new Emitter<MultiSessionListChangedEvent>();
+    private readonly _onPromptListChanged = new Emitter<MultiSessionListChangedEvent>();
+    private readonly _onResourceUpdated = new Emitter<MultiSessionResourceUpdatedEvent>();
+    private readonly _onTaskStatus = new Emitter<MultiSessionTaskStatusEvent>();
+    private readonly notificationForwarders = new Map<string, Disposable>();
+
     public readonly onNotification: Event<MultiSessionNotificationEvent> = this._onNotification.event;
+    public readonly onProgress: Event<MultiSessionProgressEvent> = this._onProgress.event;
+    public readonly onLoggingMessage: Event<MultiSessionLoggingEvent> = this._onLoggingMessage.event;
+    public readonly onToolListChanged: Event<MultiSessionListChangedEvent> = this._onToolListChanged.event;
+    public readonly onResourceListChanged: Event<MultiSessionListChangedEvent> = this._onResourceListChanged.event;
+    public readonly onPromptListChanged: Event<MultiSessionListChangedEvent> = this._onPromptListChanged.event;
+    public readonly onResourceUpdated: Event<MultiSessionResourceUpdatedEvent> = this._onResourceUpdated.event;
+    public readonly onTaskStatus: Event<MultiSessionTaskStatusEvent> = this._onTaskStatus.event;
 
     constructor(identity: string, options: MultiSessionOptions = {}) {
         this.identity = identity;
@@ -52,6 +111,51 @@ export class MultiSessionClient {
             maxRetries: 2,
             retryDelay: 1000,
             ...options
+        };
+    }
+
+    /**
+     * Registers a notification handler object similar to FastMCP-style callbacks.
+     */
+    setNotificationHandlers(handlers: MultiSessionNotificationHandlers): Disposable {
+        const subscriptions: Disposable[] = [];
+
+        if (handlers.onNotification) {
+            subscriptions.push(this.onNotification(handlers.onNotification));
+        }
+
+        if (handlers.onProgress) {
+            subscriptions.push(this.onProgress(handlers.onProgress));
+        }
+
+        if (handlers.onLoggingMessage) {
+            subscriptions.push(this.onLoggingMessage(handlers.onLoggingMessage));
+        }
+
+        if (handlers.onToolListChanged) {
+            subscriptions.push(this.onToolListChanged(handlers.onToolListChanged));
+        }
+
+        if (handlers.onResourceListChanged) {
+            subscriptions.push(this.onResourceListChanged(handlers.onResourceListChanged));
+        }
+
+        if (handlers.onPromptListChanged) {
+            subscriptions.push(this.onPromptListChanged(handlers.onPromptListChanged));
+        }
+
+        if (handlers.onResourceUpdated) {
+            subscriptions.push(this.onResourceUpdated(handlers.onResourceUpdated));
+        }
+
+        if (handlers.onTaskStatus) {
+            subscriptions.push(this.onTaskStatus(handlers.onTaskStatus));
+        }
+
+        return {
+            dispose: () => {
+                subscriptions.forEach((subscription) => subscription.dispose());
+            }
         };
     }
 
@@ -99,6 +203,74 @@ export class MultiSessionClient {
         console.error(`[MultiSessionClient] Failed to connect to session ${session.sessionId} after ${maxRetries + 1} attempts:`, lastError);
     }
 
+    private toNotificationParams(params: unknown): Record<string, unknown> | undefined {
+        if (!params || typeof params !== 'object') {
+            return undefined;
+        }
+        return params as Record<string, unknown>;
+    }
+
+    private fireTypedNotifications(event: MultiSessionNotificationEvent): void {
+        const params = this.toNotificationParams(event.params);
+
+        switch (event.method) {
+            case 'notifications/progress': {
+                const progress = params?.progress;
+                if (typeof progress !== 'number') {
+                    return;
+                }
+
+                this._onProgress.fire({
+                    ...event,
+                    method: 'notifications/progress',
+                    progress,
+                    total: typeof params?.total === 'number' ? params.total : undefined,
+                    message: typeof params?.message === 'string' ? params.message : undefined,
+                    progressToken:
+                        typeof params?.progressToken === 'string' || typeof params?.progressToken === 'number'
+                            ? params.progressToken
+                            : undefined,
+                });
+                return;
+            }
+            case 'notifications/message':
+                this._onLoggingMessage.fire({
+                    ...event,
+                    method: 'notifications/message',
+                    level: typeof params?.level === 'string' ? params.level : undefined,
+                    data: params?.data,
+                    logger: typeof params?.logger === 'string' ? params.logger : undefined,
+                });
+                return;
+            case 'notifications/tools/list_changed':
+                this._onToolListChanged.fire({ ...event, method: 'notifications/tools/list_changed' });
+                return;
+            case 'notifications/resources/list_changed':
+                this._onResourceListChanged.fire({ ...event, method: 'notifications/resources/list_changed' });
+                return;
+            case 'notifications/prompts/list_changed':
+                this._onPromptListChanged.fire({ ...event, method: 'notifications/prompts/list_changed' });
+                return;
+            case 'notifications/resources/updated':
+                this._onResourceUpdated.fire({
+                    ...event,
+                    method: 'notifications/resources/updated',
+                    uri: typeof params?.uri === 'string' ? params.uri : undefined,
+                });
+                return;
+            case 'notifications/tasks/status':
+                this._onTaskStatus.fire({
+                    ...event,
+                    method: 'notifications/tasks/status',
+                    taskId: typeof params?.taskId === 'string' ? params.taskId : undefined,
+                    status: typeof params?.status === 'string' ? params.status : undefined,
+                });
+                return;
+            default:
+                return;
+        }
+    }
+
     private async createAndConnectClient(session: SessionData): Promise<MCPClient> {
         const client = new MCPClient({
             identity: this.identity,
@@ -111,17 +283,28 @@ export class MultiSessionClient {
             headers: session.headers,
         });
 
-        client.onServerNotification((event) => {
+        const existingForwarder = this.notificationForwarders.get(session.sessionId);
+        existingForwarder?.dispose();
+
+        const forwarder = client.onServerNotification((event) => {
             this._onNotification.fire(event);
+            this.fireTypedNotifications(event);
         });
+        this.notificationForwarders.set(session.sessionId, forwarder);
 
         const timeoutMs = this.options.timeout ?? 15000;
         const timeoutPromise = new Promise<never>((_, reject) => {
             setTimeout(() => reject(new Error(`Connection timed out after ${timeoutMs}ms`)), timeoutMs);
         });
 
-        await Promise.race([client.connect(), timeoutPromise]);
-        return client;
+        try {
+            await Promise.race([client.connect(), timeoutPromise]);
+            return client;
+        } catch (error) {
+            this.notificationForwarders.get(session.sessionId)?.dispose();
+            this.notificationForwarders.delete(session.sessionId);
+            throw error;
+        }
     }
 
     async connect(): Promise<void> {
@@ -140,9 +323,31 @@ export class MultiSessionClient {
      * Disconnects all clients.
      */
     disconnect(): void {
-        this.clients.forEach((client) => client.disconnect());
+        this.clients.forEach((client) => {
+            client.disconnect();
+        });
         this.clients = [];
-        this._onNotification.dispose();
-    }
-}
 
+        this.notificationForwarders.forEach((forwarder) => {
+            forwarder.dispose();
+        });
+        this.notificationForwarders.clear();
+    }
+    /**
+     * Dispose this multi-session client and all event listeners.
+     * Use this when the instance will no longer be reused.
+     */
+    dispose(): void {
+        this.disconnect();
+        this.notificationForwarders.clear();
+        this._onNotification.dispose();
+        this._onProgress.dispose();
+        this._onLoggingMessage.dispose();
+        this._onToolListChanged.dispose();
+        this._onResourceListChanged.dispose();
+        this._onPromptListChanged.dispose();
+        this._onResourceUpdated.dispose();
+        this._onTaskStatus.dispose();
+    }
+
+}

--- a/tests/multi-session-client.test.ts
+++ b/tests/multi-session-client.test.ts
@@ -1,0 +1,119 @@
+import { test, expect } from '@playwright/test';
+import { MultiSessionClient } from '../src/server/mcp/multi-session-client';
+
+test.describe('MultiSessionClient notification listeners', () => {
+  test('preserves onNotification listeners across disconnect', () => {
+    const client = new MultiSessionClient('user-1');
+
+    const received: any[] = [];
+    client.onNotification((event) => {
+      received.push(event);
+    });
+
+    (client as any).clients = [
+      {
+        getSessionId: () => 'session-1',
+        disconnect: () => undefined,
+      },
+    ];
+
+    client.disconnect();
+
+    (client as any)._onNotification.fire({
+      sessionId: 'session-1',
+      serverId: 'server-1',
+      method: 'notifications/progress',
+      timestamp: Date.now(),
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].sessionId).toBe('session-1');
+  });
+
+  test('supports typed notification handlers via setNotificationHandlers', () => {
+    const client = new MultiSessionClient('user-1');
+
+    const progressEvents: any[] = [];
+    const taskStatusEvents: any[] = [];
+
+    const subscription = client.setNotificationHandlers({
+      onProgress: (event) => {
+        progressEvents.push(event);
+      },
+      onTaskStatus: (event) => {
+        taskStatusEvents.push(event);
+      },
+    });
+
+    (client as any).fireTypedNotifications({
+      sessionId: 'session-1',
+      serverId: 'server-1',
+      method: 'notifications/progress',
+      params: { progress: 3, total: 10, message: 'working' },
+      timestamp: Date.now(),
+    });
+
+    (client as any).fireTypedNotifications({
+      sessionId: 'session-1',
+      serverId: 'server-1',
+      method: 'notifications/tasks/status',
+      params: { taskId: 'task-1', status: 'running' },
+      timestamp: Date.now(),
+    });
+
+    expect(progressEvents).toHaveLength(1);
+    expect(progressEvents[0].progress).toBe(3);
+    expect(taskStatusEvents).toHaveLength(1);
+    expect(taskStatusEvents[0].status).toBe('running');
+
+    subscription.dispose();
+
+    (client as any).fireTypedNotifications({
+      sessionId: 'session-1',
+      serverId: 'server-1',
+      method: 'notifications/progress',
+      params: { progress: 4 },
+      timestamp: Date.now(),
+    });
+
+    expect(progressEvents).toHaveLength(1);
+  });
+
+
+
+  test('disconnect clears stale forwarders even without connected clients', () => {
+    const client = new MultiSessionClient('user-1');
+
+    const disposed: string[] = [];
+    (client as any).notificationForwarders.set('failed-session', {
+      dispose: () => {
+        disposed.push('failed-session');
+      },
+    });
+
+    client.disconnect();
+
+    expect(disposed).toEqual(['failed-session']);
+    expect((client as any).notificationForwarders.size).toBe(0);
+  });
+  test('dispose removes notification listeners', () => {
+    const client = new MultiSessionClient('user-1');
+
+    const received: any[] = [];
+    client.onNotification((event) => {
+      received.push(event);
+    });
+
+    client.dispose();
+
+    (client as any)._onNotification.fire({
+      sessionId: 'session-1',
+      serverId: 'server-1',
+      method: 'notifications/progress',
+      timestamp: Date.now(),
+    });
+
+    expect(received).toHaveLength(0);
+  });
+
+});


### PR DESCRIPTION
### Motivation
- A review noted that `notificationForwarders` is populated before `client.connect()` completes, which can leave stale disposables if the connect attempt times out or rejects. This can leak references in long‑lived processes. 
- Ensure forwarders created during a failed `createAndConnectClient()` attempt are disposed and removed, and ensure `disconnect()` always clears any remaining forwarders.

### Description
- In `createAndConnectClient()` wrap the connect step in a `try/catch` and on error `dispose()` and `delete()` the session's forwarder from `notificationForwarders` before rethrowing. 
- Ensure any pre-existing forwarder for the same session is disposed before registering a new one by calling `existingForwarder?.dispose()` prior to `set(sessionId, forwarder)`. 
- Harden `disconnect()` to iterate over `notificationForwarders`, call `dispose()` on each entry, and then `clear()` the map regardless of whether `this.clients` contains the session. 
- Added a regression test `disconnect clears stale forwarders even without connected clients` in `tests/multi-session-client.test.ts` to validate forwarders are disposed and removed when `disconnect()` is invoked.

### Testing
- Ran `npx playwright test tests/multi-session-client.test.ts tests/mcp-notifications.test.ts` and all tests passed (`5 passed`).
- The changes touch `src/server/mcp/multi-session-client.ts` and `tests/multi-session-client.test.ts` and the new test verifies the stale-forwarder cleanup behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69983f1c57b08332a037465dd3583dc1)