### PR TITLE
fix(remote-proxy): isolate agent visibility per user and fix one-command deploy defaults

### DIFF
--- a/packages/mcp-local-agent/config.json
+++ b/packages/mcp-local-agent/config.json
@@ -13,5 +13,7 @@
         "windows-mcp"
       ]
     }
-  }
+  },
+  "jwt_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJEMVdZQ0JOWkxFIiwicm9sZSI6ImFnZW50IiwiY2FwYWJpbGl0aWVzIjpbIioiXSwiZXhwIjoxNzcyNzM1MDkwfQ.mOEM-QrHKoJqPYjzKmBIjRfMjWOFIi06hNP-C8B3H5k",
+  "agent_id": "D1WYCBNZLE"
 }

--- a/packages/mcp-remote-server/README.md
+++ b/packages/mcp-remote-server/README.md
@@ -40,8 +40,8 @@ uv run remote-proxy-deploy
 
 Optional flags:
 - `--host nexus`
-- `--remote-dir /home/ubuntu/remote-proxy`
-- `--service remote-proxy`
+- `--remote-dir /home/ubuntu/mcp-remote-server`
+- `--service mcp-remote-server`
 - `--skip-verify`
 
 This command packages local code (excluding `.venv` and `.env*`), uploads to your server, runs `uv sync`, restarts the systemd service, and checks health.

--- a/packages/mcp-remote-server/src/mcp_remote_server/connection_manager.py
+++ b/packages/mcp-remote-server/src/mcp_remote_server/connection_manager.py
@@ -16,6 +16,7 @@ logger = logging.getLogger("mcp_remote_server.connection_manager")
 @dataclass
 class ConnectedAgent:
     agent_id: str
+    owner_id: str
     websocket: WebSocket
     capabilities: set[str]
     pending: dict[str, asyncio.Future[dict[str, Any]]] = field(default_factory=dict)
@@ -24,46 +25,48 @@ class ConnectedAgent:
 class ConnectionManager:
     def __init__(self) -> None:
         self._agents: dict[str, ConnectedAgent] = {}
-        self._subscribers: set[asyncio.Queue[dict[str, Any]]] = set()
+        self._subscribers: dict[str, set[asyncio.Queue[dict[str, Any]]]] = {}
         self._lock = asyncio.Lock()
 
     @staticmethod
     def _ts() -> str:
         return datetime.now(timezone.utc).isoformat()
 
-    def _connected_agents_details_unlocked(self) -> list[dict[str, Any]]:
+    def _connected_agents_details_unlocked(self, owner_id: str | None = None) -> list[dict[str, Any]]:
         return [
             {
                 "agent_id": agent_id,
                 "capabilities": sorted(agent.capabilities),
             }
             for agent_id, agent in self._agents.items()
+            if owner_id is None or agent.owner_id == owner_id
         ]
 
-    def _broadcast_agents_updated_unlocked(self, reason: str, agent_id: str) -> None:
+    def _broadcast_agents_updated_unlocked(self, reason: str, agent_id: str, owner_id: str) -> None:
         event = {
             "type": "agents_updated",
             "reason": reason,
             "agent_id": agent_id,
             "timestamp": self._ts(),
-            "agents": self._connected_agents_details_unlocked(),
+            "agents": self._connected_agents_details_unlocked(owner_id=owner_id),
         }
         stale: list[asyncio.Queue[dict[str, Any]]] = []
-        for queue in self._subscribers:
+        for queue in self._subscribers.get(owner_id, set()):
             try:
                 queue.put_nowait(event)
             except asyncio.QueueFull:
                 stale.append(queue)
         for queue in stale:
-            self._subscribers.discard(queue)
+            self._subscribers.get(owner_id, set()).discard(queue)
 
-    async def register(self, agent_id: str, websocket: WebSocket, capabilities: set[str]) -> None:
+    async def register(self, agent_id: str, owner_id: str, websocket: WebSocket, capabilities: set[str]) -> None:
         async with self._lock:
             existing = self._agents.get(agent_id)
             if existing is not None:
                 await existing.websocket.close(code=1012, reason="superseded")
             self._agents[agent_id] = ConnectedAgent(
                 agent_id=agent_id,
+                owner_id=owner_id,
                 websocket=websocket,
                 capabilities=capabilities,
             )
@@ -71,7 +74,7 @@ class ConnectionManager:
                 "agent_registered",
                 extra={"agent_id": agent_id, "capabilities": sorted(capabilities)},
             )
-            self._broadcast_agents_updated_unlocked(reason="registered", agent_id=agent_id)
+            self._broadcast_agents_updated_unlocked(reason="registered", agent_id=agent_id, owner_id=owner_id)
 
     async def unregister(self, agent_id: str, websocket: WebSocket | None = None) -> None:
         async with self._lock:
@@ -91,7 +94,7 @@ class ConnectionManager:
                     )
             self._agents.pop(agent_id, None)
             logger.info("agent_unregistered", extra={"agent_id": agent_id})
