### PR TITLE
Fix connection event sequencing and share SSE event routing helpers

### DIFF
--- a/examples/agents/src/components/mcp/connection-item.tsx
+++ b/examples/agents/src/components/mcp/connection-item.tsx
@@ -10,10 +10,14 @@ interface ConnectionItemProps {
 }
 
 const stateColors: Record<string, string> = {
+  INITIALIZING: 'bg-cyan-500/20 text-cyan-400',
+  VALIDATING: 'bg-sky-500/20 text-sky-400',
   CONNECTED: 'bg-green-500/20 text-green-400',
   CONNECTING: 'bg-yellow-500/20 text-yellow-400',
   AUTHENTICATING: 'bg-blue-500/20 text-blue-400',
+  AUTHENTICATED: 'bg-indigo-500/20 text-indigo-400',
   DISCOVERING: 'bg-purple-500/20 text-purple-400',
+  READY: 'bg-emerald-500/20 text-emerald-400',
   DISCONNECTED: 'bg-zinc-500/20 text-zinc-400',
   FAILED: 'bg-red-500/20 text-red-400',
 };

--- a/examples/agents/src/components/mcp/connection-list.tsx
+++ b/examples/agents/src/components/mcp/connection-list.tsx
@@ -11,7 +11,7 @@ interface ConnectionListProps {
 }
 
 export function ConnectionList({ connections, isInitializing, onDisconnect }: ConnectionListProps) {
-  if (isInitializing) {
+  if (isInitializing && connections.length === 0) {
     return (
       <div className="flex-1 flex items-center justify-center p-4">
         <div className="flex items-center gap-2 text-zinc-500 text-sm">
@@ -35,6 +35,12 @@ export function ConnectionList({ connections, isInitializing, onDisconnect }: Co
 
   return (
     <div className="flex-1 overflow-y-auto p-4 space-y-2">
+      {isInitializing && (
+        <div className="flex items-center gap-2 text-zinc-500 text-xs mb-3">
+          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          <span>Checking existing sessions...</span>
+        </div>
+      )}
       <h3 className="text-xs font-medium text-zinc-500 uppercase tracking-wider mb-2">
         Connected Servers ({connections.length})
       </h3>

--- a/src/client/core/sse-client.ts
+++ b/src/client/core/sse-client.ts
@@ -55,6 +55,8 @@ export interface SSEClientOptions {
 
 export type ConnectionStatus = 'connecting' | 'connected' | 'disconnected' | 'error';
 
+const CONNECTION_EVENT_INTERVAL_MS = 300;
+
 interface ToolUiMetadata {
   resourceUri?: string;
   uri?: string;
@@ -193,11 +195,19 @@ export class SSEClient {
       return this.parseRpcResponse<T>(data);
     }
 
-    const data = await this.readRpcResponseFromStream(response);
+    const data = await this.readRpcResponseFromStream(response, {
+      delayConnectionEvents:
+        method === 'connect' ||
+        method === 'restoreSession' ||
+        method === 'finishAuth',
+    });
     return this.parseRpcResponse<T>(data);
   }
 
-  private async readRpcResponseFromStream(response: Response): Promise<McpRpcResponse> {
+  private async readRpcResponseFromStream(
+    response: Response,
+    options: { delayConnectionEvents?: boolean } = {}
+  ): Promise<McpRpcResponse> {
     if (!response.body) {
       throw new Error('Streaming response body is missing');
     }
@@ -207,7 +217,7 @@ export class SSEClient {
     let buffer = '';
     let rpcResponse: McpRpcResponse | null = null;
 
-    const dispatchBlock = (block: string) => {
+    const dispatchBlock = async (block: string) => {
       const lines = block.split('\n');
       let eventName = 'message';
       const dataLines: string[] = [];
@@ -239,6 +249,9 @@ export class SSEClient {
           break;
         case 'connection':
           this.options.onConnectionEvent?.(payload as McpConnectionEvent);
+          if (options.delayConnectionEvents) {
+            await this.sleep(CONNECTION_EVENT_INTERVAL_MS);
+          }
           break;
         case 'observability':
           this.options.onObservabilityEvent?.(payload as McpObservabilityEvent);
@@ -262,13 +275,13 @@ export class SSEClient {
         const separatorLength = separatorMatch[0].length;
         const block = buffer.slice(0, separatorIndex);
         buffer = buffer.slice(separatorIndex + separatorLength);
-        dispatchBlock(block);
+        await dispatchBlock(block);
         separatorMatch = buffer.match(/\r?\n\r?\n/);
       }
     }
 
     if (buffer.trim()) {
-      dispatchBlock(buffer);
+      await dispatchBlock(buffer);
     }
 
     if (!rpcResponse) {
@@ -276,6 +289,10 @@ export class SSEClient {
     }
 
     return rpcResponse;
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
   private parseRpcResponse<T>(data: McpRpcResponse): T {

--- a/src/server/handlers/nextjs-handler.ts
+++ b/src/server/handlers/nextjs-handler.ts
@@ -7,11 +7,8 @@
 
 import { SSEConnectionManager, type ClientMetadata } from './sse-handler.js';
 import type { McpConnectionEvent, McpObservabilityEvent } from '../../shared/events.js';
+import { isConnectionEvent, isRpcResponseEvent } from '../../shared/event-routing.js';
 import type { McpRpcResponse } from '../../shared/types.js';
-
-function isRpcResponseEvent(event: McpConnectionEvent | McpObservabilityEvent | McpRpcResponse): event is McpRpcResponse {
-  return 'id' in event && ('result' in event || 'error' in event);
-}
 
 export interface NextMcpHandlerOptions {
   /**
@@ -145,7 +142,7 @@ export function createNextMcpHandler(options: NextMcpHandlerOptions = {}) {
         (event: McpConnectionEvent | McpObservabilityEvent | McpRpcResponse) => {
           if (isRpcResponseEvent(event)) {
             sendSSE('rpc-response', event);
-          } else if ('type' in event && 'sessionId' in event) {
+          } else if (isConnectionEvent(event)) {
             sendSSE('connection', event);
           } else {
             sendSSE('observability', event);

--- a/src/server/handlers/sse-handler.ts
+++ b/src/server/handlers/sse-handler.ts
@@ -34,6 +34,8 @@ import type {
   CallToolResult,
 } from '../../shared/types.js';
 import { RpcErrorCodes } from '../../shared/errors.js';
+import { UnauthorizedError } from '../../shared/errors.js';
+import { isConnectionEvent, isRpcResponseEvent } from '../../shared/event-routing.js';
 import { MCPClient } from '../mcp/oauth-client.js';
 import { storage } from '../storage/index.js';
 
@@ -279,16 +281,6 @@ export class SSEConnectionManager {
         callbackUrl,
         transportType,
         ...clientMetadata, // Spread client metadata (clientName, clientUri, logoUri, policyUri)
-        onRedirect: (authUrl) => {
-          // Emit auth required event
-          this.emitConnectionEvent({
-            type: 'auth_required',
-            sessionId,
-            serverId,
-            authUrl,
-            timestamp: Date.now(),
-          });
-        },
       });
 
       // Note: Session will be created by MCPClient after successful connection
@@ -317,6 +309,15 @@ export class SSEConnectionManager {
         success: true,
       };
     } catch (error) {
+      if (error instanceof UnauthorizedError) {
+        // OAuth-required is a pending-auth state, not a failed connection.
+        this.clients.delete(sessionId);
+        return {
+          sessionId,
+          success: true,
+        };
+      }
+
       this.emitConnectionEvent({
         type: 'error',
         sessionId,
@@ -473,17 +474,6 @@ export class SSEConnectionManager {
       throw new Error('Session not found');
     }
 
-    this.emitConnectionEvent({
-      type: 'state_changed',
-      sessionId,
-      serverId: session.serverId ?? 'unknown',
-      serverName: session.serverName ?? 'Unknown',
-      serverUrl: session.serverUrl,
-      state: 'AUTHENTICATING',
-      previousState: 'DISCONNECTED',
-      timestamp: Date.now(),
-    });
-
     try {
       const client = new MCPClient({
         identity: this.identity,
@@ -598,9 +588,9 @@ export function createSSEHandler(options: SSEHandlerOptions) {
 
     // Create connection manager with event routing
     const manager = new SSEConnectionManager(options, (event) => {
-      if ('id' in event) {
+      if (isRpcResponseEvent(event)) {
         writeSSEEvent(res, 'rpc-response', event);
-      } else if ('type' in event && 'sessionId' in event) {
+      } else if (isConnectionEvent(event)) {
         writeSSEEvent(res, 'connection', event);
       } else {
         writeSSEEvent(res, 'observability', event);

--- a/src/server/handlers/sse-handler.ts
+++ b/src/server/handlers/sse-handler.ts
@@ -265,18 +265,6 @@ export class SSEConnectionManager {
     // Generate session ID
     const sessionId = await storage.generateSessionId();
 
-    // Emit connecting state
-    this.emitConnectionEvent({
-      type: 'state_changed',
-      sessionId,
-      serverId,
-      serverName,
-      serverUrl,
-      state: 'CONNECTING',
-      previousState: 'DISCONNECTED',
-      timestamp: Date.now(),
-    });
-
     try {
       // Get resolved client metadata
       const clientMetadata = await this.getResolvedClientMetadata();

--- a/src/shared/event-routing.ts
+++ b/src/shared/event-routing.ts
@@ -1,0 +1,28 @@
+import type { McpConnectionEvent, McpObservabilityEvent } from './events.js';
+import type { McpRpcResponse } from './types.js';
+
+export function isRpcResponseEvent(
+  event: McpConnectionEvent | McpObservabilityEvent | McpRpcResponse
+): event is McpRpcResponse {
+  return 'id' in event && ('result' in event || 'error' in event);
+}
+
+export function isConnectionEvent(
+  event: McpConnectionEvent | McpObservabilityEvent | McpRpcResponse
+): event is McpConnectionEvent {
+  if (!('type' in event)) {
+    return false;
+  }
+
+  switch (event.type) {
+    case 'state_changed':
+    case 'tools_discovered':
+    case 'auth_required':
+    case 'error':
+    case 'disconnected':
+    case 'progress':
+      return true;
+    default:
+      return false;
+  }
+}


### PR DESCRIPTION
### Summary
This PR fixes MCP connection event sequencing issues and cleans up shared SSE event routing.

### Changes

- pace streamed connection lifecycle events in sse-client.ts so intermediate UI states are visible during `connect`, `restoreSession`, and `finishAuth`
- remove synthetic/duplicate auth and connection events in sse-handler.ts
- add shared event classification helpers in event-routing.ts
- update sse-handler.ts and nextjs-handler.ts to use the shared routing helpers