### PR TITLE
feat(mcp): add task RPC helpers to MCPClient and session-scoped MultiSessionClient methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,10 +306,12 @@ await client.connect();
 const sessionId = client.getClients()[0]?.getSessionId();
 if (!sessionId) throw new Error('No connected sessions');
 
+const created = await client.callToolTask(sessionId, 'long_job', { durationMs: 2500 }, 60000);
+const taskId = created.task.taskId;
+
 const list = await client.listTasks(sessionId);
 
 if (list.tasks.length > 0) {
-  const taskId = list.tasks[0].taskId;
   const state = await client.getTask(sessionId, taskId);
 
   if (state.status === 'working') {

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 ## Features
 
 - **SSE** - Server-Sent Events for connection state and observability updates
-- **Server Notifications** - Handles MCP notifications (progress, tasks/status, list updates, logs) without polling
+- **Server Notifications** - Real-time push updates for progress, task status, list changes, and logs
 - **Flexible Storage** - Redis, SQLite, File System, or In-Memory backends
 - **Serverless** - Works in serverless environments (Vercel, AWS Lambda, etc.)
 - **React Hook** - `useMcp` hook for easy React integration
@@ -218,7 +218,7 @@ const tools = await MastraAdapter.getTools(client);
 
 </details>
 
-### Server Notifications (no polling)
+### Real-Time Server Notifications
 
 `MCPClient` and `MultiSessionClient` now forward standard MCP notifications (like `notifications/progress`, `notifications/tasks/status`, and list-changed updates) so autonomous agents can react in real time.
 
@@ -228,15 +228,100 @@ import { MultiSessionClient } from '@mcp-ts/sdk/server';
 const client = new MultiSessionClient('user_123');
 await client.connect();
 
-client.onNotification((event) => {
-  if (event.method === 'notifications/progress') {
-    console.log('Progress:', event.params);
+const subscription = client.setNotificationHandlers({
+  onProgress: (event) => {
+    const total = event.total ?? event.progress;
+    const percent = total > 0 ? (event.progress / total) * 100 : event.progress;
+    console.log(`Progress ${percent.toFixed(1)}%`, event.message);
+  },
+  onTaskStatus: (event) => {
+    console.log('Task status update:', event.status, event.taskId);
+  },
+  onToolListChanged: () => {
+    console.log('Tools changed, refresh cache');
+  },
+});
+
+// Later if needed:
+subscription.dispose();
+```
+
+### Verification Example: MCP Server Emitting Notifications
+
+Use this pattern to verify end-to-end notification handling from your side. The MCP server emits progress + task status notifications during a long-running tool call, and your runtime subscribes with `setNotificationHandlers`.
+
+```typescript
+// server/mock-mcp-notifier.ts
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+const server = new McpServer({ name: 'mock-notifier', version: '0.1.0' });
+
+// Pseudo-code shape: emit progress/task-status notifications while executing the tool.
+// (Use the SDK notification API available in your server runtime adapter.)
+server.registerTool('long_job', {
+  description: 'Simulates long work and emits notifications',
+  inputSchema: {},
+}, async () => {
+  // Emit examples:
+  // notifications/progress: { progressToken: 'job-1', progress: 25, total: 100, message: 'Step 1/4' }
+  // notifications/tasks/status: { taskId: 'task-1', status: 'working', statusMessage: 'Still running' }
+
+  return {
+    content: [{ type: 'text', text: 'done' }],
+  };
+});
+```
+
+```typescript
+// app runtime
+import { MultiSessionClient } from '@mcp-ts/sdk/server';
+
+const client = new MultiSessionClient('user_123');
+await client.connect();
+
+const sub = client.setNotificationHandlers({
+  onProgress: (event) => {
+    console.log('[progress]', event.serverId, event.progress, event.total, event.message);
+  },
+  onTaskStatus: (event) => {
+    console.log('[task-status]', event.serverId, event.taskId, event.status);
+  },
+});
+
+// Call your tool through adapter/runtime; verify logs arrive.
+// await ...tool invocation...
+
+sub.dispose();
+client.disconnect();
+```
+
+### Task RPC Helpers (session-scoped)
+
+`MultiSessionClient` now provides task helper methods for polling and retrieval by session.
+
+```typescript
+const client = new MultiSessionClient('user_123');
+await client.connect();
+
+const sessionId = client.getClients()[0]?.getSessionId();
+if (!sessionId) throw new Error('No connected sessions');
+
+const list = await client.listTasks(sessionId);
+
+if (list.tasks.length > 0) {
+  const taskId = list.tasks[0].taskId;
+  const state = await client.getTask(sessionId, taskId);
+
+  if (state.status === 'working') {
+    // optional: cancel if needed
+    // await client.cancelTask(sessionId, taskId);
   }
 
-  if (event.method === 'notifications/tasks/status') {
-    console.log('Task status update:', event.params);
+  if (state.status === 'completed') {
+    const payload = await client.getTaskResult(sessionId, taskId);
+    console.log('Task payload:', payload);
   }
-});
+}
 ```
 
 ### AG-UI Middleware

--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -242,6 +242,52 @@ mcp.disconnect();
 
 ---
 
+**Task RPC Helper Methods (session-scoped)**
+
+```typescript
+const state = await mcp.getTask(sessionId: string, taskId: string);
+const payload = await mcp.getTaskResult(sessionId: string, taskId: string);
+const list = await mcp.listTasks(sessionId: string, cursor?: string);
+const cancelled = await mcp.cancelTask(sessionId: string, taskId: string);
+```
+
+These delegate to the underlying `MCPClient` for the specified `sessionId`.
+
+---
+
+**Notification Events and Handlers**
+
+`MultiSessionClient` exposes both a generic event stream and typed notification hooks:
+
+- `onNotification(event)` - raw notification stream with `method` + `params`
+- `onProgress(event)` - `notifications/progress`
+- `onLoggingMessage(event)` - `notifications/message`
+- `onToolListChanged(event)` - `notifications/tools/list_changed`
+- `onResourceListChanged(event)` - `notifications/resources/list_changed`
+- `onPromptListChanged(event)` - `notifications/prompts/list_changed`
+- `onResourceUpdated(event)` - `notifications/resources/updated`
+- `onTaskStatus(event)` - `notifications/tasks/status`
+
+You can also register a FastMCP-style callback object:
+
+```typescript
+const subscription = mcp.setNotificationHandlers({
+  onProgress: (event) => console.log(event.progress, event.total),
+  onLoggingMessage: (event) => console.log(event.level, event.data),
+  onToolListChanged: () => console.log('tool list changed'),
+});
+
+subscription.dispose();
+```
+
+**Tasks compatibility note (MCP 2025-11-25):**
+
+- `mcp-ts` currently exposes task-related notifications such as `notifications/tasks/status` through `onTaskStatus`.
+- Full task RPC lifecycle helpers (`tasks/get`, `tasks/result`, `tasks/list`, `tasks/cancel`) are not yet exposed as first-class convenience methods in `MultiSessionClient`.
+- For now, use status/progress notifications for real-time UX and rely on your MCP server/runtime task APIs for polling and result retrieval.
+
+---
+
 
 ### Adapters
 

--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -638,6 +638,9 @@ const {
   autoConnect?: boolean,
   autoInitialize?: boolean,
   onConnectionEvent?: (event) => void,
+  onNotification?: (event) => void,
+  onProgress?: (event) => void,
+  onTaskStatus?: (event) => void,
   onLog?: (level, message, metadata) => void,
 });
 ```
@@ -649,6 +652,9 @@ const {
 - `autoConnect` - Auto-connect SSE on mount (default: true)
 - `autoInitialize` - Auto-load sessions on mount (default: true)
 - `onConnectionEvent` - Connection event handler (optional)
+- `onNotification` - Raw server notification handler (`type: 'server_notification'`) (optional)
+- `onProgress` - Convenience handler for `notifications/progress` events (optional)
+- `onTaskStatus` - Convenience handler for `notifications/tasks/status` events (optional)
 - `onLog` - Debug log handler (optional)
 
 **Returns:** Object with state and methods

--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -245,6 +245,7 @@ mcp.disconnect();
 **Task RPC Helper Methods (session-scoped)**
 
 ```typescript
+const created = await mcp.callToolTask(sessionId: string, toolName: string, args: Record<string, unknown>, ttl?: number);
 const state = await mcp.getTask(sessionId: string, taskId: string);
 const payload = await mcp.getTaskResult(sessionId: string, taskId: string);
 const list = await mcp.listTasks(sessionId: string, cursor?: string);
@@ -283,8 +284,8 @@ subscription.dispose();
 **Tasks compatibility note (MCP 2025-11-25):**
 
 - `mcp-ts` currently exposes task-related notifications such as `notifications/tasks/status` through `onTaskStatus`.
-- Full task RPC lifecycle helpers (`tasks/get`, `tasks/result`, `tasks/list`, `tasks/cancel`) are not yet exposed as first-class convenience methods in `MultiSessionClient`.
-- For now, use status/progress notifications for real-time UX and rely on your MCP server/runtime task APIs for polling and result retrieval.
+- Task RPC helper methods are exposed on `MCPClient` and delegated by `MultiSessionClient` (`callToolTask`, `getTask`, `getTaskResult`, `listTasks`, `cancelTask`).
+- Use status/progress notifications for real-time UX and task helpers for polling, retrieval, and cancellation flows.
 
 ---
 

--- a/docs/docs/react.md
+++ b/docs/docs/react.md
@@ -58,6 +58,17 @@ useMcp({
     console.log('Event:', event);
   },
 
+  // Optional: Cleaner notification callbacks
+  onNotification: (event) => {
+    console.log('Server notification:', event.method, event.params);
+  },
+  onProgress: (event) => {
+    console.log('Progress:', event.params);
+  },
+  onTaskStatus: (event) => {
+    console.log('Task status:', event.params);
+  },
+
   // Optional: Debug log handler
   onLog: (level, message, metadata) => {
     console.log(`[${level}] ${message}`, metadata);
@@ -192,7 +203,7 @@ type McpConnectionState =
 
 ## Event Handling
 
-Handle connection events for custom logic:
+Handle connection lifecycle and notifications with either a single event stream (`onConnectionEvent`) or cleaner notification-specific callbacks.
 
 ```typescript
 const { connections } = useMcp({
@@ -209,7 +220,6 @@ const { connections } = useMcp({
         break;
 
       case 'auth_required':
-        // Redirect to OAuth
         window.location.href = event.authUrl;
         break;
 
@@ -221,6 +231,17 @@ const { connections } = useMcp({
         console.log('Disconnected:', event.reason);
         break;
     }
+  },
+
+  // Optional convenience notification handlers
+  onNotification: (event) => {
+    console.log('Raw notification:', event.method, event.params);
+  },
+  onProgress: (event) => {
+    console.log('Progress update:', event.params);
+  },
+  onTaskStatus: (event) => {
+    console.log('Task status update:', event.params);
   },
 });
 ```

--- a/examples/agents/src/app/api/copilotkit/route.ts
+++ b/examples/agents/src/app/api/copilotkit/route.ts
@@ -29,6 +29,15 @@ export const POST = async (req: NextRequest) => {
   const { MultiSessionClient } = await import("@mcp-ts/sdk/server");
   const client = new MultiSessionClient(identity);
 
+  const notificationSubscription = client.setNotificationHandlers({
+    onProgress: (event) => {
+      console.log(`[CopilotKit][progress][${event.serverId}] ${event.progress}/${event.total ?? '?'} ${event.message ?? ''}`);
+    },
+    onTaskStatus: (event) => {
+      console.log(`[CopilotKit][task][${event.serverId}] ${event.taskId ?? 'unknown'} -> ${event.status ?? 'unknown'}`);
+    },
+  });
+
   // Connect to all active sessions before getting tools
   await client.connect();
 
@@ -69,5 +78,11 @@ export const POST = async (req: NextRequest) => {
       endpoint: "/api/copilotkit",
     });
 
-  return handleRequest(req);
+  const response = await handleRequest(req);
+
+  // In long-lived runtimes, prefer managed lifecycle hooks. For this per-request example,
+  // clean up subscriptions after request handling.
+  notificationSubscription.dispose();
+
+  return response;
 };

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -231,6 +231,7 @@ Once connected:
 - Click **Run Tool**
 - View the result in the modal
 
+
 **Programmatic Usage**:
 ```typescript
 const { callTool } = useMcp({ ... });
@@ -240,6 +241,28 @@ const result = await callTool(
   'tool_name',
   { arg1: 'value1' }
 );
+```
+
+**Server-side task helpers (no frontend polling loop required in UI code):**
+```typescript
+import { MultiSessionClient } from '@mcp-ts/sdk/server';
+
+const manager = new MultiSessionClient(identity);
+await manager.connect();
+
+const sessionId = manager.getClients()[0]?.getSessionId();
+if (!sessionId) throw new Error('No connected sessions');
+
+const created = await manager.callToolTask(sessionId, 'long_job', { durationMs: 2000 }, 60000);
+let state = await manager.getTask(sessionId, created.task.taskId);
+
+while (state.status === 'working' || state.status === 'input_required') {
+  await new Promise((resolve) => setTimeout(resolve, state.pollInterval ?? 1000));
+  state = await manager.getTask(sessionId, created.task.taskId);
+}
+
+const payload = await manager.getTaskResult(sessionId, created.task.taskId);
+console.log(payload);
 ```
 
 ### 5. Disconnect

--- a/examples/nextjs/app/openai-agent/agent.ts
+++ b/examples/nextjs/app/openai-agent/agent.ts
@@ -10,20 +10,36 @@ You are an expert assistant, an AI assistant that helps users with their tasks u
 export async function createMcpAgent(identity: string = 'demo-user-123') {
     const manager = new MultiSessionClient(identity);
 
+    const notificationSubscription = manager.setNotificationHandlers({
+        onProgress: (event) => {
+            console.log(`[MCP][progress][${event.serverId}] ${event.progress}/${event.total ?? '?'} ${event.message ?? ''}`);
+        },
+        onTaskStatus: (event) => {
+            console.log(`[MCP][task][${event.serverId}] ${event.taskId ?? 'unknown'} -> ${event.status ?? 'unknown'}`);
+        },
+    });
+
     try {
         await manager.connect();
     } catch (error) {
+        notificationSubscription.dispose();
         console.error("[MCP] Connection failed:", error);
     }
 
     const tools = await AIAdapter.getTools(manager);
     console.log(`[MCP] Loaded ${Object.keys(tools).length} tools for agent.`);
 
-    return new ToolLoopAgent({
+    const agent = new ToolLoopAgent({
         model: openai('gpt-4.1-mini'),
         instructions: INSTRUCTIONS,
         tools: tools as any,
         stopWhen: stepCountIs(5),
     });
+
+    // Optional: if your runtime has explicit teardown, call both:
+    // notificationSubscription.dispose();
+    // manager.dispose();
+
+    return agent;
 }
 export type McpAgentUIMessage = InferAgentUIMessage<Awaited<ReturnType<typeof createMcpAgent>>>;

--- a/examples/task-notification-server/README.md
+++ b/examples/task-notification-server/README.md
@@ -1,0 +1,29 @@
+# Task + Notification Example Server
+
+This example shows an MCP server that supports:
+
+- Task-augmented tool execution
+- `notifications/progress`
+- `notifications/tasks/status`
+- Task RPC operations (`tasks/get`, `tasks/result`, `tasks/list`, `tasks/cancel`)
+
+## Run server
+
+```bash
+npx tsx examples/task-notification-server/server.ts
+```
+
+Server endpoint: `http://localhost:3007/mcp`
+
+## Run client (using mcp-ts MCPClient)
+
+```bash
+npx tsx examples/task-notification-server/client.ts
+```
+
+The client will:
+
+1. connect to the example server
+2. call the `long_job` tool
+3. print real-time notifications
+4. use task helper methods (`listTasks`, `getTask`, `getTaskResult`) to retrieve final result

--- a/examples/task-notification-server/client.ts
+++ b/examples/task-notification-server/client.ts
@@ -1,0 +1,42 @@
+import { MCPClient } from '../../src/server/mcp/oauth-client';
+
+async function main() {
+  const client = new MCPClient({
+    identity: 'example-user',
+    sessionId: 'example-session',
+    serverId: 'example-server',
+    serverUrl: 'http://localhost:3007/mcp',
+    callbackUrl: 'http://localhost:3007/oauth/callback',
+    transportType: 'streamable_http',
+  });
+
+  client.onServerNotification((event) => {
+    console.log('[notification]', event.method, event.params);
+  });
+
+  await client.connect();
+
+  // Trigger tool task (tool is declared as task-enabled on server side)
+  const created = await client.callToolTask('long_job', { durationMs: 2500 }, 60000);
+  const taskId = created.task.taskId;
+
+  const tasks = await client.listTasks();
+  console.log('[tasks/list count]', tasks.tasks.length);
+
+  let state = await client.getTask(taskId);
+  while (state.status === 'working' || state.status === 'input_required') {
+    console.log('[task state]', state.status, state.statusMessage);
+    await new Promise((resolve) => setTimeout(resolve, state.pollInterval ?? 1000));
+    state = await client.getTask(taskId);
+  }
+
+  const result = await client.getTaskResult(taskId);
+  console.log('[task result]', result);
+
+  client.disconnect();
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/task-notification-server/server.ts
+++ b/examples/task-notification-server/server.ts
@@ -1,0 +1,116 @@
+import { randomUUID } from 'node:crypto';
+import express from 'express';
+import { z } from 'zod';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { InMemoryTaskStore, InMemoryTaskMessageQueue } from '@modelcontextprotocol/sdk/experimental';
+
+type ProgressToken = string | number;
+
+const app = express();
+app.use(express.json());
+
+const taskStore = new InMemoryTaskStore();
+const messageQueue = new InMemoryTaskMessageQueue();
+
+const mcpServer = new McpServer(
+  {
+    name: 'mcp-ts-task-notifier-example',
+    version: '0.1.0',
+  },
+  {
+    capabilities: {
+      logging: {},
+      tasks: {
+        list: {},
+        cancel: {},
+        requests: {
+          tools: { call: {} },
+        },
+      },
+    },
+    taskStore,
+    taskMessageQueue: messageQueue,
+  },
+);
+
+mcpServer.experimental.tasks.registerToolTask(
+  'long_job',
+  {
+    description: 'Simulates a long job with progress and task status notifications',
+    inputSchema: {
+      durationMs: z.number().int().positive().default(5000),
+    },
+  },
+  {
+    async createTask({ durationMs }, extra) {
+      const task = await extra.taskStore.createTask({ ttl: extra.taskRequestedTtl });
+      const progressToken: ProgressToken = `task-${task.taskId}`;
+
+      void (async () => {
+        const steps = 5;
+        const stepMs = Math.max(100, Math.floor(durationMs / steps));
+
+        for (let i = 1; i <= steps; i += 1) {
+          await new Promise((resolve) => setTimeout(resolve, stepMs));
+
+          await extra.sendNotification({
+            method: 'notifications/progress',
+            params: {
+              progressToken,
+              progress: i,
+              total: steps,
+              message: `Step ${i}/${steps}`,
+            },
+          });
+
+          await extra.sendNotification({
+            method: 'notifications/tasks/status',
+            params: {
+              taskId: task.taskId,
+              status: i === steps ? 'completed' : 'working',
+              createdAt: task.createdAt,
+              lastUpdatedAt: new Date().toISOString(),
+              ttl: task.ttl,
+              pollInterval: 1000,
+              statusMessage: i === steps ? 'Task completed' : `Task progress ${i}/${steps}`,
+            },
+          });
+        }
+
+        await extra.taskStore.storeTaskResult(task.taskId, 'completed', {
+          content: [
+            {
+              type: 'text',
+              text: `long_job completed after ${durationMs}ms`,
+            },
+          ],
+        });
+      })();
+
+      return { task };
+    },
+
+    async getTask(_args, extra) {
+      return await extra.taskStore.getTask(extra.taskId);
+    },
+
+    async getTaskResult(_args, extra) {
+      return await extra.taskStore.getTaskResult(extra.taskId);
+    },
+  },
+);
+
+app.all('/mcp', async (req, res) => {
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => randomUUID(),
+  });
+
+  await mcpServer.connect(transport);
+  await transport.handleRequest(req, res, req.body);
+});
+
+const port = Number(process.env.PORT ?? 3007);
+app.listen(port, () => {
+  console.log(`MCP task notification example server listening at http://localhost:${port}/mcp`);
+});

--- a/src/client/react/use-mcp.ts
+++ b/src/client/react/use-mcp.ts
@@ -16,6 +16,10 @@ import type {
   SessionInfo,
 } from '../../shared/types';
 
+type ServerNotificationEvent = Extract<McpConnectionEvent, { type: 'server_notification' }>;
+type ProgressNotificationEvent = ServerNotificationEvent & { method: 'notifications/progress' };
+type TaskStatusNotificationEvent = ServerNotificationEvent & { method: 'notifications/tasks/status' };
+
 export interface UseMcpOptions {
   /**
    * SSE endpoint URL
@@ -48,6 +52,21 @@ export interface UseMcpOptions {
    * Connection event callback
    */
   onConnectionEvent?: (event: McpConnectionEvent) => void;
+
+  /**
+   * Raw server notification callback (`type: 'server_notification'`)
+   */
+  onNotification?: (event: ServerNotificationEvent) => void;
+
+  /**
+   * Progress notification callback (`notifications/progress`)
+   */
+  onProgress?: (event: ProgressNotificationEvent) => void;
+
+  /**
+   * Task status notification callback (`notifications/tasks/status`)
+   */
+  onTaskStatus?: (event: TaskStatusNotificationEvent) => void;
 
   /**
    * Debug logging callback
@@ -201,6 +220,9 @@ export function useMcp(options: UseMcpOptions): McpClient {
     autoConnect = true,
     autoInitialize = true,
     onConnectionEvent,
+    onNotification,
+    onProgress,
+    onTaskStatus,
     onLog,
     onRedirect,
   } = options;
@@ -227,6 +249,18 @@ export function useMcp(options: UseMcpOptions): McpClient {
       onConnectionEvent: (event) => {
         // Update local state based on event
         updateConnectionsFromEvent(event);
+
+        if (event.type === 'server_notification') {
+          onNotification?.(event);
+
+          if (event.method === 'notifications/progress') {
+            onProgress?.(event as ProgressNotificationEvent);
+          }
+
+          if (event.method === 'notifications/tasks/status') {
+            onTaskStatus?.(event as TaskStatusNotificationEvent);
+          }
+        }
 
         // Call user callback
         onConnectionEvent?.(event);

--- a/src/client/vue/use-mcp.ts
+++ b/src/client/vue/use-mcp.ts
@@ -16,6 +16,10 @@ import type {
     SessionInfo,
 } from '../../shared/types';
 
+type ServerNotificationEvent = Extract<McpConnectionEvent, { type: 'server_notification' }>;
+type ProgressNotificationEvent = ServerNotificationEvent & { method: 'notifications/progress' };
+type TaskStatusNotificationEvent = ServerNotificationEvent & { method: 'notifications/tasks/status' };
+
 export interface UseMcpOptions {
     /**
      * SSE endpoint URL
@@ -48,6 +52,21 @@ export interface UseMcpOptions {
      * Connection event callback
      */
     onConnectionEvent?: (event: McpConnectionEvent) => void;
+
+    /**
+     * Raw server notification callback (`type: 'server_notification'`)
+     */
+    onNotification?: (event: ServerNotificationEvent) => void;
+
+    /**
+     * Progress notification callback (`notifications/progress`)
+     */
+    onProgress?: (event: ProgressNotificationEvent) => void;
+
+    /**
+     * Task status notification callback (`notifications/tasks/status`)
+     */
+    onTaskStatus?: (event: TaskStatusNotificationEvent) => void;
 
     /**
      * Debug logging callback
@@ -190,6 +209,9 @@ export function useMcp(options: UseMcpOptions): McpClient {
         autoConnect = true,
         autoInitialize = true,
         onConnectionEvent,
+        onNotification,
+        onProgress,
+        onTaskStatus,
         onLog,
         onRedirect,
     } = options;
@@ -342,6 +364,18 @@ export function useMcp(options: UseMcpOptions): McpClient {
             onConnectionEvent: (event) => {
                 // Update local state based on event
                 updateConnectionsFromEvent(event);
+
+                if (event.type === 'server_notification') {
+                    onNotification?.(event);
+
+                    if (event.method === 'notifications/progress') {
+                        onProgress?.(event as ProgressNotificationEvent);
+                    }
+
+                    if (event.method === 'notifications/tasks/status') {
+                        onTaskStatus?.(event as TaskStatusNotificationEvent);
+                    }
+                }
 
                 // Call user callback
                 onConnectionEvent?.(event);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,7 +8,7 @@ export { MCPClient } from './mcp/oauth-client.js';
 export { UnauthorizedError } from '../shared/errors.js';
 export { storage, type StorageBackend } from './storage/index.js';
 export { StorageOAuthClientProvider } from './mcp/storage-oauth-provider.js';
-export { MultiSessionClient, type MultiSessionNotificationEvent } from './mcp/multi-session-client.js';
+export { MultiSessionClient, type MultiSessionNotificationEvent, type MultiSessionNotificationHandlers, type MultiSessionProgressEvent, type MultiSessionLoggingEvent, type MultiSessionListChangedEvent, type MultiSessionResourceUpdatedEvent, type MultiSessionTaskStatusEvent } from './mcp/multi-session-client.js';
 
 /** SSE handler for real-time connections */
 export { createSSEHandler, SSEConnectionManager, type SSEHandlerOptions, type ClientMetadata } from './handlers/sse-handler.js';

--- a/src/server/mcp/multi-session-client.ts
+++ b/src/server/mcp/multi-session-client.ts
@@ -1,8 +1,7 @@
 
-
 import { MCPClient } from './oauth-client.js';
 import { storage, type SessionData } from '../storage/index.js';
-import { Emitter, type Event } from '../../shared/events.js';
+import { Emitter, type Disposable, type Event } from '../../shared/events.js';
 
 /**
  * Manages multiple MCP connections for a single user identity.
@@ -34,6 +33,50 @@ export interface MultiSessionNotificationEvent {
     timestamp: number;
 }
 
+export interface MultiSessionProgressEvent extends MultiSessionNotificationEvent {
+    method: 'notifications/progress';
+    progress: number;
+    total?: number;
+    message?: string;
+    progressToken?: string | number;
+}
+
+export interface MultiSessionLoggingEvent extends MultiSessionNotificationEvent {
+    method: 'notifications/message';
+    level?: string;
+    data?: unknown;
+    logger?: string;
+}
+
+export interface MultiSessionListChangedEvent extends MultiSessionNotificationEvent {
+    method:
+    | 'notifications/tools/list_changed'
+    | 'notifications/resources/list_changed'
+    | 'notifications/prompts/list_changed';
+}
+
+export interface MultiSessionResourceUpdatedEvent extends MultiSessionNotificationEvent {
+    method: 'notifications/resources/updated';
+    uri?: string;
+}
+
+export interface MultiSessionTaskStatusEvent extends MultiSessionNotificationEvent {
+    method: 'notifications/tasks/status';
+    taskId?: string;
+    status?: string;
+}
+
+export interface MultiSessionNotificationHandlers {
+    onNotification?: (event: MultiSessionNotificationEvent) => void;
+    onProgress?: (event: MultiSessionProgressEvent) => void;
+    onLoggingMessage?: (event: MultiSessionLoggingEvent) => void;
+    onToolListChanged?: (event: MultiSessionListChangedEvent) => void;
+    onResourceListChanged?: (event: MultiSessionListChangedEvent) => void;
+    onPromptListChanged?: (event: MultiSessionListChangedEvent) => void;
+    onResourceUpdated?: (event: MultiSessionResourceUpdatedEvent) => void;
+    onTaskStatus?: (event: MultiSessionTaskStatusEvent) => void;
+}
+
 /**
  * Manages multiple MCP connections for a single user identity.
  * Allows aggregating tools from all connected servers.
@@ -43,7 +86,23 @@ export class MultiSessionClient {
     private identity: string;
     private options: MultiSessionOptions;
     private readonly _onNotification = new Emitter<MultiSessionNotificationEvent>();
+    private readonly _onProgress = new Emitter<MultiSessionProgressEvent>();
+    private readonly _onLoggingMessage = new Emitter<MultiSessionLoggingEvent>();
+    private readonly _onToolListChanged = new Emitter<MultiSessionListChangedEvent>();
+    private readonly _onResourceListChanged = new Emitter<MultiSessionListChangedEvent>();
+    private readonly _onPromptListChanged = new Emitter<MultiSessionListChangedEvent>();
+    private readonly _onResourceUpdated = new Emitter<MultiSessionResourceUpdatedEvent>();
+    private readonly _onTaskStatus = new Emitter<MultiSessionTaskStatusEvent>();
+    private readonly notificationForwarders = new Map<string, Disposable>();
+
     public readonly onNotification: Event<MultiSessionNotificationEvent> = this._onNotification.event;
+    public readonly onProgress: Event<MultiSessionProgressEvent> = this._onProgress.event;
+    public readonly onLoggingMessage: Event<MultiSessionLoggingEvent> = this._onLoggingMessage.event;
+    public readonly onToolListChanged: Event<MultiSessionListChangedEvent> = this._onToolListChanged.event;
+    public readonly onResourceListChanged: Event<MultiSessionListChangedEvent> = this._onResourceListChanged.event;
+    public readonly onPromptListChanged: Event<MultiSessionListChangedEvent> = this._onPromptListChanged.event;
+    public readonly onResourceUpdated: Event<MultiSessionResourceUpdatedEvent> = this._onResourceUpdated.event;
+    public readonly onTaskStatus: Event<MultiSessionTaskStatusEvent> = this._onTaskStatus.event;
 
     constructor(identity: string, options: MultiSessionOptions = {}) {
         this.identity = identity;
@@ -52,6 +111,51 @@ export class MultiSessionClient {
             maxRetries: 2,
             retryDelay: 1000,
             ...options
+        };
+    }
+
+    /**
+     * Registers a notification handler object similar to FastMCP-style callbacks.
+     */
+    setNotificationHandlers(handlers: MultiSessionNotificationHandlers): Disposable {
+        const subscriptions: Disposable[] = [];
+
+        if (handlers.onNotification) {
+            subscriptions.push(this.onNotification(handlers.onNotification));
+        }
+
+        if (handlers.onProgress) {
+            subscriptions.push(this.onProgress(handlers.onProgress));
+        }
+
+        if (handlers.onLoggingMessage) {
+            subscriptions.push(this.onLoggingMessage(handlers.onLoggingMessage));
+        }
+
+        if (handlers.onToolListChanged) {
+            subscriptions.push(this.onToolListChanged(handlers.onToolListChanged));
+        }
+
+        if (handlers.onResourceListChanged) {
+            subscriptions.push(this.onResourceListChanged(handlers.onResourceListChanged));
+        }
+
+        if (handlers.onPromptListChanged) {
+            subscriptions.push(this.onPromptListChanged(handlers.onPromptListChanged));
+        }
+
+        if (handlers.onResourceUpdated) {
+            subscriptions.push(this.onResourceUpdated(handlers.onResourceUpdated));
+        }
+
+        if (handlers.onTaskStatus) {
+            subscriptions.push(this.onTaskStatus(handlers.onTaskStatus));
+        }
+
+        return {
+            dispose: () => {
+                subscriptions.forEach((subscription) => subscription.dispose());
+            }
         };
     }
 
@@ -99,6 +203,74 @@ export class MultiSessionClient {
         console.error(`[MultiSessionClient] Failed to connect to session ${session.sessionId} after ${maxRetries + 1} attempts:`, lastError);
     }
 
+    private toNotificationParams(params: unknown): Record<string, unknown> | undefined {
+        if (!params || typeof params !== 'object') {
+            return undefined;
+        }
+        return params as Record<string, unknown>;
+    }
+
+    private fireTypedNotifications(event: MultiSessionNotificationEvent): void {
+        const params = this.toNotificationParams(event.params);
+
+        switch (event.method) {
+            case 'notifications/progress': {
+                const progress = params?.progress;
+                if (typeof progress !== 'number') {
+                    return;
+                }
+
+                this._onProgress.fire({
+                    ...event,
+                    method: 'notifications/progress',
+                    progress,
+                    total: typeof params?.total === 'number' ? params.total : undefined,
+                    message: typeof params?.message === 'string' ? params.message : undefined,
+                    progressToken:
+                        typeof params?.progressToken === 'string' || typeof params?.progressToken === 'number'
+                            ? params.progressToken
+                            : undefined,
+                });
+                return;
+            }
+            case 'notifications/message':
+                this._onLoggingMessage.fire({
+                    ...event,
+                    method: 'notifications/message',
+                    level: typeof params?.level === 'string' ? params.level : undefined,
+                    data: params?.data,
+                    logger: typeof params?.logger === 'string' ? params.logger : undefined,
+                });
+                return;
+            case 'notifications/tools/list_changed':
+                this._onToolListChanged.fire({ ...event, method: 'notifications/tools/list_changed' });
+                return;
+            case 'notifications/resources/list_changed':
+                this._onResourceListChanged.fire({ ...event, method: 'notifications/resources/list_changed' });
+                return;
+            case 'notifications/prompts/list_changed':
+                this._onPromptListChanged.fire({ ...event, method: 'notifications/prompts/list_changed' });
+                return;
+            case 'notifications/resources/updated':
+                this._onResourceUpdated.fire({
+                    ...event,
+                    method: 'notifications/resources/updated',
+                    uri: typeof params?.uri === 'string' ? params.uri : undefined,
+                });
+                return;
+            case 'notifications/tasks/status':
+                this._onTaskStatus.fire({
+                    ...event,
+                    method: 'notifications/tasks/status',
+                    taskId: typeof params?.taskId === 'string' ? params.taskId : undefined,
+                    status: typeof params?.status === 'string' ? params.status : undefined,
+                });
+                return;
+            default:
+                return;
+        }
+    }
+
     private async createAndConnectClient(session: SessionData): Promise<MCPClient> {
         const client = new MCPClient({
             identity: this.identity,
@@ -111,22 +283,70 @@ export class MultiSessionClient {
             headers: session.headers,
         });
 
-        client.onServerNotification((event) => {
+        const existingForwarder = this.notificationForwarders.get(session.sessionId);
+        existingForwarder?.dispose();
+
+        const forwarder = client.onServerNotification((event) => {
             this._onNotification.fire(event);
+            this.fireTypedNotifications(event);
         });
+        this.notificationForwarders.set(session.sessionId, forwarder);
 
         const timeoutMs = this.options.timeout ?? 15000;
         const timeoutPromise = new Promise<never>((_, reject) => {
             setTimeout(() => reject(new Error(`Connection timed out after ${timeoutMs}ms`)), timeoutMs);
         });
 
-        await Promise.race([client.connect(), timeoutPromise]);
-        return client;
+        try {
+            await Promise.race([client.connect(), timeoutPromise]);
+            return client;
+        } catch (error) {
+            this.notificationForwarders.get(session.sessionId)?.dispose();
+            this.notificationForwarders.delete(session.sessionId);
+            throw error;
+        }
     }
 
     async connect(): Promise<void> {
         const sessions = await this.getActiveSessions();
         await this.connectInBatches(sessions);
+    }
+
+
+    private getClientBySessionId(sessionId: string): MCPClient {
+        const client = this.clients.find((item) => item.getSessionId() === sessionId);
+        if (!client) {
+            throw new Error(`No connected client found for session ${sessionId}`);
+        }
+        return client;
+    }
+
+    /**
+     * Get the latest task state for a specific session.
+     */
+    async getTask(sessionId: string, taskId: string) {
+        return await this.getClientBySessionId(sessionId).getTask(taskId);
+    }
+
+    /**
+     * Get final task payload for a specific session.
+     */
+    async getTaskResult(sessionId: string, taskId: string) {
+        return await this.getClientBySessionId(sessionId).getTaskResult(taskId);
+    }
+
+    /**
+     * List tasks for a specific session.
+     */
+    async listTasks(sessionId: string, cursor?: string) {
+        return await this.getClientBySessionId(sessionId).listTasks(cursor);
+    }
+
+    /**
+     * Cancel a task for a specific session.
+     */
+    async cancelTask(sessionId: string, taskId: string) {
+        return await this.getClientBySessionId(sessionId).cancelTask(taskId);
     }
 
     /**
@@ -140,9 +360,31 @@ export class MultiSessionClient {
      * Disconnects all clients.
      */
     disconnect(): void {
-        this.clients.forEach((client) => client.disconnect());
+        this.clients.forEach((client) => {
+            client.disconnect();
+        });
         this.clients = [];
-        this._onNotification.dispose();
-    }
-}
 
+        this.notificationForwarders.forEach((forwarder) => {
+            forwarder.dispose();
+        });
+        this.notificationForwarders.clear();
+    }
+    /**
+     * Dispose this multi-session client and all event listeners.
+     * Use this when the instance will no longer be reused.
+     */
+    dispose(): void {
+        this.disconnect();
+        this.notificationForwarders.clear();
+        this._onNotification.dispose();
+        this._onProgress.dispose();
+        this._onLoggingMessage.dispose();
+        this._onToolListChanged.dispose();
+        this._onResourceListChanged.dispose();
+        this._onPromptListChanged.dispose();
+        this._onResourceUpdated.dispose();
+        this._onTaskStatus.dispose();
+    }
+
+}

--- a/src/server/mcp/multi-session-client.ts
+++ b/src/server/mcp/multi-session-client.ts
@@ -322,6 +322,13 @@ export class MultiSessionClient {
     }
 
     /**
+     * Execute a tool as a task for a specific session.
+     */
+    async callToolTask(sessionId: string, toolName: string, toolArgs: Record<string, unknown>, ttl?: number) {
+        return await this.getClientBySessionId(sessionId).callToolTask(toolName, toolArgs, ttl);
+    }
+
+    /**
      * Get the latest task state for a specific session.
      */
     async getTask(sessionId: string, taskId: string) {

--- a/src/server/mcp/oauth-client.ts
+++ b/src/server/mcp/oauth-client.ts
@@ -46,6 +46,8 @@ import {
   CancelTaskRequest,
   CancelTaskResult,
   CancelTaskResultSchema,
+  CreateTaskResult,
+  CreateTaskResultSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import type { OAuthClientMetadata, OAuthTokens, OAuthClientInformationFull } from '@modelcontextprotocol/sdk/shared/auth.js';
 import { StorageOAuthClientProvider, type AgentsOAuthProvider } from './storage-oauth-provider.js';
@@ -978,6 +980,25 @@ export class MCPClient {
     return await this.client.request(request, ReadResourceResultSchema);
   }
 
+  /**
+   * Executes a tool as a task-augmented request.
+   */
+  async callToolTask(toolName: string, toolArgs: Record<string, unknown>, ttl?: number): Promise<CreateTaskResult> {
+    if (!this.client) {
+      throw new Error('Not connected to server');
+    }
+
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: toolName,
+        arguments: toolArgs,
+        task: ttl !== undefined ? { ttl } : {},
+      },
+    } as const;
+
+    return await this.client.request(request, CreateTaskResultSchema);
+  }
 
   /**
    * Gets current state for a task.

--- a/src/server/mcp/oauth-client.ts
+++ b/src/server/mcp/oauth-client.ts
@@ -34,6 +34,18 @@ import {
   PromptListChangedNotificationSchema,
   ToolListChangedNotificationSchema,
   TaskStatusNotificationSchema,
+  GetTaskRequest,
+  GetTaskResult,
+  GetTaskResultSchema,
+  GetTaskPayloadRequest,
+  GetTaskPayloadResult,
+  GetTaskPayloadResultSchema,
+  ListTasksRequest,
+  ListTasksResult,
+  ListTasksResultSchema,
+  CancelTaskRequest,
+  CancelTaskResult,
+  CancelTaskResultSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import type { OAuthClientMetadata, OAuthTokens, OAuthClientInformationFull } from '@modelcontextprotocol/sdk/shared/auth.js';
 import { StorageOAuthClientProvider, type AgentsOAuthProvider } from './storage-oauth-provider.js';
@@ -964,6 +976,72 @@ export class MCPClient {
     };
 
     return await this.client.request(request, ReadResourceResultSchema);
+  }
+
+
+  /**
+   * Gets current state for a task.
+   */
+  async getTask(taskId: string): Promise<GetTaskResult> {
+    if (!this.client) {
+      throw new Error('Not connected to server');
+    }
+
+    const request: GetTaskRequest = {
+      method: 'tasks/get',
+      params: { taskId },
+    };
+
+    return await this.client.request(request, GetTaskResultSchema);
+  }
+
+  /**
+   * Gets the final payload result for a task.
+   * The returned shape matches the original request's result type.
+   */
+  async getTaskResult(taskId: string): Promise<GetTaskPayloadResult> {
+    if (!this.client) {
+      throw new Error('Not connected to server');
+    }
+
+    const request: GetTaskPayloadRequest = {
+      method: 'tasks/result',
+      params: { taskId },
+    };
+
+    return await this.client.request(request, GetTaskPayloadResultSchema);
+  }
+
+  /**
+   * Lists tasks available to the current session.
+   */
+  async listTasks(cursor?: string): Promise<ListTasksResult> {
+    if (!this.client) {
+      throw new Error('Not connected to server');
+    }
+
+    const request: ListTasksRequest = {
+      method: 'tasks/list',
+      params: cursor ? { cursor } : {},
+    };
+
+    return await this.client.request(request, ListTasksResultSchema);
+  }
+
+  /**
+   * Cancels an active task.
+   */
+  async cancelTask(taskId: string): Promise<CancelTaskResult> {
+    if (!this.client) {
+      throw new Error('Not connected to server');
+    }
+
+    const request: CancelTaskRequest = {
+      method: 'tasks/cancel',
+      params: { taskId },
+    };
+
+    return await this.client.request(request, CancelTaskResultSchema);
   }
 
   /**

--- a/tests/mcp-tasks.test.ts
+++ b/tests/mcp-tasks.test.ts
@@ -17,6 +17,18 @@ test.describe('MCP task helper methods', () => {
       request: async (request: any) => {
         calls.push(request);
 
+        if (request.method === 'tools/call') {
+          return {
+            task: {
+              taskId: 'task-1',
+              status: 'working',
+              ttl: 60000,
+              createdAt: '2026-01-01T00:00:00Z',
+              lastUpdatedAt: '2026-01-01T00:00:01Z',
+            },
+          };
+        }
+
         if (request.method === 'tasks/get') {
           return {
             taskId: request.params.taskId,
@@ -59,17 +71,20 @@ test.describe('MCP task helper methods', () => {
       },
     };
 
+    const created = await client.callToolTask('long_job', { durationMs: 500 }, 60000);
     const state = await client.getTask('task-1');
     const payload = await client.getTaskResult('task-1');
     const list = await client.listTasks();
     const cancelled = await client.cancelTask('task-1');
 
+    expect(created.task.taskId).toBe('task-1');
     expect(state.status).toBe('working');
     expect((payload as any).content[0].text).toBe('done');
     expect(list.tasks[0].taskId).toBe('task-1');
     expect(cancelled.status).toBe('cancelled');
 
     expect(calls.map((c) => c.method)).toEqual([
+      'tools/call',
       'tasks/get',
       'tasks/result',
       'tasks/list',
@@ -96,6 +111,10 @@ test.describe('MCP task helper methods', () => {
           delegated.push(['listTasks', cursor]);
           return { tasks: [] };
         },
+        callToolTask: async (toolName: string, args: Record<string, unknown>, ttl?: number) => {
+          delegated.push(['callToolTask', toolName, args, ttl]);
+          return { task: { taskId: 'task-1' } };
+        },
         cancelTask: async (taskId: string) => {
           delegated.push(['cancelTask', taskId]);
           return { taskId, status: 'cancelled' };
@@ -103,12 +122,14 @@ test.describe('MCP task helper methods', () => {
       },
     ];
 
+    await multi.callToolTask('session-1', 'long_job', { durationMs: 500 }, 60000);
     await multi.getTask('session-1', 'task-1');
     await multi.getTaskResult('session-1', 'task-1');
     await multi.listTasks('session-1', 'cursor-1');
     await multi.cancelTask('session-1', 'task-1');
 
     expect(delegated).toEqual([
+      ['callToolTask', 'long_job', { durationMs: 500 }, 60000],
       ['getTask', 'task-1'],
       ['getTaskResult', 'task-1'],
       ['listTasks', 'cursor-1'],

--- a/tests/mcp-tasks.test.ts
+++ b/tests/mcp-tasks.test.ts
@@ -1,0 +1,118 @@
+import { test, expect } from '@playwright/test';
+import { MCPClient } from '../src/server/mcp/oauth-client';
+import { MultiSessionClient } from '../src/server/mcp/multi-session-client';
+
+test.describe('MCP task helper methods', () => {
+  test('MCPClient task helpers call expected task RPC methods', async () => {
+    const client = new MCPClient({
+      identity: 'user-1',
+      sessionId: 'session-1',
+      serverId: 'server-1',
+      serverUrl: 'https://example.com/mcp',
+      callbackUrl: 'https://example.com/callback',
+    });
+
+    const calls: any[] = [];
+    (client as any).client = {
+      request: async (request: any) => {
+        calls.push(request);
+
+        if (request.method === 'tasks/get') {
+          return {
+            taskId: request.params.taskId,
+            status: 'working',
+            ttl: 1000,
+            createdAt: '2026-01-01T00:00:00Z',
+            lastUpdatedAt: '2026-01-01T00:00:01Z',
+          };
+        }
+
+        if (request.method === 'tasks/result') {
+          return { content: [{ type: 'text', text: 'done' }] };
+        }
+
+        if (request.method === 'tasks/list') {
+          return {
+            tasks: [
+              {
+                taskId: 'task-1',
+                status: 'working',
+                ttl: 1000,
+                createdAt: '2026-01-01T00:00:00Z',
+                lastUpdatedAt: '2026-01-01T00:00:01Z',
+              },
+            ],
+          };
+        }
+
+        if (request.method === 'tasks/cancel') {
+          return {
+            taskId: request.params.taskId,
+            status: 'cancelled',
+            ttl: 1000,
+            createdAt: '2026-01-01T00:00:00Z',
+            lastUpdatedAt: '2026-01-01T00:00:01Z',
+          };
+        }
+
+        return {};
+      },
+    };
+
+    const state = await client.getTask('task-1');
+    const payload = await client.getTaskResult('task-1');
+    const list = await client.listTasks();
+    const cancelled = await client.cancelTask('task-1');
+
+    expect(state.status).toBe('working');
+    expect((payload as any).content[0].text).toBe('done');
+    expect(list.tasks[0].taskId).toBe('task-1');
+    expect(cancelled.status).toBe('cancelled');
+
+    expect(calls.map((c) => c.method)).toEqual([
+      'tasks/get',
+      'tasks/result',
+      'tasks/list',
+      'tasks/cancel',
+    ]);
+  });
+
+  test('MultiSessionClient delegates task helpers by session id', async () => {
+    const multi = new MultiSessionClient('user-1');
+
+    const delegated: any[] = [];
+    (multi as any).clients = [
+      {
+        getSessionId: () => 'session-1',
+        getTask: async (taskId: string) => {
+          delegated.push(['getTask', taskId]);
+          return { taskId, status: 'working' };
+        },
+        getTaskResult: async (taskId: string) => {
+          delegated.push(['getTaskResult', taskId]);
+          return { ok: true, taskId };
+        },
+        listTasks: async (cursor?: string) => {
+          delegated.push(['listTasks', cursor]);
+          return { tasks: [] };
+        },
+        cancelTask: async (taskId: string) => {
+          delegated.push(['cancelTask', taskId]);
+          return { taskId, status: 'cancelled' };
+        },
+      },
+    ];
+
+    await multi.getTask('session-1', 'task-1');
+    await multi.getTaskResult('session-1', 'task-1');
+    await multi.listTasks('session-1', 'cursor-1');
+    await multi.cancelTask('session-1', 'task-1');
+
+    expect(delegated).toEqual([
+      ['getTask', 'task-1'],
+      ['getTaskResult', 'task-1'],
+      ['listTasks', 'cursor-1'],
+      ['cancelTask', 'task-1'],
+    ]);
+  });
+});

--- a/tests/multi-session-client.test.ts
+++ b/tests/multi-session-client.test.ts
@@ -1,0 +1,119 @@
+import { test, expect } from '@playwright/test';
+import { MultiSessionClient } from '../src/server/mcp/multi-session-client';
+
+test.describe('MultiSessionClient notification listeners', () => {
+  test('preserves onNotification listeners across disconnect', () => {
+    const client = new MultiSessionClient('user-1');
+
+    const received: any[] = [];
+    client.onNotification((event) => {
+      received.push(event);
+    });
+
+    (client as any).clients = [
+      {
+        getSessionId: () => 'session-1',
+        disconnect: () => undefined,
+      },
+    ];
+
+    client.disconnect();
+
+    (client as any)._onNotification.fire({
+      sessionId: 'session-1',
+      serverId: 'server-1',
+      method: 'notifications/progress',
+      timestamp: Date.now(),
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].sessionId).toBe('session-1');
+  });
+
+  test('supports typed notification handlers via setNotificationHandlers', () => {
+    const client = new MultiSessionClient('user-1');
+
+    const progressEvents: any[] = [];
+    const taskStatusEvents: any[] = [];
+
+    const subscription = client.setNotificationHandlers({
+      onProgress: (event) => {
+        progressEvents.push(event);
+      },
+      onTaskStatus: (event) => {
+        taskStatusEvents.push(event);
+      },
+    });
+
+    (client as any).fireTypedNotifications({
+      sessionId: 'session-1',
+      serverId: 'server-1',
+      method: 'notifications/progress',
+      params: { progress: 3, total: 10, message: 'working' },
+      timestamp: Date.now(),
+    });
+
+    (client as any).fireTypedNotifications({
+      sessionId: 'session-1',
+      serverId: 'server-1',
+      method: 'notifications/tasks/status',
+      params: { taskId: 'task-1', status: 'running' },
+      timestamp: Date.now(),
+    });
+
+    expect(progressEvents).toHaveLength(1);
+    expect(progressEvents[0].progress).toBe(3);
+    expect(taskStatusEvents).toHaveLength(1);
+    expect(taskStatusEvents[0].status).toBe('running');
+
+    subscription.dispose();
+
+    (client as any).fireTypedNotifications({
+      sessionId: 'session-1',
+      serverId: 'server-1',
+      method: 'notifications/progress',
+      params: { progress: 4 },
+      timestamp: Date.now(),
+    });
+
+    expect(progressEvents).toHaveLength(1);
+  });
+
+
+
+  test('disconnect clears stale forwarders even without connected clients', () => {
+    const client = new MultiSessionClient('user-1');
+
+    const disposed: string[] = [];
+    (client as any).notificationForwarders.set('failed-session', {
+      dispose: () => {
+        disposed.push('failed-session');
+      },
+    });
+
+    client.disconnect();
+
+    expect(disposed).toEqual(['failed-session']);
+    expect((client as any).notificationForwarders.size).toBe(0);
+  });
+  test('dispose removes notification listeners', () => {
+    const client = new MultiSessionClient('user-1');
+
+    const received: any[] = [];
+    client.onNotification((event) => {
+      received.push(event);
+    });
+
+    client.dispose();
+
+    (client as any)._onNotification.fire({
+      sessionId: 'session-1',
+      serverId: 'server-1',
+      method: 'notifications/progress',
+      timestamp: Date.now(),
+    });
+
+    expect(received).toHaveLength(0);
+  });
+
+});


### PR DESCRIPTION
### Motivation
- Close the gap where task status notifications were exposed but full task RPC lifecycle helpers (`tasks/get`, `tasks/result`, `tasks/list`, `tasks/cancel`) were not first-class on the multi-session API.
- Provide a simple session-scoped API for polling and cancelling tasks so runtimes and adapters can retrieve final payloads and list tasks without manual client lookup.

### Description
- Added task RPC helper methods to `MCPClient` in `src/server/mcp/oauth-client.ts`: `getTask`, `getTaskResult`, `listTasks`, and `cancelTask`, wired to the corresponding MCP RPCs and schemas. 
- Added session-scoped delegating helpers to `MultiSessionClient` in `src/server/mcp/multi-session-client.ts`: `getTask(sessionId, ...)`, `getTaskResult(sessionId, ...)`, `listTasks(sessionId, ...)`, and `cancelTask(sessionId, ...)`, plus a `getClientBySessionId` helper used for delegation. 
- Improved typed notification support and handler registration by exposing typed emitters/handler interfaces and `setNotificationHandlers(handlers): Disposable`, and hardened forwarder lifecycle (dispose on failure and `disconnect()`), and exported types from `src/server/index.ts`. 
- Documentation updated with a README verification example and API reference snippets showing task helper usage, and added `tests/mcp-tasks.test.ts` to validate RPC dispatch and delegation.

### Testing
- Ran Playwright tests with `npx playwright test tests/mcp-notifications.test.ts tests/multi-session-client.test.ts tests/mcp-tasks.test.ts` and all tests passed. 
- Test summary: executed the notification + multi-session + task helper suites (total `7` tests) and they completed successfully (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69983f1c57b08332a037465dd3583dc1)