-            self._broadcast_agents_updated_unlocked(reason="unregistered", agent_id=agent_id)
+            self._broadcast_agents_updated_unlocked(reason="unregistered", agent_id=agent_id, owner_id=agent.owner_id)
 
     async def handle_result(self, agent_id: str, request_id: str, result: dict[str, Any]) -> None:
         async with self._lock:
@@ -113,10 +116,13 @@ class ConnectionManager:
         payload: dict[str, Any],
         request_id: str,
         timeout_seconds: float,
+        owner_id: str | None = None,
     ) -> dict[str, Any]:
         async with self._lock:
             agent = self._agents.get(agent_id)
             if agent is None:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not connected")
+            if owner_id is not None and agent.owner_id != owner_id:
                 raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not connected")
             if mcp_server not in agent.capabilities:
                 raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="MCP server not allowed for agent")
@@ -150,27 +156,33 @@ class ConnectionManager:
                     active.pending.pop(request_id, None)
             raise HTTPException(status_code=status.HTTP_504_GATEWAY_TIMEOUT, detail="Agent response timed out") from exc
 
-    async def connected_agent_ids(self) -> list[str]:
+    async def connected_agent_ids(self, owner_id: str | None = None) -> list[str]:
         async with self._lock:
-            return list(self._agents.keys())
+            return [agent_id for agent_id, agent in self._agents.items() if owner_id is None or agent.owner_id == owner_id]
 
-    async def connected_agents_details(self) -> list[dict[str, Any]]:
+    async def connected_agents_details(self, owner_id: str | None = None) -> list[dict[str, Any]]:
         async with self._lock:
-            return self._connected_agents_details_unlocked()
+            return self._connected_agents_details_unlocked(owner_id=owner_id)
 
-    async def subscribe_agent_events(self) -> asyncio.Queue[dict[str, Any]]:
+    async def subscribe_agent_events(self, owner_id: str) -> asyncio.Queue[dict[str, Any]]:
         queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=100)
         async with self._lock:
-            self._subscribers.add(queue)
+            owner_subs = self._subscribers.setdefault(owner_id, set())
+            owner_subs.add(queue)
             queue.put_nowait(
                 {
                     "type": "agents_snapshot",
                     "timestamp": self._ts(),
-                    "agents": self._connected_agents_details_unlocked(),
+                    "agents": self._connected_agents_details_unlocked(owner_id=owner_id),
                 }
             )
         return queue
 
-    async def unsubscribe_agent_events(self, queue: asyncio.Queue[dict[str, Any]]) -> None:
+    async def unsubscribe_agent_events(self, owner_id: str, queue: asyncio.Queue[dict[str, Any]]) -> None:
         async with self._lock:
-            self._subscribers.discard(queue)
+            owner_subs = self._subscribers.get(owner_id)
+            if owner_subs is None:
+                return
+            owner_subs.discard(queue)
+            if not owner_subs:
+                self._subscribers.pop(owner_id, None)

--- a/packages/mcp-remote-server/src/mcp_remote_server/deploy.py
+++ b/packages/mcp-remote-server/src/mcp_remote_server/deploy.py
@@ -109,8 +109,8 @@ def deploy(host: str, remote_dir: str, service: str, skip_verify: bool) -> None:
 def run() -> None:
     parser = argparse.ArgumentParser(description='Deploy remote-proxy package to EC2 host')
     parser.add_argument('--host', default='nexus', help='SSH host alias (default: nexus)')
-    parser.add_argument('--remote-dir', default='/home/ubuntu/remote-proxy', help='Remote project directory')
-    parser.add_argument('--service', default='remote-proxy', help='Systemd service name')
+    parser.add_argument('--remote-dir', default='/home/ubuntu/mcp-remote-server', help='Remote project directory')
+    parser.add_argument('--service', default='mcp-remote-server', help='Systemd service name')
     parser.add_argument('--skip-verify', action='store_true', help='Skip post-deploy health checks')
     args = parser.parse_args()
 

--- a/packages/mcp-remote-server/src/mcp_remote_server/main.py
+++ b/packages/mcp-remote-server/src/mcp_remote_server/main.py
@@ -39,26 +39,26 @@ async def healthz() -> dict[str, str]:
 
 
 @app.get("/agents")
-async def agents(_: AuthContext = Depends(authenticator.http_auth)) -> dict[str, list[str]]:
-    ids = await connection_manager.connected_agent_ids()
+async def agents(auth_ctx: AuthContext = Depends(authenticator.http_auth)) -> dict[str, list[str]]:
+    ids = await connection_manager.connected_agent_ids(owner_id=auth_ctx.subject)
     return {"connected_agents": ids}
 
 
 @app.get("/agents/details")
-async def agent_details(_: AuthContext = Depends(authenticator.http_auth)) -> dict[str, list[dict[str, object]]]:
-    agents = await connection_manager.connected_agents_details()
+async def agent_details(auth_ctx: AuthContext = Depends(authenticator.http_auth)) -> dict[str, list[dict[str, object]]]:
+    agents = await connection_manager.connected_agents_details(owner_id=auth_ctx.subject)
     return {"agents": agents}
 
 
 @app.get("/manage/agents/details")
