### PR TITLE
feat: enhance server connection checks and improve OAuth client config

### DIFF
--- a/packages/mcp-local-agent/src/mcp_local_agent/bridge_runtime.py
+++ b/packages/mcp-local-agent/src/mcp_local_agent/bridge_runtime.py
@@ -83,23 +83,33 @@ class ManagedMCPServer:
         self._initialize_result: dict[str, Any] = {}
 
     async def start(self) -> None:
-        command = str(self.server_cfg.get("command", "")).strip()
-        if not command:
-            raise RuntimeError(f"mcpServers.{self.name}.command is required")
+        # Important: ensure partial startup failures always close the entered
+        # async contexts from the same task that created them. Otherwise Python
+        # GC may finalize the async generator on a different task, which trips
+        # AnyIO's cancel scope ownership checks.
+        try:
+            command = str(self.server_cfg.get("command", "")).strip()
+            if not command:
+                raise RuntimeError(f"mcpServers.{self.name}.command is required")
 
-        resolved_command = shutil.which(command) if command in {"npx", "npm", "pnpm", "yarn"} else command
-        if resolved_command is None:
-            raise RuntimeError(f"Unable to resolve command for mcpServers.{self.name}: {command}")
+            resolved_command = shutil.which(command) if command in {"npx", "npm", "pnpm", "yarn"} else command
+            if resolved_command is None:
+                raise RuntimeError(f"Unable to resolve command for mcpServers.{self.name}: {command}")
 
-        args = [str(item) for item in self.server_cfg.get("args", [])]
-        env = {**os.environ, **{str(k): str(v) for k, v in self.server_cfg.get("env", {}).items()}}
+            args = [str(item) for item in self.server_cfg.get("args", [])]
+            env = {**os.environ, **{str(k): str(v) for k, v in self.server_cfg.get("env", {}).items()}}
 
-        server_params = StdioServerParameters(command=resolved_command, args=args, env=env)
-        transport = await self.exit_stack.enter_async_context(stdio_client(server_params))
-        read, write = transport
-        session = await self.exit_stack.enter_async_context(ClientSession(read, write))
-        self._initialize_result = _normalize_initialize_result(await session.initialize())
-        self.session = session
+            server_params = StdioServerParameters(command=resolved_command, args=args, env=env)
+            transport = await self.exit_stack.enter_async_context(stdio_client(server_params))
+            read, write = transport
+            session = await self.exit_stack.enter_async_context(ClientSession(read, write))
+            self._initialize_result = _normalize_initialize_result(await session.initialize())
+            self.session = session
+        except Exception:
+            await self.exit_stack.aclose()
+            self.session = None
+            self._initialize_result = {}
+            raise
 
     async def close(self) -> None:
         await self.exit_stack.aclose()
@@ -244,7 +254,9 @@ class LocalBridgeAgent:
                     await asyncio.sleep(backoff)
                     backoff = min(backoff * 2, self.config.reconnect_max_delay_seconds)
         finally:
-            await self._stop_mcp_servers()
+            # If the runner task is cancelled (Ctrl+C path), still close the MCP
+            # stdio sessions cleanly to avoid background task/generator teardown.
+            await asyncio.shield(self._stop_mcp_servers())
 
     async def stop(self) -> None:
         self._stop_event.set()
@@ -316,7 +328,18 @@ class LocalBridgeAgent:
                 self._mcp_servers[name] = managed
                 elapsed = asyncio.get_running_loop().time() - start_at
                 self._log("mcp", f"[{index}/{total}] ready '{name}' via stdio MCP client ({elapsed:.1f}s)")
+            except asyncio.CancelledError:
+                try:
+                    await managed.close()
+                except Exception as close_exc:
+                    logger.warning("error while cleaning up cancelled MCP server '%s': %s", name, close_exc)
+                raise
             except Exception as exc:
+                # Best-effort cleanup in the same task that attempted startup.
+                try:
+                    await managed.close()
+                except Exception as close_exc:
+                    logger.warning("error while cleaning up failed MCP server '%s': %s", name, close_exc)
                 self._log("mcp", f"[{index}/{total}] failed '{name}': {exc}")
 
     async def _stop_mcp_servers(self) -> None:

