### PR TITLE
Add `cancelled` & `elicitation/complete` notifications; simplify Next.js example and restore `onFinish` cleanup

### DIFF
--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -266,6 +266,8 @@ These delegate to the underlying `MCPClient` for the specified `sessionId`.
 - `onToolListChanged(event)` - `notifications/tools/list_changed`
 - `onResourceListChanged(event)` - `notifications/resources/list_changed`
 - `onPromptListChanged(event)` - `notifications/prompts/list_changed`
+- `onCancelled(event)` - `notifications/cancelled` *(request cancellation signal)*
+- `onElicitationComplete(event)` - `notifications/elicitation/complete` *(out-of-band elicitation complete)*
 - `onResourceUpdated(event)` - `notifications/resources/updated`
 - `onTaskStatus(event)` - `notifications/tasks/status`
 
@@ -276,10 +278,17 @@ const subscription = mcp.setNotificationHandlers({
   onProgress: (event) => console.log(event.progress, event.total),
   onLoggingMessage: (event) => console.log(event.level, event.data),
   onToolListChanged: () => console.log('tool list changed'),
+  onCancelled: (event) => console.log('cancelled', event.requestId, event.reason),
 });
 
-subscription.dispose();
+subscription.dispose(); // only dispose when you no longer need notifications
 ```
+
+`dispose()` is final cleanup for the client and its event emitters. After calling it, the instance cannot receive new notifications. For long-lived streams (chat sessions, background jobs), keep the client/subscription alive and dispose during teardown.
+
+For always-on use cases (for example, watching an inbox and reacting to new mail), do **not** tie the client lifecycle to a single HTTP request. Keep a long-lived process/runtime that owns the `MultiSessionClient`, and dispose only when shutting that runtime down.
+
+Note: `notifications/roots/list_changed` is a client-to-server signal in MCP, so `MultiSessionClient` (as a client) does not expose it as an incoming server notification handler.
 
 **Tasks compatibility note (MCP 2025-11-25):**
 

--- a/docs/docs/nextjs.md
+++ b/docs/docs/nextjs.md
@@ -142,6 +142,10 @@ export async function POST(req: Request) {
   const { messages, identity } = await req.json();
 
   const client = new MultiSessionClient(identity);
+  const notificationSubscription = client.setNotificationHandlers({
+    onProgress: (event) => console.log('progress', event.progress),
+    onTaskStatus: (event) => console.log('task', event.taskId, event.status),
+  });
 
   try {
     await client.connect();
@@ -154,17 +158,23 @@ export async function POST(req: Request) {
       messages,
       tools,
       onFinish: async () => {
-        await mcp.disconnect();
+        notificationSubscription.dispose();
+        client.disconnect();
       }
     });
 
     return result.toDataStreamResponse();
   } catch (error) {
-    await mcp.disconnect();
+    notificationSubscription.dispose();
+    client.disconnect();
     throw error;
   }
 }
 ```
+
+> `dispose()` is final teardown. If you dispose immediately, notifications stop.
+>
+> For request-scoped chat routes, cleanup in `onFinish` + `catch` is correct. But for always-on automations (for example: “summarize every new Gmail inbox email”), use a long-lived worker/service that keeps `MultiSessionClient` connected across events and only disposes on process shutdown.
 
 For more details, see the [AI SDK Adapter documentation](./adapters.md#ai-sdk-adapter).
 

--- a/examples/nextjs/app/openai-agent/agent.ts
+++ b/examples/nextjs/app/openai-agent/agent.ts
@@ -23,7 +23,7 @@ export async function createMcpAgent(identity: string = 'demo-user-123') {
         await manager.connect();
     } catch (error) {
         notificationSubscription.dispose();
-        console.error("[MCP] Connection failed:", error);
+        console.error('[MCP] Connection failed:', error);
     }
 
     const tools = await AIAdapter.getTools(manager);
@@ -36,10 +36,16 @@ export async function createMcpAgent(identity: string = 'demo-user-123') {
         stopWhen: stepCountIs(5),
     });
 
-    // Optional: if your runtime has explicit teardown, call both:
+    // Reference only (optional long-lived pattern):
+    // Keep one MultiSessionClient per identity in a process-level map when you need
+    // always-on notifications across multiple requests (e.g., inbox watcher workers).
+    // In that pattern, DO NOT dispose after each request; dispose on worker shutdown.
+
+    // Optional explicit teardown if your runtime provides a request/session end hook:
     // notificationSubscription.dispose();
     // manager.dispose();
 
     return agent;
 }
+
 export type McpAgentUIMessage = InferAgentUIMessage<Awaited<ReturnType<typeof createMcpAgent>>>;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,7 +8,7 @@ export { MCPClient } from './mcp/oauth-client.js';
 export { UnauthorizedError } from '../shared/errors.js';
 export { storage, type StorageBackend } from './storage/index.js';
 export { StorageOAuthClientProvider } from './mcp/storage-oauth-provider.js';