-async def get_agents_details() -> dict[str, list[dict[str, object]]]:
-    agents = await connection_manager.connected_agents_details()
+async def get_agents_details(auth_ctx: AuthContext = Depends(authenticator.http_auth)) -> dict[str, list[dict[str, object]]]:
+    agents = await connection_manager.connected_agents_details(owner_id=auth_ctx.subject)
     return {"agents": agents}
 
 
 @app.get("/manage/agents/stream")
-async def stream_agents_details() -> StreamingResponse:
-    queue = await connection_manager.subscribe_agent_events()
+async def stream_agents_details(auth_ctx: AuthContext = Depends(authenticator.http_auth)) -> StreamingResponse:
+    queue = await connection_manager.subscribe_agent_events(owner_id=auth_ctx.subject)
 
     async def _stream() -> object:
         try:
@@ -75,7 +75,7 @@ async def stream_agents_details() -> StreamingResponse:
         except asyncio.CancelledError:
             raise
         finally:
-            await connection_manager.unsubscribe_agent_events(queue)
+            await connection_manager.unsubscribe_agent_events(auth_ctx.subject, queue)
 
     return StreamingResponse(
         _stream(),
@@ -153,7 +153,7 @@ async def connect(websocket: WebSocket) -> None:
             return
 
         agent_id = initial_obj.agent_id
-        await connection_manager.register(agent_id, websocket, declared_capabilities)
+        await connection_manager.register(agent_id, auth_ctx.subject, websocket, declared_capabilities)
 
         while True:
             raw = await websocket.receive_text()
@@ -179,6 +179,8 @@ async def _invoke_core(
     payload: dict[str, object],
     auth_ctx: AuthContext,
 ) -> dict[str, object]:
+    if auth_ctx.subject != agent_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Caller cannot access this agent")
     if mcp_server not in auth_ctx.capabilities and "*" not in auth_ctx.capabilities:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Caller missing MCP server scope")
 
@@ -190,11 +192,12 @@ async def _invoke_core(
         payload=payload,
         request_id=request_id,
         timeout_seconds=REQUEST_TIMEOUT_SECONDS,
+        owner_id=auth_ctx.subject,
     )
     return result
 
 
-async def _get_mcp_server_info(agent_id: str, mcp_server: str) -> dict[str, object]:
+async def _get_mcp_server_info(agent_id: str, mcp_server: str, owner_id: str) -> dict[str, object]:
     request_id = str(uuid4())
     init_payload = {
         "jsonrpc": "2.0",
@@ -212,6 +215,7 @@ async def _get_mcp_server_info(agent_id: str, mcp_server: str) -> dict[str, obje
         payload=init_payload,
         request_id=request_id,
         timeout_seconds=REQUEST_TIMEOUT_SECONDS,
+        owner_id=owner_id,
     )
 
     request_id_tools = str(uuid4())
@@ -222,6 +226,7 @@ async def _get_mcp_server_info(agent_id: str, mcp_server: str) -> dict[str, obje
         payload=tools_payload,
         request_id=request_id_tools,
         timeout_seconds=REQUEST_TIMEOUT_SECONDS,
+        owner_id=owner_id,
     )
 
     init_data = init_result.get("result", init_result) if isinstance(init_result, dict) else {}
@@ -245,9 +250,12 @@ async def _get_mcp_server_info(agent_id: str, mcp_server: str) -> dict[str, obje
 async def get_mcp_server_info(
     agent_id: str,
     mcp_server: str,
+    auth_ctx: AuthContext = Depends(authenticator.http_auth),
 ) -> JSONResponse:
+    if auth_ctx.subject != agent_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Caller cannot access this agent")
     try:
-        data = await _get_mcp_server_info(agent_id=agent_id, mcp_server=mcp_server)
+        data = await _get_mcp_server_info(agent_id=agent_id, mcp_server=mcp_server, owner_id=auth_ctx.subject)
         return JSONResponse(content=data)
     except HTTPException as exc:
         return JSONResponse(


### PR DESCRIPTION
**Summary**
This PR fixes a multi-tenant data leakage issue in remote-proxy where connected agents/config could be visible across users in remote-bridge pages. It also aligns deploy defaults so uv run remote-proxy-deploy works as a true one-command deploy for the current server setup.

**Problem**

Agent connection state and SSE updates were stored/broadcast globally.
/manage/agents/details and /manage/agents/stream were not scoped by authenticated user.

**What Changed**

1. User-scoped agent ownership in connection manager

- Added owner_id to connected agent state.
- Scoped:
  - connected agent ids/details
  - SSE subscribers/events
  - invoke access checks (owner-aware path)
 
 2. Auth + subject scoping in API routes

- GET /agents, GET /agents/details, GET /manage/agents/details, GET /manage/agents/stream
- now use authenticated context and return only caller-owned agents.
- WebSocket registration now stores owner as authenticated subject.
- POST /manage/{agent_id}/{mcp_server}/server-info
- now requires auth and blocks cross-agent access.
- Core invoke path enforces auth_ctx.subject == agent_id.