--- a/packages/mcp-local-agent/uv.lock
+++ b/packages/mcp-local-agent/uv.lock
@@ -305,7 +305,9 @@ wheels = [
 
 [[package]]
 name = "mcpassistant-gateway"
-version = "0.1.3"
+
+
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/src/client/react/use-mcp.ts
+++ b/src/client/react/use-mcp.ts
@@ -602,7 +602,7 @@ export function useMcp(options: UseMcpOptions): McpClient {
   const isServerConnected = useCallback(
     (serverId: string) => {
       const conn = getConnectionByServerId(serverId);
-      return conn?.state === 'CONNECTED';
+      return conn ? conn.state === 'CONNECTED' || conn.state === 'DISCOVERING' || conn.state === 'READY' : false;
     },
     [getConnectionByServerId]
   );

--- a/src/client/vue/use-mcp.ts
+++ b/src/client/vue/use-mcp.ts
@@ -582,7 +582,7 @@ export function useMcp(options: UseMcpOptions): McpClient {
 
     const isServerConnected = (serverId: string) => {
         const conn = getConnectionByServerId(serverId);
-        return conn?.state === 'CONNECTED';
+        return conn ? conn.state === 'CONNECTED' || conn.state === 'DISCOVERING' || conn.state === 'READY' : false;
     };
 
     const getTools = (sessionId: string) => {

--- a/src/server/handlers/sse-handler.ts
+++ b/src/server/handlers/sse-handler.ts
@@ -322,16 +322,7 @@ export class SSEConnectionManager {
       await client.connect();
 
       // Fetch tools
-      const tools = await client.listTools();
-
-      this.emitConnectionEvent({
-        type: 'tools_discovered',
-        sessionId,
-        serverId,
-        toolCount: tools.tools.length,
-        tools: tools.tools,
-        timestamp: Date.now(),
-      });
+      await client.listTools();
 
       return {
         sessionId,
@@ -468,15 +459,6 @@ export class SSEConnectionManager {
 
       const tools = await client.listTools();
 
-      this.emitConnectionEvent({
-        type: 'tools_discovered',
-        sessionId,
-        serverId: session.serverId ?? 'unknown',
-        toolCount: tools.tools.length,
-        tools: tools.tools,
-        timestamp: Date.now(),
-      });
-
       return { success: true, toolCount: tools.tools.length };
     } catch (error) {
       this.emitConnectionEvent({
@@ -526,15 +508,6 @@ export class SSEConnectionManager {
       this.clients.set(sessionId, client);
 
       const tools = await client.listTools();
-
-      this.emitConnectionEvent({
-        type: 'tools_discovered',
-        sessionId,
-        serverId: session.serverId ?? 'unknown',
-        toolCount: tools.tools.length,
-        tools: tools.tools,
-        timestamp: Date.now(),
-      });
 
       return { success: true, toolCount: tools.tools.length };
     } catch (error) {

--- a/src/server/mcp/oauth-client.ts
+++ b/src/server/mcp/oauth-client.ts
@@ -28,15 +28,18 @@ import {
   ReadResourceResult,
   ReadResourceResultSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import type { OAuthClientMetadata, OAuthTokens, OAuthClientInformationFull } from '@modelcontextprotocol/sdk/shared/auth.js';
+import type { OAuthTokens, OAuthClientInformationFull } from '@modelcontextprotocol/sdk/shared/auth.js';
 import { StorageOAuthClientProvider, type AgentsOAuthProvider } from './storage-oauth-provider.js';
 import { sanitizeServerLabel } from '../../shared/utils.js';
 import { Emitter, type McpConnectionEvent, type McpObservabilityEvent, type McpConnectionState } from '../../shared/events.js';
 import { UnauthorizedError } from '../../shared/errors.js';
 import { storage } from '../storage/index.js';
-import { SESSION_TTL_SECONDS, STATE_EXPIRATION_MS } from '../../shared/constants.js';
-
-
+import {
+  MCP_CLIENT_NAME,
+  MCP_CLIENT_VERSION,
+  SESSION_TTL_SECONDS,
+  STATE_EXPIRATION_MS,
+} from '../../shared/constants.js';
 
 /**
  * Supported MCP transport types
@@ -300,49 +303,34 @@ export class MCPClient {
       throw new Error('Missing required connection metadata');
     }
 
-    const clientMetadata: OAuthClientMetadata = {
-      client_name: this.clientName || 'MCP Assistant',
-      redirect_uris: [this.callbackUrl],
-      grant_types: ['authorization_code', 'refresh_token'],
-      response_types: ['code'],
-      token_endpoint_auth_method: this.clientSecret ? 'client_secret_basic' : 'none',
-      client_uri: this.clientUri || 'https://mcp-assistant.in',
-      logo_uri: this.logoUri || 'https://mcp-assistant.in/logo.png',
-      policy_uri: this.policyUri || 'https://mcp-assistant.in/privacy',
-      software_id: '@mcp-ts',
-      software_version: '1.0.0-beta.4',
-      ...(this.clientId ? { client_id: this.clientId } : {}),
-      ...(this.clientSecret ? { client_secret: this.clientSecret } : {}),
-    };
-
     if (!this.oauthProvider) {
       if (!this.serverId) {
         throw new Error('serverId required for OAuth provider initialization');
       }
-
-      this.oauthProvider = new StorageOAuthClientProvider(
-        this.identity,
-        this.serverId,
-        this.sessionId,
-        clientMetadata.client_name ?? 'MCP Assistant',
-        this.callbackUrl,
-        (redirectUrl: string) => {
+      this.oauthProvider = new StorageOAuthClientProvider({
+        identity: this.identity,
+        serverId: this.serverId,
+        sessionId: this.sessionId,
+        redirectUrl: this.callbackUrl!,
+        clientName: this.clientName,
+        clientUri: this.clientUri,
+        logoUri: this.logoUri,
+        policyUri: this.policyUri,
+        clientId: this.clientId,
+        clientSecret: this.clientSecret,
+        onRedirect: (redirectUrl: string) => {
           if (this.onRedirect) {
             this.onRedirect(redirectUrl);
           }
         }
-      );
-
-      if (this.clientId && this.oauthProvider) {
-        this.oauthProvider.clientId = this.clientId;
-      }
+      });
     }
 
     if (!this.client) {
       this.client = new Client(
         {
-          name: 'mcp-ts-oauth-client',
-          version: '2.0',
+          name: MCP_CLIENT_NAME,
+          version: MCP_CLIENT_VERSION,
         },
         {
           capabilities: {
@@ -620,8 +608,8 @@ export class MCPClient {
 
         this.client = new Client(
           {
-            name: 'mcp-ts-oauth-client',
-            version: '2.0',
+            name: MCP_CLIENT_NAME,
+            version: MCP_CLIENT_VERSION,
           },
           {
             capabilities: {
@@ -980,8 +968,8 @@ export class MCPClient {
 
     this.client = new Client(
       {
-        name: 'mcp-ts-oauth-client',
-        version: '2.0',
+        name: MCP_CLIENT_NAME,
+        version: MCP_CLIENT_VERSION,
       },
       { capabilities: {} }
     );

--- a/src/server/mcp/storage-oauth-provider.ts
+++ b/src/server/mcp/storage-oauth-provider.ts
@@ -1,13 +1,20 @@
-
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
 import type {
-    OAuthClientInformation,
     OAuthClientInformationFull,
+    OAuthClientInformationMixed,
     OAuthClientMetadata,
     OAuthTokens
 } from "@modelcontextprotocol/sdk/shared/auth.js";
 import { storage, SessionData } from "../storage/index.js";
-import { TOKEN_EXPIRY_BUFFER_MS } from '../../shared/constants.js';
+import {
+    DEFAULT_CLIENT_NAME,
+    DEFAULT_CLIENT_URI,
+    DEFAULT_LOGO_URI,
+    DEFAULT_POLICY_URI,
+    SOFTWARE_ID,
+    SOFTWARE_VERSION,
+    TOKEN_EXPIRY_BUFFER_MS,
+} from '../../shared/constants.js';
 
 /**
  * Extension of OAuthClientProvider interface with additional methods
@@ -26,54 +33,72 @@ export interface AgentsOAuthProvider extends OAuthClientProvider {
     setTokenExpiresAt(expiresAt: number): void;
 }
 
+export interface StorageOAuthClientProviderOptions {
+    identity: string;
+    serverId: string;
+    sessionId: string;
+    redirectUrl: string;
+    clientName?: string;
+    clientUri?: string;
+    logoUri?: string;
+    policyUri?: string;
+    clientId?: string;
+    clientSecret?: string;
+    onRedirect?: (url: string) => void;
+}
+
 /**
  * Storage-backed OAuth provider implementation for MCP
  * Stores OAuth tokens, client information, and PKCE verifiers using the configured StorageBackend
  */
 export class StorageOAuthClientProvider implements AgentsOAuthProvider {
+    public readonly identity: string;
+    public readonly serverId: string;
+    public readonly sessionId: string;
+    public readonly redirectUrl: string;
+
+    private readonly clientName?: string;
+    private readonly clientUri?: string;
+    private readonly logoUri?: string;
+    private readonly policyUri?: string;
+    private readonly clientSecret?: string;
+
     private _authUrl: string | undefined;
     private _clientId: string | undefined;
     private onRedirectCallback?: (url: string) => void;
     private tokenExpiresAt?: number;
 
     /**
-     * Creates a new Storage-backed OAuth provider
-     * @param identity - User/Client identifier
-     * @param serverId - Server identifier (for tracking which server this OAuth session belongs to)
-     * @param sessionId - Session identifier (used as OAuth state)
-     * @param clientName - OAuth client name
-     * @param baseRedirectUrl - OAuth callback URL
-     * @param onRedirect - Optional callback when redirect to authorization is needed
+     * Creates a new storage-backed OAuth provider
+     * @param options - Provider configuration
      */
-    constructor(
-        public identity: string,
-        public serverId: string,
-        public sessionId: string,
-        public clientName: string,
-        public baseRedirectUrl: string,
-        onRedirect?: (url: string) => void
-    ) {
-        this.onRedirectCallback = onRedirect;
+    constructor(options: StorageOAuthClientProviderOptions) {
+        this.identity = options.identity;
+        this.serverId = options.serverId;
+        this.sessionId = options.sessionId;
+        this.redirectUrl = options.redirectUrl;
+        this.clientName = options.clientName;
+        this.clientUri = options.clientUri;
+        this.logoUri = options.logoUri;
+        this.policyUri = options.policyUri;
+        this._clientId = options.clientId;
+        this.clientSecret = options.clientSecret;
+        this.onRedirectCallback = options.onRedirect;
     }
 
     get clientMetadata(): OAuthClientMetadata {
         return {
-            client_name: this.clientName,
-            client_uri: this.clientUri,
+            client_name: this.clientName || DEFAULT_CLIENT_NAME,
+            client_uri: this.clientUri || DEFAULT_CLIENT_URI,
+            logo_uri: this.logoUri || DEFAULT_LOGO_URI,
+            policy_uri: this.policyUri || DEFAULT_POLICY_URI,
             grant_types: ["authorization_code", "refresh_token"],
             redirect_uris: [this.redirectUrl],
             response_types: ["code"],
-            token_endpoint_auth_method: "none",
-            ...(this._clientId ? { client_id: this._clientId } : {})
+            token_endpoint_auth_method: this.clientSecret ? "client_secret_basic" : "none",
+            software_id: SOFTWARE_ID,
+            software_version: SOFTWARE_VERSION,
         };
-    }
-
-    get clientUri() {
-        return new URL(this.redirectUrl).origin;
-    }
-
-    get redirectUrl() {
-        return this.baseRedirectUrl;
     }
 
     get clientId() {
@@ -91,7 +116,6 @@ export class StorageOAuthClientProvider implements AgentsOAuthProvider {
     private async getSessionData(): Promise<SessionData> {
         const data = await storage.getSession(this.identity, this.sessionId);
         if (!data) {
-            // Return empty/partial object if not found
             return {} as SessionData;
         }
         return data;
@@ -110,14 +134,25 @@ export class StorageOAuthClientProvider implements AgentsOAuthProvider {
     /**
      * Retrieves stored OAuth client information
      */
-    async clientInformation(): Promise<OAuthClientInformation | undefined> {
+    async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
         const data = await this.getSessionData();
 
         if (data.clientId && !this._clientId) {
             this._clientId = data.clientId;
         }
 
-        return data.clientInformation;
+        if (data.clientInformation) {
+            return data.clientInformation;
+        }
+
+        if (!this._clientId) {
+            return undefined;
+        }
+
+        return {
+            client_id: this._clientId,
+            ...(this.clientSecret ? { client_secret: this.clientSecret } : {}),
+        };
     }
 
     /**
@@ -152,7 +187,7 @@ export class StorageOAuthClientProvider implements AgentsOAuthProvider {
         return this.sessionId;
     }
 
-    async checkState(state: string): Promise<{ valid: boolean; serverId?: string; error?: string }> {
+    async checkState(_state: string): Promise<{ valid: boolean; serverId?: string; error?: string }> {
         const data = await storage.getSession(this.identity, this.sessionId);
 
         if (!data) {
@@ -162,7 +197,7 @@ export class StorageOAuthClientProvider implements AgentsOAuthProvider {
         return { valid: true, serverId: this.serverId };
     }
 
-    async consumeState(state: string): Promise<void> {
+    async consumeState(_state: string): Promise<void> {
         // No-op
     }
 
@@ -179,8 +214,6 @@ export class StorageOAuthClientProvider implements AgentsOAuthProvider {
         if (scope === "all") {
             await storage.removeSession(this.identity, this.sessionId);
         } else {
-            const data = await this.getSessionData();
-            // Create a copy to modify
             const updates: Partial<SessionData> = {};
 
             if (scope === "client") {

--- a/src/server/storage/index.ts
+++ b/src/server/storage/index.ts
@@ -12,6 +12,13 @@ export { RedisStorageBackend, MemoryStorageBackend, FileStorageBackend, SqliteSt
 let storageInstance: StorageBackend | null = null;
 let storagePromise: Promise<StorageBackend> | null = null;
 
+async function initializeStorage<T extends StorageBackend>(store: T): Promise<T> {
+    if (typeof store.init === 'function') {
+        await store.init();
+    }
+    return store;
+}
+
 async function createStorage(): Promise<StorageBackend> {
     const type = process.env.MCP_TS_STORAGE_TYPE?.toLowerCase();
 
@@ -38,17 +45,13 @@ async function createStorage(): Promise<StorageBackend> {
             console.warn('[Storage] MCP_TS_STORAGE_TYPE is "file" but MCP_TS_STORAGE_FILE is missing');
         }
         console.log(`[Storage] Using File storage (${filePath}) (Explicit)`);
-        const store = new FileStorageBackend({ path: filePath });
-        store.init().catch(err => console.error('[Storage] Failed to initialize file storage:', err));
-        return store;
+        return await initializeStorage(new FileStorageBackend({ path: filePath }));
     }
 
     if (type === 'sqlite') {
         const dbPath = process.env.MCP_TS_STORAGE_SQLITE_PATH;
         console.log(`[Storage] Using SQLite storage (${dbPath || 'default'}) (Explicit)`);
-        const store = new SqliteStorage({ path: dbPath });
-        store.init().catch(err => console.error('[Storage] Failed to initialize SQLite storage:', err));
-        return store;
+        return await initializeStorage(new SqliteStorage({ path: dbPath }));
     }
 
     if (type === 'memory') {
@@ -72,16 +75,12 @@ async function createStorage(): Promise<StorageBackend> {
 
     if (process.env.MCP_TS_STORAGE_FILE) {
         console.log(`[Storage] Auto-detected MCP_TS_STORAGE_FILE. Using File storage (${process.env.MCP_TS_STORAGE_FILE}).`);
-        const store = new FileStorageBackend({ path: process.env.MCP_TS_STORAGE_FILE });
-        store.init().catch(err => console.error('[Storage] Failed to initialize file storage:', err));
-        return store;
+        return await initializeStorage(new FileStorageBackend({ path: process.env.MCP_TS_STORAGE_FILE }));
     }
 
     if (process.env.MCP_TS_STORAGE_SQLITE_PATH) {
         console.log(`[Storage] Auto-detected MCP_TS_STORAGE_SQLITE_PATH. Using SQLite storage (${process.env.MCP_TS_STORAGE_SQLITE_PATH}).`);
-        const store = new SqliteStorage({ path: process.env.MCP_TS_STORAGE_SQLITE_PATH });
-        store.init().catch(err => console.error('[Storage] Failed to initialize SQLite storage:', err));
-        return store;
+        return await initializeStorage(new SqliteStorage({ path: process.env.MCP_TS_STORAGE_SQLITE_PATH }));
     }
 
     console.log('[Storage] No storage configured. Using In-Memory storage (Default).');
@@ -94,7 +93,10 @@ async function getStorage(): Promise<StorageBackend> {
     }
 
     if (!storagePromise) {
-        storagePromise = createStorage();
+        storagePromise = createStorage().catch((error) => {
+            storagePromise = null;
+            throw error;
+        });
     }
 
     storageInstance = await storagePromise;

--- a/src/server/storage/redis-backend.ts
+++ b/src/server/storage/redis-backend.ts
@@ -1,7 +1,7 @@
 
 import type { Redis } from 'ioredis';
 import { customAlphabet } from 'nanoid';
-import { StorageBackend, SessionData, SetClientOptions } from './types';
+import { StorageBackend, SessionData } from './types';
 import { SESSION_TTL_SECONDS } from '../../shared/constants.js';
 
 /** first char: letters only (required by OpenAI) */
@@ -22,6 +22,8 @@ const rest = customAlphabet(
 export class RedisStorageBackend implements StorageBackend {
     private readonly DEFAULT_TTL = SESSION_TTL_SECONDS;
     private readonly KEY_PREFIX = 'mcp:session:';
+    private readonly IDENTITY_KEY_PREFIX = 'mcp:identity:';
+    private readonly IDENTITY_KEY_SUFFIX = ':sessions';
 
     constructor(private redis: Redis) { }
 
@@ -38,7 +40,42 @@ export class RedisStorageBackend implements StorageBackend {
      * @private
      */
     private getIdentityKey(identity: string): string {
-        return `mcp:identity:${identity}:sessions`;
+        return `${this.IDENTITY_KEY_PREFIX}${identity}${this.IDENTITY_KEY_SUFFIX}`;
+    }
+
+    private parseIdentityFromKey(identityKey: string): string {
+        return identityKey.slice(
+            this.IDENTITY_KEY_PREFIX.length,
+            identityKey.length - this.IDENTITY_KEY_SUFFIX.length
+        );
+    }
+
+    private async scanKeys(pattern: string): Promise<string[]> {
+        const redis = this.redis as Redis & {
+            scan?: (cursor: string, ...args: Array<string | number>) => Promise<[string, string[]]>;
+        };
+
+        if (typeof redis.scan !== 'function') {
+            return await this.redis.keys(pattern);
+        }
+
+        const keys = new Set<string>();
+        let cursor = '0';
+
+        try {
+            do {
+                const [nextCursor, batch] = await redis.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
+                cursor = nextCursor;
+                for (const key of batch) {
+                    keys.add(key);
+                }
+            } while (cursor !== '0');
+        } catch (error) {
+            console.warn('[RedisStorage] SCAN failed, falling back to KEYS:', error);
+            return await this.redis.keys(pattern);
+        }
+
+        return Array.from(keys);
     }
 
     generateSessionId(): string {
@@ -121,18 +158,14 @@ export class RedisStorageBackend implements StorageBackend {
     }
 
     async getIdentityMcpSessions(identity: string): Promise<string[]> {
-        const identityKey = this.getIdentityKey(identity);
-        try {
-            return await this.redis.smembers(identityKey);
-        } catch (error) {
-            console.error(`[RedisStorage] Failed to get sessions for ${identity}:`, error);
-            return [];
-        }
+        const sessions = await this.getIdentitySessionsData(identity);
+        return sessions.map((session) => session.sessionId);
     }
 
     async getIdentitySessionsData(identity: string): Promise<SessionData[]> {
         try {
-            const sessionIds = await this.redis.smembers(this.getIdentityKey(identity));
+            const identityKey = this.getIdentityKey(identity);
+            const sessionIds = await this.redis.smembers(identityKey);
             if (sessionIds.length === 0) return [];
 
             const results = await Promise.all(
@@ -141,6 +174,11 @@ export class RedisStorageBackend implements StorageBackend {
                     return data ? (JSON.parse(data) as SessionData) : null;
                 })
             );
+
+            const staleSessionIds = sessionIds.filter((_, index) => results[index] === null);
+            if (staleSessionIds.length > 0) {
+                await this.redis.srem(identityKey, ...staleSessionIds);
+            }
 
             return results.filter((session): session is SessionData => session !== null);
         } catch (error) {
@@ -163,9 +201,24 @@ export class RedisStorageBackend implements StorageBackend {
 
     async getAllSessionIds(): Promise<string[]> {
         try {
-            const pattern = `${this.KEY_PREFIX}*`;
-            const keys = await this.redis.keys(pattern);
-            return keys.map((key) => key.replace(this.KEY_PREFIX, ''));
+            const keys = await this.scanKeys(`${this.KEY_PREFIX}*`);
+            const sessions = await Promise.all(
+                keys.map(async (key) => {
+                    const data = await this.redis.get(key);
+                    if (!data) {
+                        return null;
+                    }
+
+                    try {
+                        return (JSON.parse(data) as SessionData).sessionId;
+                    } catch (error) {
+                        console.error('[RedisStorage] Failed to parse session while listing all session IDs:', error);
+                        return null;
+                    }
+                })
+            );
+
+            return sessions.filter((sessionId): sessionId is string => sessionId !== null);
         } catch (error) {
             console.error('[RedisStorage] Failed to get all sessions:', error);
             return [];
@@ -174,10 +227,11 @@ export class RedisStorageBackend implements StorageBackend {
 
     async clearAll(): Promise<void> {
         try {
-            const pattern = `${this.KEY_PREFIX}*`;
-            const keys = await this.redis.keys(pattern);
-            if (keys.length > 0) {
-                await this.redis.del(...keys);
+            const keys = await this.scanKeys(`${this.KEY_PREFIX}*`);
+            const identityKeys = await this.scanKeys(`${this.IDENTITY_KEY_PREFIX}*${this.IDENTITY_KEY_SUFFIX}`);
+            const allKeys = [...keys, ...identityKeys];
+            if (allKeys.length > 0) {
+                await this.redis.del(...allKeys);
             }
         } catch (error) {
             console.error('[RedisStorage] Failed to clear sessions:', error);
@@ -186,13 +240,29 @@ export class RedisStorageBackend implements StorageBackend {
 
     async cleanupExpiredSessions(): Promise<void> {
         try {
-            const pattern = `${this.KEY_PREFIX}*`;
-            const keys = await this.redis.keys(pattern);
+            const identityKeys = await this.scanKeys(`${this.IDENTITY_KEY_PREFIX}*${this.IDENTITY_KEY_SUFFIX}`);
 
-            for (const key of keys) {
-                const ttl = await this.redis.ttl(key);
-                if (ttl <= 0) {
-                    await this.redis.del(key);
+            for (const identityKey of identityKeys) {
+                const identity = this.parseIdentityFromKey(identityKey);
+                const sessionIds = await this.redis.smembers(identityKey);
+
+                if (sessionIds.length === 0) {
+                    await this.redis.del(identityKey);
+                    continue;
+                }
+
+                const existenceChecks = await Promise.all(
+                    sessionIds.map((sessionId) => this.redis.exists(this.getSessionKey(identity, sessionId)))
+                );
+
+                const staleSessionIds = sessionIds.filter((_, index) => existenceChecks[index] === 0);
+                if (staleSessionIds.length > 0) {
+                    await this.redis.srem(identityKey, ...staleSessionIds);
+                }
+
+                const remainingCount = await this.redis.scard(identityKey);
+                if (remainingCount === 0) {
+                    await this.redis.del(identityKey);
                 }
             }
         } catch (error) {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -19,10 +19,10 @@ export const TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000; // 5 minute buffer before e
 // Client Information
 export const DEFAULT_CLIENT_NAME = 'MCP Assistant';
 export const DEFAULT_CLIENT_URI = 'https://mcp-assistant.in';
-export const DEFAULT_LOGO_URI = 'https://mcp-assistant.in/logo.png';
+export const DEFAULT_LOGO_URI = 'https://mcp-assistant.in/logo.svg';
 export const DEFAULT_POLICY_URI = 'https://mcp-assistant.in/privacy';
 export const SOFTWARE_ID = '@mcp-ts';
-export const SOFTWARE_VERSION = '1.0.0-beta.5';
+export const SOFTWARE_VERSION = '1.3.4';
 
 // MCP Client Configuration
 export const MCP_CLIENT_NAME = 'mcp-ts-oauth-client';

--- a/tests/storage/redis-backend.test.ts
+++ b/tests/storage/redis-backend.test.ts
@@ -143,5 +143,59 @@ test.describe('RedisStorageBackend', () => {
             const sessions = await storage.getIdentitySessionsData('unknown-identity');
             expect(sessions).toEqual([]);
         });
+
+        test('should prune stale session ids from the identity index', async () => {
+            const session = createMockSession({ sessionId: 'stale-session' });
+            await storage.createSession(session);
+
+            await redis.del(`mcp:session:${session.identity}:${session.sessionId}`);
+
+            const sessions = await storage.getIdentitySessionsData(session.identity);
+            const indexedSessionIds = await redis.smembers(`mcp:identity:${session.identity}:sessions`);
+
+            expect(sessions).toEqual([]);
+            expect(indexedSessionIds).toEqual([]);
+        });
+    });
+
+    test.describe('getAllSessionIds', () => {
+        test('should return plain session ids without identity prefixes', async () => {
+            const session = createMockSession({ sessionId: 'session-admin-view' });
+            await storage.createSession(session);
+
+            const sessionIds = await storage.getAllSessionIds();
+
+            expect(sessionIds).toContain('session-admin-view');
+            expect(sessionIds).not.toContain(`${session.identity}:${session.sessionId}`);
+        });
+    });
+
+    test.describe('clearAll', () => {
+        test('should delete both session keys and identity indexes', async () => {
+            const session = createMockSession({ sessionId: 'clear-all-session' });
+            await storage.createSession(session);
+
+            await storage.clearAll();
+
+            const sessionIds = await storage.getIdentityMcpSessions(session.identity);
+            const indexedSessionIds = await redis.smembers(`mcp:identity:${session.identity}:sessions`);
+
+            expect(sessionIds).toEqual([]);
+            expect(indexedSessionIds).toEqual([]);
+        });
+    });
+
+    test.describe('cleanupExpiredSessions', () => {
+        test('should remove stale identity indexes for missing session keys', async () => {
+            const session = createMockSession({ sessionId: 'expired-session' });
+            await storage.createSession(session);
+
+            await redis.del(`mcp:session:${session.identity}:${session.sessionId}`);
+
+            await storage.cleanupExpiredSessions();
+
+            const indexedSessionIds = await redis.smembers(`mcp:identity:${session.identity}:sessions`);
+            expect(indexedSessionIds).toEqual([]);
+        });
     });
 });

--- a/tests/storage/storage-index.test.ts
+++ b/tests/storage/storage-index.test.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { storage, _setStorageInstanceForTesting } from '../../src/server/storage';
+import { createMockSession } from '../test-utils';
+
+test.describe('storage index bootstrap', () => {
+    const originalEnv = {
+        MCP_TS_STORAGE_TYPE: process.env.MCP_TS_STORAGE_TYPE,
+        MCP_TS_STORAGE_SQLITE_PATH: process.env.MCP_TS_STORAGE_SQLITE_PATH,
+        MCP_TS_STORAGE_FILE: process.env.MCP_TS_STORAGE_FILE,
+        REDIS_URL: process.env.REDIS_URL,
+    };
+
+    let dbPath: string;
+
+    test.beforeEach(() => {
+        dbPath = path.join(__dirname, `storage-index-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+        _setStorageInstanceForTesting(null);
+        delete process.env.REDIS_URL;
+        delete process.env.MCP_TS_STORAGE_FILE;
+    });
+
+    test.afterEach(async () => {
+        try {
+            await storage.disconnect();
+        } catch {
+            // Storage may not have been initialized for a given test.
+        }
+
+        _setStorageInstanceForTesting(null);
+        process.env.MCP_TS_STORAGE_TYPE = originalEnv.MCP_TS_STORAGE_TYPE;
+        process.env.MCP_TS_STORAGE_SQLITE_PATH = originalEnv.MCP_TS_STORAGE_SQLITE_PATH;
+        process.env.MCP_TS_STORAGE_FILE = originalEnv.MCP_TS_STORAGE_FILE;
+        process.env.REDIS_URL = originalEnv.REDIS_URL;
+
+        for (const suffix of ['', '-journal', '-shm', '-wal']) {
+            const filePath = `${dbPath}${suffix}`;
+            if (fs.existsSync(filePath)) {
+                fs.unlinkSync(filePath);
+            }
+        }
+    });
+
+    test('awaits sqlite initialization before the first proxied operation', async () => {
+        process.env.MCP_TS_STORAGE_TYPE = 'sqlite';
+        process.env.MCP_TS_STORAGE_SQLITE_PATH = dbPath;
+
+        const session = createMockSession({
+            sessionId: 'sqlite-bootstrap-session',
+            transportType: 'streamable_http',
+        });
+
+        await storage.createSession(session);
+
+        const retrieved = await storage.getSession(session.identity, session.sessionId);
+        expect(retrieved?.sessionId).toBe(session.sessionId);
+        expect(retrieved?.transportType).toBe('streamable_http');
+    });
+});


### PR DESCRIPTION
## Summary

This PR tightens the OAuth/storage flow in `mcp-ts` and fixes a few session lifecycle issues that were causing inconsistent behavior across storage backends.

## What changed

- refactored `StorageOAuthClientProvider` to accept a structured options object
- centralized default OAuth client metadata and software versioning in shared constants
- preserved `client_id` / `client_secret` behavior more cleanly when client info is partially stored
- updated storage bootstrap so file/sqlite backends are fully initialized before first use
- reset cached storage initialization state if bootstrap fails, so retries work correctly
- improved Redis session handling by:
  - pruning stale session ids from identity indexes
  - returning plain session ids from `getAllSessionIds()`
  - clearing identity index keys during `clearAll()`
  - cleaning up dangling identity references during expired-session cleanup
  - preferring `SCAN` over `KEYS` where available, with fallback support
- treated `DISCOVERING` and `READY` as connected states in React/Vue MCP clients
- removed duplicate `tools_discovered` emits from the SSE handler
- hardened local agent MCP server startup/cleanup to avoid leaked async contexts on failure or cancellation
- bumped `mcpassistant-gateway` to `0.1.4`

## Why

A few pieces of the OAuth/session flow were loosely coupled:
- sqlite/file storage could be used before async initialization completed
- Redis identity indexes could retain stale session ids
- partially initialized OAuth clients could lose expected metadata behavior
- local MCP server startup failures could leave cleanup to happen on the wrong task

This PR makes those paths more deterministic and easier to recover from.

## Tests

- added Redis coverage for stale identity index pruning
- added Redis coverage for `getAllSessionIds()`
- added Redis coverage for `clearAll()`
- added Redis coverage for expired-session cleanup
- added storage bootstrap coverage to verify sqlite initialization completes before the first proxied operation