-export { MultiSessionClient, type MultiSessionNotificationEvent, type MultiSessionNotificationHandlers, type MultiSessionProgressEvent, type MultiSessionLoggingEvent, type MultiSessionListChangedEvent, type MultiSessionResourceUpdatedEvent, type MultiSessionTaskStatusEvent } from './mcp/multi-session-client.js';
+export { MultiSessionClient, type MultiSessionNotificationEvent, type MultiSessionNotificationHandlers, type MultiSessionProgressEvent, type MultiSessionLoggingEvent, type MultiSessionListChangedEvent, type MultiSessionCancelledEvent, type MultiSessionElicitationCompleteEvent, type MultiSessionResourceUpdatedEvent, type MultiSessionTaskStatusEvent } from './mcp/multi-session-client.js';
 
 /** SSE handler for real-time connections */
 export { createSSEHandler, SSEConnectionManager, type SSEHandlerOptions, type ClientMetadata } from './handlers/sse-handler.js';

--- a/src/server/mcp/multi-session-client.ts
+++ b/src/server/mcp/multi-session-client.ts
@@ -55,6 +55,17 @@ export interface MultiSessionListChangedEvent extends MultiSessionNotificationEv
     | 'notifications/prompts/list_changed';
 }
 
+export interface MultiSessionCancelledEvent extends MultiSessionNotificationEvent {
+    method: 'notifications/cancelled';
+    requestId?: string | number;
+    reason?: string;
+}
+
+export interface MultiSessionElicitationCompleteEvent extends MultiSessionNotificationEvent {
+    method: 'notifications/elicitation/complete';
+    elicitationId?: string;
+}
+
 export interface MultiSessionResourceUpdatedEvent extends MultiSessionNotificationEvent {
     method: 'notifications/resources/updated';
     uri?: string;
@@ -73,6 +84,8 @@ export interface MultiSessionNotificationHandlers {
     onToolListChanged?: (event: MultiSessionListChangedEvent) => void;
     onResourceListChanged?: (event: MultiSessionListChangedEvent) => void;
     onPromptListChanged?: (event: MultiSessionListChangedEvent) => void;
+    onCancelled?: (event: MultiSessionCancelledEvent) => void;
+    onElicitationComplete?: (event: MultiSessionElicitationCompleteEvent) => void;
     onResourceUpdated?: (event: MultiSessionResourceUpdatedEvent) => void;
     onTaskStatus?: (event: MultiSessionTaskStatusEvent) => void;
 }
@@ -91,6 +104,8 @@ export class MultiSessionClient {
     private readonly _onToolListChanged = new Emitter<MultiSessionListChangedEvent>();
     private readonly _onResourceListChanged = new Emitter<MultiSessionListChangedEvent>();
     private readonly _onPromptListChanged = new Emitter<MultiSessionListChangedEvent>();
+    private readonly _onCancelled = new Emitter<MultiSessionCancelledEvent>();
+    private readonly _onElicitationComplete = new Emitter<MultiSessionElicitationCompleteEvent>();
     private readonly _onResourceUpdated = new Emitter<MultiSessionResourceUpdatedEvent>();
     private readonly _onTaskStatus = new Emitter<MultiSessionTaskStatusEvent>();
     private readonly notificationForwarders = new Map<string, Disposable>();
@@ -101,6 +116,8 @@ export class MultiSessionClient {
     public readonly onToolListChanged: Event<MultiSessionListChangedEvent> = this._onToolListChanged.event;
     public readonly onResourceListChanged: Event<MultiSessionListChangedEvent> = this._onResourceListChanged.event;
     public readonly onPromptListChanged: Event<MultiSessionListChangedEvent> = this._onPromptListChanged.event;
+    public readonly onCancelled: Event<MultiSessionCancelledEvent> = this._onCancelled.event;
+    public readonly onElicitationComplete: Event<MultiSessionElicitationCompleteEvent> = this._onElicitationComplete.event;
     public readonly onResourceUpdated: Event<MultiSessionResourceUpdatedEvent> = this._onResourceUpdated.event;
     public readonly onTaskStatus: Event<MultiSessionTaskStatusEvent> = this._onTaskStatus.event;
 
@@ -142,6 +159,14 @@ export class MultiSessionClient {
 
         if (handlers.onPromptListChanged) {
             subscriptions.push(this.onPromptListChanged(handlers.onPromptListChanged));
+        }
+
+        if (handlers.onCancelled) {
+            subscriptions.push(this.onCancelled(handlers.onCancelled));
+        }
+
+        if (handlers.onElicitationComplete) {
+            subscriptions.push(this.onElicitationComplete(handlers.onElicitationComplete));
         }
 
         if (handlers.onResourceUpdated) {
@@ -250,6 +275,24 @@ export class MultiSessionClient {
                 return;
             case 'notifications/prompts/list_changed':
                 this._onPromptListChanged.fire({ ...event, method: 'notifications/prompts/list_changed' });
+                return;
+            case 'notifications/cancelled':
+                this._onCancelled.fire({
+                    ...event,
+                    method: 'notifications/cancelled',
+                    requestId:
+                        typeof params?.requestId === 'string' || typeof params?.requestId === 'number'
+                            ? params.requestId
+                            : undefined,
+                    reason: typeof params?.reason === 'string' ? params.reason : undefined,
+                });
+                return;
+            case 'notifications/elicitation/complete':
+                this._onElicitationComplete.fire({
+                    ...event,
+                    method: 'notifications/elicitation/complete',
+                    elicitationId: typeof params?.elicitationId === 'string' ? params.elicitationId : undefined,
+                });
                 return;
             case 'notifications/resources/updated':
                 this._onResourceUpdated.fire({
@@ -390,6 +433,8 @@ export class MultiSessionClient {
         this._onToolListChanged.dispose();
         this._onResourceListChanged.dispose();
         this._onPromptListChanged.dispose();
+        this._onCancelled.dispose();
+        this._onElicitationComplete.dispose();
         this._onResourceUpdated.dispose();
         this._onTaskStatus.dispose();
     }

--- a/tests/multi-session-client.test.ts
+++ b/tests/multi-session-client.test.ts
@@ -81,6 +81,57 @@ test.describe('MultiSessionClient notification listeners', () => {
 
 
 
+  test('supports cancelled notifications', () => {
+    const client = new MultiSessionClient('user-1');
+
+    const cancelledEvents: any[] = [];
+
+    const subscription = client.setNotificationHandlers({
+      onCancelled: (event) => {
+        cancelledEvents.push(event);
+      },
+    });
+
+    (client as any).fireTypedNotifications({
+      sessionId: 'session-1',
+      serverId: 'server-1',
+      method: 'notifications/cancelled',
+      params: { requestId: 99, reason: 'stopped by user' },
+      timestamp: Date.now(),
+    });
+
+    expect(cancelledEvents).toHaveLength(1);
+    expect(cancelledEvents[0].requestId).toBe(99);
+    expect(cancelledEvents[0].reason).toBe('stopped by user');
+
+    subscription.dispose();
+  });
+
+  test('supports elicitation complete notifications', () => {
+    const client = new MultiSessionClient('user-1');
+
+    const events: any[] = [];
+
+    const subscription = client.setNotificationHandlers({
+      onElicitationComplete: (event) => {
+        events.push(event);
+      },
+    });
+
+    (client as any).fireTypedNotifications({
+      sessionId: 'session-1',
+      serverId: 'server-1',
+      method: 'notifications/elicitation/complete',
+      params: { elicitationId: 'elicit-1' },
+      timestamp: Date.now(),
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].elicitationId).toBe('elicit-1');
+
+    subscription.dispose();
+  });
+
   test('disconnect clears stale forwarders even without connected clients', () => {
     const client = new MultiSessionClient('user-1');
 


### PR DESCRIPTION
### Motivation
- Surface MCP server→client semantics for cancellation and out-of-band elicitation by adding typed incoming notification events for `notifications/cancelled` and `notifications/elicitation/complete`.
- Simplify the Next.js example to keep the primary pattern easy to follow while preserving the long-lived client pattern as reference comments.
- Restore explicit request-scoped cleanup using `onFinish` + `catch` semantics so streaming use-cases properly dispose/disconnect when the operation completes or errors.
- Address developer feedback by making lifecycle guidance a comments-only reference in `examples/nextjs/app/openai-agent/agent.ts` rather than changing the active example behavior.

### Description
- Added `MultiSessionCancelledEvent` and `MultiSessionElicitationCompleteEvent` types, emitters, public `onCancelled` / `onElicitationComplete` events, and wired them into the notification dispatch logic in `src/server/mcp/multi-session-client.ts`.
- Extended `MultiSessionNotificationHandlers` and `setNotificationHandlers` to accept `onCancelled` and `onElicitationComplete` callbacks and ensured the new events are disposed in `dispose()` and cleared on `disconnect()`.
- Re-exported the new types from `src/server/index.ts` and updated `docs/docs/api-reference.md` to document the new handlers and lifecycle guidance.
- Reverted the Next.js example at `examples/nextjs/app/openai-agent/agent.ts` to a simpler flow and preserved the cache/long-lived client pattern as comment-only reference, and updated `docs/docs/nextjs.md` to show `onFinish` + `catch` cleanup with `notificationSubscription.dispose()` and `client.disconnect()`.
- Added unit tests in `tests/multi-session-client.test.ts` to validate `cancelled` and `elicitation/complete` notification handling.

### Testing
- Ran `npx playwright test tests/multi-session-client.test.ts` and all tests in that file passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998c039a4948332a7ff9bd2b6a73394)