### PR TITLE
feat: Add Supabase Storage Backend with CLI Init Command

### DIFF
--- a/docs/docs/storage-backends.md
+++ b/docs/docs/storage-backends.md
@@ -232,9 +232,19 @@ SUPABASE_ANON_KEY=your-anon-key
 To use Supabase as a storage backend, you must create the `mcp_sessions` table and configure RLS policies.
 
 #### Option A: Supabase CLI (Recommended)
-The project includes a pre-configured migration file. To apply it:
-1. Link your project: `npx supabase link --project-ref <your-project-id>`
-2. Push migrations: `npm run supabase:push`
+You can easily "eject" the required migration SQL into your own project using the built-in CLI:
+
+1. Run the initialization command:
+   ```bash
+   npx mcp-ts supabase-init
+   ```
+   This will copy the migration files to your local `./supabase/migrations/` folder.
+
+2. Link your project & push:
+   ```bash
+   npx supabase link --project-ref <your-project-id>
+   npx supabase db push
+   ```
 
 #### Option B: SQL Editor (Manual)
 If you prefer manual setup, copy the SQL from the [migration file](https://github.com/zonlabs/mcp-ts/blob/main/supabase/migrations/20260330195700_install_mcp_sessions.sql) and run it in the Supabase Dashboard SQL Editor.

--- a/docs/docs/storage-backends.md
+++ b/docs/docs/storage-backends.md
@@ -221,11 +221,13 @@ MCP_TS_STORAGE_TYPE=supabase
 
 # Supabase connection details (required)
 SUPABASE_URL=https://your-project.supabase.co
+# Use the service_role key for server-side storage (not the anon key)
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
-
-# OR for client-side/authenticated use
-SUPABASE_ANON_KEY=your-anon-key
 ```
+
+:::warning
+**Always use `SUPABASE_SERVICE_ROLE_KEY`** for server-side storage — not `SUPABASE_ANON_KEY`. The anon key is subject to Row Level Security (RLS) policies which will block session creation. The service_role key is designed for trusted server-to-server communication and bypasses RLS. Find it in: **Supabase Dashboard → Project Settings → API → service_role**.
+:::
 
 **Database Setup:**
 
@@ -261,7 +263,11 @@ If you prefer manual setup, copy the SQL from the [migration file](https://githu
 import { createSupabaseStorageBackend } from '@mcp-ts/sdk/server';
 import { createClient } from '@supabase/supabase-js';
 
-const supabase = createClient(URL, KEY);
+// Always use the service_role key for server-side usage
+const supabase = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
 const storage = createSupabaseStorageBackend(supabase);
 
 await storage.createSession({

--- a/docs/docs/storage-backends.md
+++ b/docs/docs/storage-backends.md
@@ -197,13 +197,85 @@ await storage.createSession({
 
 ---
 
-### <DocIcon type="postgres" size={24} /> PostgreSQL (Coming Soon)
+### <DocIcon type="supabase" size={24} /> Supabase (Production)
 
-PostgreSQL support is planned for a future release, providing:
-- Relational data storage
-- Advanced querying capabilities
-- ACID compliance
-- Integration with existing databases
+**Cloud-native PostgreSQL storage with built-in security and row-level security (RLS).**
+
+Supabase provides a powerful, scalable backend for your MCP sessions. Ideal for:
+- Production environments
+- Next.js applications (built-in integration)
+- Applications requiring Row Level Security (RLS)
+- Managed PostgreSQL with zero maintenance
+
+**Installation:**
+
+```bash
+npm install @mcp-ts/sdk @supabase/supabase-js
+```
+
+**Configuration:**
+
+```bash
+# Explicit selection (optional)
+MCP_TS_STORAGE_TYPE=supabase
+
+# Supabase connection details (required)
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# OR for client-side/authenticated use
+SUPABASE_ANON_KEY=your-anon-key
+```
+
+**Database Setup:**
+
+To use Supabase as a storage backend, you must create the `mcp_sessions` table and configure RLS policies.
+
+#### Option A: Supabase CLI (Recommended)
+The project includes a pre-configured migration file. To apply it:
+1. Link your project: `npx supabase link --project-ref <your-project-id>`
+2. Push migrations: `npm run supabase:push`
+
+#### Option B: SQL Editor (Manual)
+If you prefer manual setup, copy the SQL from the [migration file](https://github.com/zonlabs/mcp-ts/blob/main/supabase/migrations/20260330195700_install_mcp_sessions.sql) and run it in the Supabase Dashboard SQL Editor.
+
+**Features:**
+- <DocIcon type="success" size={16} /> PostgreSQL persistence with JSONB support
+- <DocIcon type="lock" size={16} /> Row Level Security (RLS) for tenant isolation
+- <DocIcon type="success" size={16} /> Automatic updated_at and expires_at management
+- <DocIcon type="bolt" size={16} /> Cloud-native and serverless friendly
+
+**Usage:**
+
+```typescript
+import { createSupabaseStorageBackend } from '@mcp-ts/sdk/server';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(URL, KEY);
+const storage = createSupabaseStorageBackend(supabase);
+
+await storage.createSession({
+  sessionId: 'sb-123',
+  identity: 'user-789',
+  serverUrl: 'https://mcp.example.com',
+  callbackUrl: 'https://app.com/callback',
+  transportType: 'sse',
+  active: true,
+  createdAt: Date.now(),
+});
+```
+
+---
+
+### <DocIcon type="postgres" size={24} /> PostgreSQL
+
+For self-hosted PostgreSQL environments.
+
+**Features:**
+- <DocIcon type="success" size={16} /> Relational data storage
+- <DocIcon type="success" size={16} /> Advanced querying capabilities
+- <DocIcon type="success" size={16} /> ACID compliance
+- <DocIcon type="success" size={16} /> Integration with existing databases
 
 ---
 
@@ -217,31 +289,33 @@ graph TD
     B -->|Yes| C[Use specified backend]
     B -->|No| D{REDIS_URL present?}
     D -->|Yes| E[Use Redis]
-    D -->|No| F{MCP_TS_STORAGE_FILE present?}
-    F -->|Yes| G[Use File System]
-    F -->|No| H[Use In-Memory Default]
+    D -->|No| F{SUPABASE_URL present?}
+    F -->|Yes| G[Use Supabase]
+    F -->|No| H{MCP_TS_STORAGE_FILE present?}
     
-    C --> I[Storage Ready]
-    E --> I
-    G --> I
-    F -->|No| G{MCP_TS_STORAGE_SQLITE_PATH present?}
-    G -->|Yes| H[Use SQLite]
-    G -->|No| I[Use In-Memory Default]
+    C --> L[Storage Ready]
+    E --> L
+    G --> L
     
-    C --> J[Storage Ready]
-    E --> J
-    K[Use File System] --> J
-    H --> J
-    I --> J
+    H -->|Yes| I[Use File System]
+    H -->|No| J{MCP_TS_STORAGE_SQLITE_PATH present?}
+    
+    I --> L
+    J -->|Yes| K[Use SQLite]
+    J -->|No| M[Use In-Memory Default]
+    
+    K --> L
+    M --> L
 ```
 
 **Priority Order:**
 
 1. **Explicit**: If `MCP_TS_STORAGE_TYPE` is set, use that backend
 2. **Auto-detect Redis**: If `REDIS_URL` is present, use Redis
-3. **Auto-detect File**: If `MCP_TS_STORAGE_FILE` is present, use File
-4. **Auto-detect SQLite**: If `MCP_TS_STORAGE_SQLITE_PATH` is present, use SQLite
-5. **Default**: Fall back to In-Memory storage
+3. **Auto-detect Supabase**: If `SUPABASE_URL` is present, use Supabase
+4. **Auto-detect File**: If `MCP_TS_STORAGE_FILE` is present, use File
+5. **Auto-detect SQLite**: If `MCP_TS_STORAGE_SQLITE_PATH` is present, use SQLite
+6. **Default**: Fall back to In-Memory storage
 
 ---
 
@@ -279,17 +353,17 @@ const memoryStorage = new MemoryStorageBackend();
 
 ## <DocIcon type="chart" size={28} /> Backend Comparison
 
-| Feature | <DocIcon type="redis" size={20} /> Redis | <DocIcon type="sqlite" size={20} /> SQLite | <DocIcon type="filesystem" size={20} /> File System | <DocIcon type="memory" size={20} /> In-Memory |
-|---------|----------|----------|----------------|--------------|
-| **Persistence** | <DocIcon type="success" size={16} /> Yes | <DocIcon type="success" size={16} /> Yes | <DocIcon type="success" size={16} /> Yes | <DocIcon type="error" size={16} /> No |
-| **Distributed** | <DocIcon type="success" size={16} /> Yes | <DocIcon type="error" size={16} /> No | <DocIcon type="error" size={16} /> No | <DocIcon type="error" size={16} /> No |
-| **Auto-Expiry** | <DocIcon type="success" size={16} /> Yes (TTL) | <DocIcon type="success" size={16} /> Yes (Manual) | <DocIcon type="error" size={16} /> No | <DocIcon type="error" size={16} /> No |
-| **Performance** | <DocIcon type="bolt" size={16} /> Fast | <DocIcon type="bolt" size={16} /> Very Fast | <DocIcon type="chart" size={16} /> Medium | <DocIcon type="rocket" size={16} /> Fastest |
-| **Setup** | <DocIcon type="tools" size={16} /> Requires Redis | <DocIcon type="tools" size={16} /> Native | <DocIcon type="filesystem" size={16} /> Built-in | <DocIcon type="target" size={16} /> Built-in |
-| **Serverless** | <DocIcon type="success" size={16} /> Yes | <DocIcon type="warning" size={16} /> Limited | <DocIcon type="success" size={16} /> Yes |
-| **Production** | <DocIcon type="success" size={16} /> Recommended | <DocIcon type="warning" size={16} /> Single-instance | <DocIcon type="error" size={16} /> Not recommended |
-| **Development** | <DocIcon type="success" size={16} /> Good | <DocIcon type="success" size={16} /> Excellent | <DocIcon type="success" size={16} /> Good |
-| **Testing** | <DocIcon type="success" size={16} /> Good | <DocIcon type="success" size={16} /> Good | <DocIcon type="success" size={16} /> Excellent |
+| Feature | <DocIcon type="redis" size={20} /> Redis | <DocIcon type="supabase" size={20} /> Supabase | <DocIcon type="sqlite" size={20} /> SQLite | <DocIcon type="filesystem" size={20} /> File System | <DocIcon type="memory" size={20} /> In-Memory |
+|---------|----------|----------|----------|----------------|--------------|
+| **Persistence** | <DocIcon type="success" size={16} /> Yes | <DocIcon type="success" size={16} /> Yes | <DocIcon type="success" size={16} /> Yes | <DocIcon type="success" size={16} /> Yes | <DocIcon type="error" size={16} /> No |
+| **Distributed** | <DocIcon type="success" size={16} /> Yes | <DocIcon type="success" size={16} /> Yes | <DocIcon type="error" size={16} /> No | <DocIcon type="error" size={16} /> No | <DocIcon type="error" size={16} /> No |
+| **Auto-Expiry** | <DocIcon type="success" size={16} /> Yes (TTL) | <DocIcon type="success" size={16} /> Yes (Manual) | <DocIcon type="success" size={16} /> Yes (Manual) | <DocIcon type="error" size={16} /> No | <DocIcon type="error" size={16} /> No |
+| **Performance** | <DocIcon type="bolt" size={16} /> Fast | <DocIcon type="bolt" size={16} /> Fast | <DocIcon type="bolt" size={16} /> Very Fast | <DocIcon type="chart" size={16} /> Medium | <DocIcon type="rocket" size={16} /> Fastest |
+| **Setup** | <DocIcon type="tools" size={16} /> External | <DocIcon type="tools" size={16} /> Cloud | <DocIcon type="tools" size={16} /> Native | <DocIcon type="filesystem" size={16} /> Built-in | <DocIcon type="target" size={16} /> Built-in |
+| **Serverless** | <DocIcon type="success" size={16} /> Yes | <DocIcon type="success" size={16} /> Recommended | <DocIcon type="warning" size={16} /> Limited | <DocIcon type="success" size={16} /> Yes |
+| **Production** | <DocIcon type="success" size={16} /> Recommended | <DocIcon type="success" size={16} /> Recommended | <DocIcon type="warning" size={16} /> Single-instance | <DocIcon type="error" size={16} /> Not recommended |
+| **Development** | <DocIcon type="success" size={16} /> Good | <DocIcon type="success" size={16} /> Excellent | <DocIcon type="success" size={16} /> Excellent | <DocIcon type="success" size={16} /> Good |
+| **Testing** | <DocIcon type="success" size={16} /> Good | <DocIcon type="success" size={16} /> Excellent | <DocIcon type="success" size={16} /> Good | <DocIcon type="success" size={16} /> Excellent |
 
 ---
 

--- a/docs/src/components/DocIcons.tsx
+++ b/docs/src/components/DocIcons.tsx
@@ -17,7 +17,7 @@ import {
     FaHardDrive,
     FaBoxesStacked
 } from 'react-icons/fa6';
-import { SiRedis } from 'react-icons/si';
+import { SiRedis, SiSupabase } from 'react-icons/si';
 import { CiFileOn } from 'react-icons/ci';
 import { PiMemoryThin } from 'react-icons/pi';
 import { BiLogoPostgresql } from 'react-icons/bi';
@@ -26,7 +26,7 @@ import { GrDatabase } from 'react-icons/gr';
 export type IconType =
     | 'database' | 'sync' | 'tools' | 'chart' | 'lock' | 'idea' | 'search' | 'book'
     | 'success' | 'warning' | 'error'
-    | 'rocket' | 'bolt' | 'target' | 'filesystem' | 'memory' | 'redis' | 'postgres' | 'backends';
+    | 'rocket' | 'bolt' | 'target' | 'filesystem' | 'memory' | 'redis' | 'supabase' | 'postgres' | 'backends';
 
 interface DocIconProps {
     type: IconType;
@@ -45,7 +45,8 @@ const palette = {
     slate: '#64748b',
     neutral: '#4b5563',
     brandRedis: '#D82C20',
-    brandPostgres: '#336791', // Still Postgres brand blue, but let's see
+    brandPostgres: '#336791',
+    brandSupabase: '#3ECF8E', // Supabase Emerald Green
 };
 
 const iconMap: Record<IconType, { Icon: any, defaultColor: string }> = {
@@ -69,6 +70,7 @@ const iconMap: Record<IconType, { Icon: any, defaultColor: string }> = {
     filesystem: { Icon: CiFileOn, defaultColor: palette.yellow },
     memory: { Icon: PiMemoryThin, defaultColor: palette.slate },
     redis: { Icon: SiRedis, defaultColor: palette.brandRedis },
+    supabase: { Icon: SiSupabase, defaultColor: palette.brandSupabase },
     postgres: { Icon: BiLogoPostgresql, defaultColor: palette.brandPostgres },
     backends: { Icon: GrDatabase, defaultColor: palette.red },
 };

--- a/examples/agents/package.json
+++ b/examples/agents/package.json
@@ -15,6 +15,7 @@
     "@copilotkit/react-ui": "1.51.0",
     "@copilotkit/runtime": "1.51.0",
     "@mcp-ts/sdk": "file:../..",
+    "@supabase/supabase-js": "^2.101.0",
     "next": "16.1.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@ag-ui/client": "^0.0.42",
         "@langchain/core": "^0.3.33",
         "@playwright/test": "^1.58.0",
+        "@supabase/supabase-js": "^2.48.0",
         "@types/better-sqlite3": "^7.6.13",
         "@types/json-schema": "^7.0.15",
         "@types/node": "^25.0.10",
@@ -41,6 +42,7 @@
       "peerDependencies": {
         "@ag-ui/client": ">=0.0.40",
         "@langchain/core": "^0.3.0",
+        "@supabase/supabase-js": "^2.0.0",
         "ai": "^6.0.0",
         "better-sqlite3": "^12.0.0",
         "ioredis": "^5.0.0",
@@ -53,6 +55,9 @@
           "optional": true
         },
         "@langchain/core": {
+          "optional": true
+        },
+        "@supabase/supabase-js": {
           "optional": true
         },
         "ai": {
@@ -1417,6 +1422,99 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.100.1.tgz",
+      "integrity": "sha512-c5FB4nrG7cs1mLSzFGuIVl2iR2YO5XkSJ96uF4zubYm8YDn71XOi2emE9sBm/avfGCj61jaRBLOvxEAVnpys0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.100.1.tgz",
+      "integrity": "sha512-mo8QheoV4KR+wSubtyEWhZUxWnCM7YZ23TncccMAlbWAHb8YTDqRGRm9IalWCAswniKyud6buZCk9snRqI86KA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.100.1.tgz",
+      "integrity": "sha512-OIh4mOSo2LdqF2kox76OAPDtcSs+PwKABJOjc6plUV4/LXhFEsI2uwdEEIs7K7fd141qehWEVl/Y+Ts0fNvYsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.100.1.tgz",
+      "integrity": "sha512-FHuRWPX4qZQ4x+0Q+ZrKaBZnOiVGiwsgiAUJM98pYRib1yeaE/fOM1lZ1ozd+4gA8Udw23OyaD8SxKS5mT5NYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.100.1.tgz",
+      "integrity": "sha512-x9xpEIoWM4xKiAlwfWTgHPSN6N4Y0aS4FVU4F6ZPbq7Gayw08SrtC6/YH/gOr8CjXQr0HxXYXDop2xGTSjubYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.100.1.tgz",
+      "integrity": "sha512-CAeFm5sfX8sbTzxoxRafhohreIzl9a7R6qHTck3MrgTqm5M5g/u0IHfEKYzI9w/17r8NINl8UZrw2i08wrO7Iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.100.1",
+        "@supabase/functions-js": "2.100.1",
+        "@supabase/postgrest-js": "2.100.1",
+        "@supabase/realtime-js": "2.100.1",
+        "@supabase/storage-js": "2.100.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -1493,6 +1591,16 @@
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@vercel/oidc": {
       "version": "3.1.0",
@@ -2721,6 +2829,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -4497,6 +4615,28 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,10 @@
     "prepublishOnly": "npm run clean && npm run build",
     "test": "npx playwright test",
     "test:ui": "npx playwright test --ui",
-    "test:debug": "npx playwright test --debug"
+    "test:debug": "npx playwright test --debug",
+    "supabase:push": "supabase db push",
+    "supabase:reset": "supabase db reset",
+    "supabase:status": "supabase status"
   },
   "keywords": [
     "mcp",
@@ -111,7 +114,8 @@
     "ioredis": "^5.0.0",
     "react": ">=18.0.0",
     "rxjs": ">=7.0.0",
-    "zod": "^3.23.0"
+    "zod": "^3.23.0",
+    "@supabase/supabase-js": "^2.0.0"
   },
   "peerDependenciesMeta": {
     "react": {
@@ -136,6 +140,9 @@
       "optional": true
     },
     "better-sqlite3": {
+      "optional": true
+    },
+    "@supabase/supabase-js": {
       "optional": true
     }
   },
@@ -164,7 +171,8 @@
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vue": "^3.5.27",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "@supabase/supabase-js": "^2.48.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "mcp-ts": "./dist/bin/mcp-ts.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -68,7 +71,9 @@
   "files": [
     "dist",
     "src",
-    "README.md"
+    "supabase",
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
     "build": "tsup",

--- a/src/bin/mcp-ts.ts
+++ b/src/bin/mcp-ts.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * MCP-TS CLI Utility
+ * 
+ * Provides helper commands for users of the @mcp-ts/sdk library.
+ */
+async function run() {
+    const args = process.argv.slice(2);
+    const command = args[0];
+
+    if (command === 'supabase-init') {
+        await initSupabase();
+    } else {
+        showHelp();
+    }
+}
+
+function showHelp() {
+    console.log(`
+🚀 MCP-TS CLI Utility
+Usage: npx mcp-ts <command>
+
+Commands:
+  supabase-init    Initialize Supabase migrations in your project
+    `);
+}
+
+async function initSupabase() {
+    console.log('🚀 Initializing Supabase storage for MCP-TS...');
+
+    // When running from dist/bin/mcp-ts.js (compiled), __dirname is dist/bin.
+    // The supabase/ migrations are at the root of the package.
+    // We need to look up two levels to find 'supabase' folder in the package.
+    const pkgRoot = path.resolve(__dirname, '../..');
+    const sourceDir = path.join(pkgRoot, 'supabase', 'migrations');
+    
+    if (!fs.existsSync(sourceDir)) {
+        console.error(`❌ Error: Could not find migration files in package at: ${sourceDir}`);
+        console.log('Please ensure you are running this from a project where @mcp-ts/sdk is installed.');
+        process.exit(1);
+    }
+
+    const targetDir = path.join(process.cwd(), 'supabase', 'migrations');
+
+    try {
+        if (!fs.existsSync(targetDir)) {
+            fs.mkdirSync(targetDir, { recursive: true });
+            console.log(`📁 Created directory: ${targetDir}`);
+        }
+
+        const files = fs.readdirSync(sourceDir);
+        let copiedCount = 0;
+
+        for (const file of files) {
+            if (file.endsWith('.sql')) {
+                const srcPath = path.join(sourceDir, file);
+                const destPath = path.join(targetDir, file);
+                
+                if (fs.existsSync(destPath)) {
+                    console.log(`⏭️  Skipping existing migration: ${file}`);
+                    continue;
+                }
+
+                fs.copyFileSync(srcPath, destPath);
+                console.log(`✅ Copied: ${file}`);
+                copiedCount++;
+            }
+        }
+
+        if (copiedCount > 0) {
+            console.log('\n✨ Database migrations successfully initialized!');
+            console.log('\nNext steps:');
+            console.log('1. Link your Supabase project:');
+            console.log('   npx supabase link --project-ref <your-project-id>');
+            console.log('\n2. Push the migrations to your remote database:');
+            console.log('   npx supabase db push');
+        } else if (files.length > 0) {
+            console.log('\n👍 All migration files are already present in your project.');
+        } else {
+            console.log('⚠️  No migration files found to copy.');
+        }
+
+    } catch (error: any) {
+        console.error(`❌ Error initializing Supabase: ${error.message}`);
+        process.exit(1);
+    }
+}
+
+run().catch(err => {
+    console.error(err);
+    process.exit(1);
+});

--- a/src/bin/mcp-ts.ts
+++ b/src/bin/mcp-ts.ts
@@ -77,8 +77,15 @@ async function initSupabase() {
             console.log('   npx supabase link --project-ref <your-project-id>');
             console.log('\n2. Push the migrations to your remote database:');
             console.log('   npx supabase db push');
+            console.log('\n3. Add your Supabase credentials to .env:');
+            console.log('   SUPABASE_URL=https://<your-project-id>.supabase.co');
+            console.log('   SUPABASE_SERVICE_ROLE_KEY=<your-service-role-key>');
+            console.log('\n⚠️  Important: Use the service_role key (not the anon key) for server-side storage.');
+            console.log('   The service_role key bypasses RLS policies and is required for mcp-ts to work correctly.');
+            console.log('   Find it in: Supabase Dashboard -> Project Settings -> API -> service_role');
         } else if (files.length > 0) {
             console.log('\n👍 All migration files are already present in your project.');
+            console.log('   Ensure SUPABASE_SERVICE_ROLE_KEY (not SUPABASE_ANON_KEY) is set in your .env');
         } else {
             console.log('⚠️  No migration files found to copy.');
         }

--- a/src/server/storage/file-backend.ts
+++ b/src/server/storage/file-backend.ts
@@ -65,6 +65,7 @@ export class FileStorageBackend implements StorageBackend {
         }
 
         this.initialized = true;
+        console.log(`[mcp-ts][Storage] File: ✓ storage directory at ${path.dirname(this.filePath)} verified.`);
     }
 
     private async ensureInitialized() {

--- a/src/server/storage/index.ts
+++ b/src/server/storage/index.ts
@@ -108,6 +108,19 @@ async function createStorage(): Promise<StorageBackend> {
         return await initializeStorage(new SqliteStorage({ path: process.env.MCP_TS_STORAGE_SQLITE_PATH }));
     }
 
+    if (process.env.SUPABASE_URL && (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY)) {
+        try {
+            const { createClient } = await import('@supabase/supabase-js');
+            const url = process.env.SUPABASE_URL;
+            const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY!;
+            const client = createClient(url, key);
+            console.log('[Storage] Auto-detected Supabase. Using Supabase storage.');
+            return await initializeStorage(new SupabaseStorageBackend(client as any));
+        } catch (error: any) {
+            console.error('[Storage] Supabase auto-detection failed:', error.message);
+        }
+    }
+
     console.log('[Storage] No storage configured. Using In-Memory storage (Default).');
     return new MemoryStorageBackend();
 }

--- a/src/server/storage/index.ts
+++ b/src/server/storage/index.ts
@@ -70,7 +70,7 @@ async function createStorage(): Promise<StorageBackend> {
                 const { createClient } = await import('@supabase/supabase-js');
                 const client = createClient(url, key);
                 console.log('[Storage] Using Supabase storage (Explicit)');
-                return new SupabaseStorageBackend(client as any);
+                return await initializeStorage(new SupabaseStorageBackend(client as any));
             } catch (error: any) {
                 console.error('[Storage] Failed to initialize Supabase:', error.message);
                 console.log('[Storage] Falling back to In-Memory storage');

--- a/src/server/storage/index.ts
+++ b/src/server/storage/index.ts
@@ -35,27 +35,24 @@ async function createStorage(): Promise<StorageBackend> {
         try {
             const { getRedis } = await import('./redis.js');
             const redis = await getRedis();
-            console.log('[Storage] Using Redis storage (Explicit)');
-            return new RedisStorageBackend(redis);
+            console.log('[mcp-ts][Storage] Explicit selection: "redis"');
+            return await initializeStorage(new RedisStorageBackend(redis));
         } catch (error: any) {
-            console.error('[Storage] Failed to initialize Redis:', error.message);
-            console.log('[Storage] Falling back to In-Memory storage');
-            return new MemoryStorageBackend();
+            console.error('[mcp-ts][Storage] Failed to initialize Redis:', error.message);
+            console.log('[mcp-ts][Storage] Falling back to In-Memory storage');
+            return await initializeStorage(new MemoryStorageBackend());
         }
     }
 
     if (type === 'file') {
         const filePath = process.env.MCP_TS_STORAGE_FILE;
-        if (!filePath) {
-            console.warn('[Storage] MCP_TS_STORAGE_TYPE is "file" but MCP_TS_STORAGE_FILE is missing');
-        }
-        console.log(`[Storage] Using File storage (${filePath}) (Explicit)`);
+        console.log(`[mcp-ts][Storage] Explicit selection: "file" (${filePath || 'default'})`);
         return await initializeStorage(new FileStorageBackend({ path: filePath }));
     }
 
     if (type === 'sqlite') {
         const dbPath = process.env.MCP_TS_STORAGE_SQLITE_PATH;
-        console.log(`[Storage] Using SQLite storage (${dbPath || 'default'}) (Explicit)`);
+        console.log(`[mcp-ts][Storage] Explicit selection: "sqlite" (${dbPath || 'default'})`);
         return await initializeStorage(new SqliteStorage({ path: dbPath }));
     }
 
@@ -64,24 +61,27 @@ async function createStorage(): Promise<StorageBackend> {
         const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
         
         if (!url || !key) {
-            console.warn('[Storage] MCP_TS_STORAGE_TYPE is "supabase" but SUPABASE_URL and a key are missing');
+            console.warn('[mcp-ts][Storage] Explicit selection "supabase" requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.');
         } else {
+            if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+                console.warn('[mcp-ts][Storage] ⚠️  Warning: Using "SUPABASE_ANON_KEY" for server-side storage. You may encounter RLS policy violations. "SUPABASE_SERVICE_ROLE_KEY" is recommended.');
+            }
             try {
                 const { createClient } = await import('@supabase/supabase-js');
                 const client = createClient(url, key);
-                console.log('[Storage] Using Supabase storage (Explicit)');
+                console.log('[mcp-ts][Storage] Explicit selection: "supabase"');
                 return await initializeStorage(new SupabaseStorageBackend(client as any));
             } catch (error: any) {
-                console.error('[Storage] Failed to initialize Supabase:', error.message);
-                console.log('[Storage] Falling back to In-Memory storage');
-                return new MemoryStorageBackend();
+                console.error('[mcp-ts][Storage] Failed to initialize Supabase:', error.message);
+                console.log('[mcp-ts][Storage] Falling back to In-Memory storage');
+                return await initializeStorage(new MemoryStorageBackend());
             }
         }
     }
 
     if (type === 'memory') {
-        console.log('[Storage] Using In-Memory storage (Explicit)');
-        return new MemoryStorageBackend();
+        console.log('[mcp-ts][Storage] Explicit selection: "memory"');
+        return await initializeStorage(new MemoryStorageBackend());
     }
 
     // Automatic inference (Fallback)
@@ -89,22 +89,21 @@ async function createStorage(): Promise<StorageBackend> {
         try {
             const { getRedis } = await import('./redis.js');
             const redis = await getRedis();
-            console.log('[Storage] Auto-detected REDIS_URL. Using Redis storage.');
-            return new RedisStorageBackend(redis);
+            console.log('[mcp-ts][Storage] Auto-detection: "redis" (via REDIS_URL)');
+            return await initializeStorage(new RedisStorageBackend(redis));
         } catch (error: any) {
-            console.error('[Storage] Redis auto-detection failed:', error.message);
-            console.log('[Storage] Falling back to In-Memory storage');
-            return new MemoryStorageBackend();
+            console.error('[mcp-ts][Storage] Redis auto-detection failed:', error.message);
+            console.log('[mcp-ts][Storage] Falling back to next available backend');
         }
     }
 
     if (process.env.MCP_TS_STORAGE_FILE) {
-        console.log(`[Storage] Auto-detected MCP_TS_STORAGE_FILE. Using File storage (${process.env.MCP_TS_STORAGE_FILE}).`);
+        console.log(`[mcp-ts][Storage] Auto-detection: "file" (${process.env.MCP_TS_STORAGE_FILE})`);
         return await initializeStorage(new FileStorageBackend({ path: process.env.MCP_TS_STORAGE_FILE }));
     }
 
     if (process.env.MCP_TS_STORAGE_SQLITE_PATH) {
-        console.log(`[Storage] Auto-detected MCP_TS_STORAGE_SQLITE_PATH. Using SQLite storage (${process.env.MCP_TS_STORAGE_SQLITE_PATH}).`);
+        console.log(`[mcp-ts][Storage] Auto-detection: "sqlite" (${process.env.MCP_TS_STORAGE_SQLITE_PATH})`);
         return await initializeStorage(new SqliteStorage({ path: process.env.MCP_TS_STORAGE_SQLITE_PATH }));
     }
 
@@ -113,16 +112,21 @@ async function createStorage(): Promise<StorageBackend> {
             const { createClient } = await import('@supabase/supabase-js');
             const url = process.env.SUPABASE_URL;
             const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY!;
+            
+            if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+                console.warn('[mcp-ts][Storage] ⚠️ Warning: Using "SUPABASE_ANON_KEY" for server-side storage. You may encounter RLS policy violations. "SUPABASE_SERVICE_ROLE_KEY" is recommended.');
+            }
+
             const client = createClient(url, key);
-            console.log('[Storage] Auto-detected Supabase. Using Supabase storage.');
+            console.log('[mcp-ts][Storage] Auto-detection: "supabase" (via SUPABASE_URL)');
             return await initializeStorage(new SupabaseStorageBackend(client as any));
         } catch (error: any) {
-            console.error('[Storage] Supabase auto-detection failed:', error.message);
+            console.error('[mcp-ts][Storage] Supabase auto-detection failed:', error.message);
         }
     }
 
-    console.log('[Storage] No storage configured. Using In-Memory storage (Default).');
-    return new MemoryStorageBackend();
+    console.log('[mcp-ts][Storage] Defaulting to: "memory"');
+    return await initializeStorage(new MemoryStorageBackend());
 }
 
 async function getStorage(): Promise<StorageBackend> {

--- a/src/server/storage/index.ts
+++ b/src/server/storage/index.ts
@@ -2,12 +2,17 @@
 import { RedisStorageBackend } from './redis-backend';
 import { MemoryStorageBackend } from './memory-backend';
 import { FileStorageBackend } from './file-backend';
-import { SqliteStorage } from './sqlite-backend';
-import type { StorageBackend } from './types';
+import { SqliteStorage } from './sqlite-backend.js';
+import { SupabaseStorageBackend } from './supabase-backend.js';
+import type { StorageBackend } from './types.js';
 
 // Re-export types
-export * from './types';
-export { RedisStorageBackend, MemoryStorageBackend, FileStorageBackend, SqliteStorage };
+export * from './types.js';
+export { RedisStorageBackend, MemoryStorageBackend, FileStorageBackend, SqliteStorage, SupabaseStorageBackend };
+
+export function createSupabaseStorageBackend(client: any): SupabaseStorageBackend {
+    return new SupabaseStorageBackend(client);
+}
 
 let storageInstance: StorageBackend | null = null;
 let storagePromise: Promise<StorageBackend> | null = null;
@@ -52,6 +57,26 @@ async function createStorage(): Promise<StorageBackend> {
         const dbPath = process.env.MCP_TS_STORAGE_SQLITE_PATH;
         console.log(`[Storage] Using SQLite storage (${dbPath || 'default'}) (Explicit)`);
         return await initializeStorage(new SqliteStorage({ path: dbPath }));
+    }
+
+    if (type === 'supabase') {
+        const url = process.env.SUPABASE_URL;
+        const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
+        
+        if (!url || !key) {
+            console.warn('[Storage] MCP_TS_STORAGE_TYPE is "supabase" but SUPABASE_URL and a key are missing');
+        } else {
+            try {
+                const { createClient } = await import('@supabase/supabase-js');
+                const client = createClient(url, key);
+                console.log('[Storage] Using Supabase storage (Explicit)');
+                return new SupabaseStorageBackend(client as any);
+            } catch (error: any) {
+                console.error('[Storage] Failed to initialize Supabase:', error.message);
+                console.log('[Storage] Falling back to In-Memory storage');
+                return new MemoryStorageBackend();
+            }
+        }
     }
 
     if (type === 'memory') {

--- a/src/server/storage/memory-backend.ts
+++ b/src/server/storage/memory-backend.ts
@@ -27,6 +27,10 @@ export class MemoryStorageBackend implements StorageBackend {
 
     constructor() { }
 
+    async init(): Promise<void> {
+        console.log('[mcp-ts][Storage] Memory: ✓ internal memory store active.');
+    }
+
     private getSessionKey(identity: string, sessionId: string): string {
         return `${identity}:${sessionId}`;
     }

--- a/src/server/storage/redis-backend.ts
+++ b/src/server/storage/redis-backend.ts
@@ -26,6 +26,15 @@ export class RedisStorageBackend implements StorageBackend {
     private readonly IDENTITY_KEY_SUFFIX = ':sessions';
 
     constructor(private redis: Redis) { }
+    
+    async init(): Promise<void> {
+        try {
+            await this.redis.ping();
+            console.log('[mcp-ts][Storage] Redis: ✓ Connected to server.');
+        } catch (error: any) {
+            throw new Error(`[RedisStorage] Failed to connect to Redis: ${error.message}`);
+        }
+    }
 
     /**
      * Generates Redis key for a specific session

--- a/src/server/storage/sqlite-backend.ts
+++ b/src/server/storage/sqlite-backend.ts
@@ -44,6 +44,7 @@ export class SqliteStorage implements StorageBackend {
             `);
 
             this.initialized = true;
+            console.log(`[mcp-ts][Storage] SQLite: ✓ database at ${this.dbPath} verified.`);
         } catch (error: any) {
             if (error.code === 'MODULE_NOT_FOUND' || error.message?.includes('better-sqlite3')) {
                 throw new Error(

--- a/src/server/storage/supabase-backend.ts
+++ b/src/server/storage/supabase-backend.ts
@@ -6,6 +6,25 @@ export class SupabaseStorageBackend implements StorageBackend {
     private readonly DEFAULT_TTL = SESSION_TTL_SECONDS;
 
     constructor(private supabase: SupabaseClient) {}
+    
+    async init(): Promise<void> {
+        // Validate that the table exists
+        const { error } = await this.supabase
+            .from('mcp_sessions')
+            .select('session_id')
+            .limit(0);
+
+        if (error) {
+            // Postgres error code 42P01 is "relation does not exist"
+            if (error.code === '42P01') {
+                throw new Error(
+                    '[SupabaseStorage] Table "mcp_sessions" not found in your database. ' +
+                    'Please run "npx mcp-ts supabase-init" in your project to set up the required table and RLS policies.'
+                );
+            }
+            throw new Error(`[SupabaseStorage] Initialization check failed: ${error.message}`);
+        }
+    }
 
     generateSessionId(): string {
         return crypto.randomUUID();

--- a/src/server/storage/supabase-backend.ts
+++ b/src/server/storage/supabase-backend.ts
@@ -24,6 +24,8 @@ export class SupabaseStorageBackend implements StorageBackend {
             }
             throw new Error(`[SupabaseStorage] Initialization check failed: ${error.message}`);
         }
+
+        console.log('[mcp-ts][Storage] Supabase: ✓ "mcp_sessions" table verified.');
     }
 
     generateSessionId(): string {

--- a/src/server/storage/supabase-backend.ts
+++ b/src/server/storage/supabase-backend.ts
@@ -1,0 +1,206 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { StorageBackend, SessionData } from './types.js';
+import { SESSION_TTL_SECONDS } from '../../shared/constants.js';
+
+export class SupabaseStorageBackend implements StorageBackend {
+    private readonly DEFAULT_TTL = SESSION_TTL_SECONDS;
+
+    constructor(private supabase: SupabaseClient) {}
+
+    generateSessionId(): string {
+        return crypto.randomUUID();
+    }
+
+    private mapRowToSessionData(row: any): SessionData {
+        return {
+            sessionId: row.session_id,
+            serverId: row.server_id,
+            serverName: row.server_name,
+            serverUrl: row.server_url,
+            transportType: row.transport_type,
+            callbackUrl: row.callback_url,
+            createdAt: new Date(row.created_at).getTime(),
+            identity: row.identity,
+            headers: row.headers,
+            active: row.active,
+            clientInformation: row.client_information,
+            tokens: row.tokens,
+            codeVerifier: row.code_verifier,
+            clientId: row.client_id,
+        };
+    }
+
+    async createSession(session: SessionData, ttl?: number): Promise<void> {
+        const { sessionId, identity } = session;
+        if (!sessionId || !identity) throw new Error('identity and sessionId required');
+
+        const effectiveTtl = ttl ?? this.DEFAULT_TTL;
+        const expiresAt = new Date(Date.now() + effectiveTtl * 1000).toISOString();
+
+        const { error } = await this.supabase
+            .from('mcp_sessions')
+            .insert({
+                session_id: sessionId,
+                user_id: identity, // Maps user_id to identity to support RLS using auth.uid()
+                server_id: session.serverId,
+                server_name: session.serverName,
+                server_url: session.serverUrl,
+                transport_type: session.transportType,
+                callback_url: session.callbackUrl,
+                created_at: new Date(session.createdAt || Date.now()).toISOString(),
+                identity: identity,
+                headers: session.headers,
+                active: session.active ?? false,
+                client_information: session.clientInformation,
+                tokens: session.tokens,
+                code_verifier: session.codeVerifier,
+                client_id: session.clientId,
+                expires_at: expiresAt
+            });
+
+        if (error) {
+            // Postgres error code 23505 is unique violation
+            if (error.code === '23505') {
+                throw new Error(`Session ${sessionId} already exists`);
+            }
+            throw new Error(`Failed to create session in Supabase: ${error.message}`);
+        }
+    }
+
+    async updateSession(identity: string, sessionId: string, data: Partial<SessionData>, ttl?: number): Promise<void> {
+        const effectiveTtl = ttl ?? this.DEFAULT_TTL;
+        const expiresAt = new Date(Date.now() + effectiveTtl * 1000).toISOString();
+
+        // Convert the camelCase keys to snake_case for Supabase
+        const updateData: any = {
+            expires_at: expiresAt,
+            updated_at: new Date().toISOString()
+        };
+
+        if ('serverId' in data) updateData.server_id = data.serverId;
+        if ('serverName' in data) updateData.server_name = data.serverName;
+        if ('serverUrl' in data) updateData.server_url = data.serverUrl;
+        if ('transportType' in data) updateData.transport_type = data.transportType;
+        if ('callbackUrl' in data) updateData.callback_url = data.callbackUrl;
+        if ('active' in data) updateData.active = data.active;
+        if ('headers' in data) updateData.headers = data.headers;
+        if ('clientInformation' in data) updateData.client_information = data.clientInformation;
+        if ('tokens' in data) updateData.tokens = data.tokens;
+        if ('codeVerifier' in data) updateData.code_verifier = data.codeVerifier;
+        if ('clientId' in data) updateData.client_id = data.clientId;
+
+        const { data: updatedRows, error } = await this.supabase
+            .from('mcp_sessions')
+            .update(updateData)
+            .eq('identity', identity)
+            .eq('session_id', sessionId)
+            .select('id');
+
+        if (error) {
+            throw new Error(`Failed to update session: ${error.message}`);
+        }
+
+        if (!updatedRows || updatedRows.length === 0) {
+            throw new Error(`Session ${sessionId} not found for identity ${identity}`);
+        }
+    }
+
+    async getSession(identity: string, sessionId: string): Promise<SessionData | null> {
+        const { data, error } = await this.supabase
+            .from('mcp_sessions')
+            .select('*')
+            .eq('identity', identity)
+            .eq('session_id', sessionId)
+            .maybeSingle();
+
+        if (error) {
+            console.error('[SupabaseStorage] Failed to get session:', error);
+            return null;
+        }
+
+        if (!data) return null;
+
+        return this.mapRowToSessionData(data);
+    }
+
+    async getIdentitySessionsData(identity: string): Promise<SessionData[]> {
+        const { data, error } = await this.supabase
+            .from('mcp_sessions')
+            .select('*')
+            .eq('identity', identity);
+
+        if (error) {
+            console.error(`[SupabaseStorage] Failed to get session data for ${identity}:`, error);
+            return [];
+        }
+
+        return data.map(row => this.mapRowToSessionData(row));
+    }
+
+    async removeSession(identity: string, sessionId: string): Promise<void> {
+        const { error } = await this.supabase
+            .from('mcp_sessions')
+            .delete()
+            .eq('identity', identity)
+            .eq('session_id', sessionId);
+
+        if (error) {
+            console.error('[SupabaseStorage] Failed to remove session:', error);
+        }
+    }
+
+    async getIdentityMcpSessions(identity: string): Promise<string[]> {
+        const { data, error } = await this.supabase
+            .from('mcp_sessions')
+            .select('session_id')
+            .eq('identity', identity);
+
+        if (error) {
+            console.error(`[SupabaseStorage] Failed to get sessions for ${identity}:`, error);
+            return [];
+        }
+
+        return data.map(row => row.session_id);
+    }
+
+    async getAllSessionIds(): Promise<string[]> {
+        const { data, error } = await this.supabase
+            .from('mcp_sessions')
+            .select('session_id');
+
+        if (error) {
+            console.error('[SupabaseStorage] Failed to get all sessions:', error);
+            return [];
+        }
+
+        return data.map(row => row.session_id);
+    }
+
+    async clearAll(): Promise<void> {
+        // Warning: This deletes everything. Typically only used in testing.
+        const { error } = await this.supabase
+            .from('mcp_sessions')
+            .delete()
+            .neq('session_id', ''); // Delete all rows trick
+            
+        if (error) {
+            console.error('[SupabaseStorage] Failed to clear sessions:', error);
+        }
+    }
+
+    async cleanupExpiredSessions(): Promise<void> {
+        const { error } = await this.supabase
+            .from('mcp_sessions')
+            .delete()
+            .lt('expires_at', new Date().toISOString());
+
+        if (error) {
+            console.error('[SupabaseStorage] Failed to cleanup expired sessions:', error);
+        }
+    }
+
+    async disconnect(): Promise<void> {
+        // Supabase client handles its own connection pooling over HTTP, 
+        // there is no explicit disconnect method.
+    }
+}

--- a/supabase/migrations/20260330195700_install_mcp_sessions.sql
+++ b/supabase/migrations/20260330195700_install_mcp_sessions.sql
@@ -1,0 +1,84 @@
+-- Create the mcp_sessions table
+CREATE TABLE IF NOT EXISTS public.mcp_sessions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    session_id TEXT NOT NULL UNIQUE,
+    user_id TEXT NOT NULL, -- Will store the Next.js user's ID or identity
+    server_id TEXT,
+    server_name TEXT,
+    server_url TEXT NOT NULL,
+    transport_type TEXT NOT NULL,
+    callback_url TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at TIMESTAMPTZ NOT NULL,
+    active BOOLEAN DEFAULT false,
+    identity TEXT NOT NULL,
+    headers JSONB,
+    client_information JSONB,
+    tokens JSONB,
+    code_verifier TEXT,
+    client_id TEXT
+);
+
+-- Add an index on identity and user_id for faster lookups
+CREATE INDEX IF NOT EXISTS idx_mcp_sessions_identity ON public.mcp_sessions(identity);
+CREATE INDEX IF NOT EXISTS idx_mcp_sessions_user_id ON public.mcp_sessions(user_id);
+-- Add an index on expires_at to speed up the cleanup job
+CREATE INDEX IF NOT EXISTS idx_mcp_sessions_expires_at ON public.mcp_sessions(expires_at);
+
+-- Trigger to automatically update the 'updated_at' column
+CREATE OR REPLACE FUNCTION public.set_current_timestamp_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_mcp_sessions_updated_at ON public.mcp_sessions;
+CREATE TRIGGER trg_mcp_sessions_updated_at
+BEFORE UPDATE ON public.mcp_sessions
+FOR EACH ROW
+EXECUTE FUNCTION public.set_current_timestamp_updated_at();
+
+-- Enable Row Level Security (RLS)
+ALTER TABLE public.mcp_sessions ENABLE ROW LEVEL SECURITY;
+
+-- Policy 1: Users can read their own sessions
+CREATE POLICY "Users can view their own sessions"
+ON public.mcp_sessions
+FOR SELECT
+TO authenticated
+USING (
+    auth.uid()::text = user_id OR auth.uid()::text = identity
+);
+
+-- Policy 2: Users can insert their own sessions
+CREATE POLICY "Users can insert their own sessions"
+ON public.mcp_sessions
+FOR INSERT
+TO authenticated
+WITH CHECK (
+    auth.uid()::text = user_id OR auth.uid()::text = identity
+);
+
+-- Policy 3: Users can update their own sessions
+CREATE POLICY "Users can update their own sessions"
+ON public.mcp_sessions
+FOR UPDATE
+TO authenticated
+USING (
+    auth.uid()::text = user_id OR auth.uid()::text = identity
+)
+WITH CHECK (
+    auth.uid()::text = user_id OR auth.uid()::text = identity
+);
+
+-- Policy 4: Users can delete their own sessions
+CREATE POLICY "Users can delete their own sessions"
+ON public.mcp_sessions
+FOR DELETE
+TO authenticated
+USING (
+    auth.uid()::text = user_id OR auth.uid()::text = identity
+);

--- a/tests/storage/supabase-backend.test.ts
+++ b/tests/storage/supabase-backend.test.ts
@@ -11,13 +11,16 @@ import { createMockSession, createMockTokens } from '../test-utils';
  */
 function createMockSupabaseClient() {
     let sessions: any[] = [];
+    let simulateMissingTable = false;
 
-    return {
+    const mock = {
         /** Test-only helper to inspect internal state */
         _getSessions: () => sessions,
+        get _simulateMissingTable() { return simulateMissingTable; },
+        set _simulateMissingTable(v: boolean) { simulateMissingTable = v; },
 
         from: (_table: string) => {
-            let action: 'insert' | 'update' | 'select' | 'delete' | null = null;
+            let action: 'insert' | 'update' | 'select' | 'delete' | 'init_check' | null = null;
             let payload: any = null;
             const filters: Array<(item: any) => boolean> = [];
             let selectAfterMutation = false;
@@ -27,13 +30,19 @@ function createMockSupabaseClient() {
                 update: (data: any) => { action = 'update'; payload = { ...data }; return chain; },
                 delete: () => { action = 'delete'; return chain; },
                 select: (_cols?: any) => {
-                    // If called after update/delete → request rows back, not a fresh SELECT
-                    if (action === 'update' || action === 'delete') {
+                    // Specific check for init() validation: select('session_id').limit(0)
+                    if (_cols === 'session_id' && payload === 'limit_zero_check') {
+                        action = 'init_check';
+                    } else if (action === 'update' || action === 'delete') {
                         selectAfterMutation = true;
                     } else {
                         action = 'select';
                     }
                     return chain;
+                },
+                limit: (n: number) => { 
+                    if (n === 0) payload = 'limit_zero_check'; 
+                    return chain; 
                 },
                 eq:  (k: string, v: any) => { filters.push(row => row[k] === v);  return chain; },
                 neq: (k: string, v: any) => { filters.push(row => row[k] !== v);  return chain; },
@@ -54,6 +63,11 @@ function createMockSupabaseClient() {
                  */
                 then: (resolve: (v: any) => void, reject?: (e: any) => void) => {
                     try {
+                        // Determine if this is actually our init_check based on column choice + limit
+                        if (action === 'select' && payload === 'limit_zero_check') {
+                            action = 'init_check';
+                        }
+
                         if (action === 'insert') {
                             if (sessions.some(s => s.session_id === payload.session_id)) {
                                 return resolve({ data: null, error: { code: '23505', message: 'duplicate key violation' } });
@@ -72,6 +86,12 @@ function createMockSupabaseClient() {
                             const removed = before - sessions.length;
                             return resolve({ data: selectAfterMutation ? Array(removed).fill(null) : null, error: null });
 
+                        } else if (action === 'init_check') {
+                            if (simulateMissingTable) {
+                                return resolve({ data: null, error: { code: '42P01', message: 'relation "mcp_sessions" does not exist' } });
+                            }
+                            return resolve({ data: [], error: null });
+
                         } else if (action === 'select') {
                             const res = sessions.filter(s => filters.every(f => f(s)));
                             return resolve({ data: res, error: null });
@@ -86,7 +106,8 @@ function createMockSupabaseClient() {
             };
             return chain;
         },
-    } as any;
+    };
+    return mock;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -99,6 +120,19 @@ test.describe('SupabaseStorageBackend', () => {
     test.beforeEach(() => {
         mockSupabase = createMockSupabaseClient();
         storage    = new SupabaseStorageBackend(mockSupabase);
+    });
+
+    // ── init ─────────────────────────────────────────────────────────────────
+    test.describe('init', () => {
+        test('resolves when table exists', async () => {
+            await expect(storage.init()).resolves.toBeUndefined();
+        });
+
+        test('throws descriptive error when table is missing', async () => {
+            mockSupabase._simulateMissingTable = true;
+            await expect(storage.init()).rejects.toThrow(/Table "mcp_sessions" not found/);
+            await expect(storage.init()).rejects.toThrow(/npx mcp-ts supabase-init/);
+        });
     });
 
     // ── generateSessionId ────────────────────────────────────────────────────

--- a/tests/storage/supabase-backend.test.ts
+++ b/tests/storage/supabase-backend.test.ts
@@ -1,0 +1,362 @@
+import { test, expect } from '@playwright/test';
+import { SupabaseStorageBackend } from '../../src/server/storage/supabase-backend';
+import { createMockSession, createMockTokens } from '../test-utils';
+
+/**
+ * A mock Supabase client that faithfully simulates the fluent builder API:
+ *   .from(table).update(data).eq(k,v).eq(k,v).select('id')
+ *
+ * Key insight: .select() called AFTER .update()/.delete() does NOT switch the
+ * action — it sets `selectAfterMutation = true` so we return matched rows.
+ */
+function createMockSupabaseClient() {
+    let sessions: any[] = [];
+
+    return {
+        /** Test-only helper to inspect internal state */
+        _getSessions: () => sessions,
+
+        from: (_table: string) => {
+            let action: 'insert' | 'update' | 'select' | 'delete' | null = null;
+            let payload: any = null;
+            const filters: Array<(item: any) => boolean> = [];
+            let selectAfterMutation = false;
+
+            const chain: any = {
+                insert: (data: any) => { action = 'insert'; payload = { ...data }; return chain; },
+                update: (data: any) => { action = 'update'; payload = { ...data }; return chain; },
+                delete: () => { action = 'delete'; return chain; },
+                select: (_cols?: any) => {
+                    // If called after update/delete → request rows back, not a fresh SELECT
+                    if (action === 'update' || action === 'delete') {
+                        selectAfterMutation = true;
+                    } else {
+                        action = 'select';
+                    }
+                    return chain;
+                },
+                eq:  (k: string, v: any) => { filters.push(row => row[k] === v);  return chain; },
+                neq: (k: string, v: any) => { filters.push(row => row[k] !== v);  return chain; },
+                lt:  (k: string, v: any) => {
+                    filters.push(row => new Date(row[k]).getTime() < new Date(v).getTime());
+                    return chain;
+                },
+
+                /** Used by getSession */
+                maybeSingle: async () => {
+                    let res = [...sessions];
+                    for (const f of filters) res = res.filter(f);
+                    return { data: res[0] ?? null, error: null };
+                },
+
+                /**
+                 * Makes the chain awaitable — mimics the real Supabase PromiseLike
+                 */
+                then: (resolve: (v: any) => void, reject?: (e: any) => void) => {
+                    try {
+                        if (action === 'insert') {
+                            if (sessions.some(s => s.session_id === payload.session_id)) {
+                                return resolve({ data: null, error: { code: '23505', message: 'duplicate key violation' } });
+                            }
+                            sessions.push({ ...payload });
+                            return resolve({ data: [payload], error: null });
+
+                        } else if (action === 'update') {
+                            const matched = sessions.filter(s => filters.every(f => f(s)));
+                            matched.forEach(s => Object.assign(s, payload));
+                            return resolve({ data: selectAfterMutation ? matched : null, error: null });
+
+                        } else if (action === 'delete') {
+                            const before = sessions.length;
+                            sessions = sessions.filter(s => !filters.every(f => f(s)));
+                            const removed = before - sessions.length;
+                            return resolve({ data: selectAfterMutation ? Array(removed).fill(null) : null, error: null });
+
+                        } else if (action === 'select') {
+                            const res = sessions.filter(s => filters.every(f => f(s)));
+                            return resolve({ data: res, error: null });
+
+                        } else {
+                            return resolve({ data: null, error: new Error('Unknown action') });
+                        }
+                    } catch (err) {
+                        reject ? reject(err) : resolve({ data: null, error: err });
+                    }
+                },
+            };
+            return chain;
+        },
+    } as any;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test Suite
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('SupabaseStorageBackend', () => {
+    let mockSupabase: any;
+    let storage: SupabaseStorageBackend;
+
+    test.beforeEach(() => {
+        mockSupabase = createMockSupabaseClient();
+        storage    = new SupabaseStorageBackend(mockSupabase);
+    });
+
+    // ── generateSessionId ────────────────────────────────────────────────────
+    test.describe('generateSessionId', () => {
+        test('generates unique UUIDs', () => {
+            const id1 = storage.generateSessionId();
+            const id2 = storage.generateSessionId();
+            expect(id1).not.toBe(id2);
+            // UUIDv4 pattern
+            expect(id1).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+        });
+    });
+
+    // ── createSession ────────────────────────────────────────────────────────
+    test.describe('createSession', () => {
+        test('maps all SessionData fields to snake_case columns', async () => {
+            const session = createMockSession();
+            await storage.createSession(session);
+
+            const row = mockSupabase._getSessions()[0];
+            expect(row.session_id).toBe(session.sessionId);
+            expect(row.identity).toBe(session.identity);
+            expect(row.user_id).toBe(session.identity);   // RLS mirror
+            expect(row.server_id).toBe(session.serverId);
+            expect(row.server_name).toBe(session.serverName);
+            expect(row.server_url).toBe(session.serverUrl);
+            expect(row.transport_type).toBe(session.transportType);
+            expect(row.callback_url).toBe(session.callbackUrl);
+            expect(row.active).toBe(session.active);
+        });
+
+        test('sets expires_at correctly from TTL', async () => {
+            const ttl = 3600;
+            const before = Date.now();
+            await storage.createSession(createMockSession(), ttl);
+
+            const row = mockSupabase._getSessions()[0];
+            const expiresMs = new Date(row.expires_at).getTime();
+            expect(expiresMs).toBeGreaterThanOrEqual(before + ttl * 1000 - 100);
+            expect(expiresMs).toBeLessThanOrEqual(Date.now() + ttl * 1000 + 100);
+        });
+
+        test('persists JSONB fields: tokens, headers, clientInformation', async () => {
+            const tokens = createMockTokens();
+            const session = createMockSession({
+                tokens,
+                headers: { Authorization: 'Bearer xyz' },
+            });
+            await storage.createSession(session);
+
+            const row = mockSupabase._getSessions()[0];
+            expect(row.tokens).toEqual(tokens);
+            expect(row.headers).toEqual({ Authorization: 'Bearer xyz' });
+        });
+
+        test('throws on duplicate session (unique key violation)', async () => {
+            const session = createMockSession();
+            await storage.createSession(session);
+            await expect(storage.createSession(session)).rejects.toThrow('already exists');
+        });
+    });
+
+    // ── updateSession ────────────────────────────────────────────────────────
+    test.describe('updateSession', () => {
+        test('updates partial fields and preserves unchanged ones', async () => {
+            const session = createMockSession();
+            await storage.createSession(session);
+
+            const newTokens = createMockTokens();
+            await storage.updateSession(session.identity, session.sessionId, {
+                active: true,
+                tokens: newTokens,
+                transportType: 'streamable_http',
+            });
+
+            const retrieved = await storage.getSession(session.identity, session.sessionId);
+            // Updated
+            expect(retrieved?.active).toBe(true);
+            expect(retrieved?.tokens).toEqual(newTokens);
+            expect(retrieved?.transportType).toBe('streamable_http');
+            // Preserved
+            expect(retrieved?.serverId).toBe(session.serverId);
+            expect(retrieved?.serverUrl).toBe(session.serverUrl);
+            expect(retrieved?.identity).toBe(session.identity);
+        });
+
+        test('handles OAuth token refresh safely', async () => {
+            const session = createMockSession({ tokens: createMockTokens() });
+            await storage.createSession(session);
+
+            const refreshed = createMockTokens({
+                access_token:  'new-access-token',
+                refresh_token: 'new-refresh-token',
+            });
+            await storage.updateSession(session.identity, session.sessionId, { tokens: refreshed });
+
+            const retrieved = await storage.getSession(session.identity, session.sessionId);
+            expect(retrieved?.tokens?.access_token).toBe('new-access-token');
+            expect(retrieved?.tokens?.refresh_token).toBe('new-refresh-token');
+        });
+
+        test('refreshes expires_at with a new TTL', async () => {
+            const session = createMockSession();
+            await storage.createSession(session, 10);        // 10s TTL on create
+
+            const before = Date.now();
+            await storage.updateSession(session.identity, session.sessionId, { active: true }, 7200);
+
+            const row = mockSupabase._getSessions()[0];
+            const expiresMs = new Date(row.expires_at).getTime();
+            // Should now be ~2 hours from now (not 10 seconds)
+            expect(expiresMs).toBeGreaterThan(before + 7000 * 1000);
+        });
+
+        test('throws if session does not exist', async () => {
+            await expect(
+                storage.updateSession('no-user', 'no-session', { active: true })
+            ).rejects.toThrow('not found');
+        });
+    });
+
+    // ── getSession ───────────────────────────────────────────────────────────
+    test.describe('getSession', () => {
+        test('maps DB row back to camelCase SessionData correctly', async () => {
+            const session = createMockSession();
+            await storage.createSession(session);
+
+            const result = await storage.getSession(session.identity, session.sessionId);
+
+            expect(result).not.toBeNull();
+            expect(result?.sessionId).toBe(session.sessionId);
+            expect(result?.serverId).toBe(session.serverId);
+            expect(result?.serverName).toBe(session.serverName);
+            expect(result?.serverUrl).toBe(session.serverUrl);
+            expect(result?.transportType).toBe(session.transportType);
+            expect(result?.callbackUrl).toBe(session.callbackUrl);
+            expect(result?.identity).toBe(session.identity);
+            expect(result?.active).toBe(session.active);
+            expect(typeof result?.createdAt).toBe('number');
+        });
+
+        test('returns null when session does not exist', async () => {
+            expect(await storage.getSession('ghost', 'ghost')).toBeNull();
+        });
+
+        test('does not leak sessions across identities', async () => {
+            const a = createMockSession({ sessionId: 'a', identity: 'user-a' });
+            const b = createMockSession({ sessionId: 'b', identity: 'user-b' });
+            await storage.createSession(a);
+            await storage.createSession(b);
+
+            // user-a queries for user-b's session ID → should get null
+            expect(await storage.getSession('user-a', 'b')).toBeNull();
+        });
+    });
+
+    // ── removeSession ────────────────────────────────────────────────────────
+    test.describe('removeSession', () => {
+        test('deletes the session so it can no longer be retrieved', async () => {
+            const session = createMockSession();
+            await storage.createSession(session);
+            await storage.removeSession(session.identity, session.sessionId);
+            expect(await storage.getSession(session.identity, session.sessionId)).toBeNull();
+        });
+
+        test('does not remove other sessions belonging to the same identity', async () => {
+            const identity = 'multi-user';
+            await storage.createSession(createMockSession({ sessionId: 's1', identity }));
+            await storage.createSession(createMockSession({ sessionId: 's2', identity }));
+
+            await storage.removeSession(identity, 's1');
+
+            const remaining = await storage.getIdentityMcpSessions(identity);
+            expect(remaining).toEqual(['s2']);
+        });
+    });
+
+    // ── getIdentitySessionsData ──────────────────────────────────────────────
+    test.describe('getIdentitySessionsData', () => {
+        test('returns all full SessionData objects for the identity', async () => {
+            const identity = 'owner';
+            await storage.createSession(createMockSession({ sessionId: 'x1', identity }));
+            await storage.createSession(createMockSession({ sessionId: 'x2', identity, serverName: 'Alt Server' }));
+            // Another user — must NOT appear
+            await storage.createSession(createMockSession({ sessionId: 'x3', identity: 'intruder' }));
+
+            const sessions = await storage.getIdentitySessionsData(identity);
+            expect(sessions.length).toBe(2);
+            expect(sessions.map(s => s.sessionId)).toContain('x1');
+            expect(sessions.map(s => s.sessionId)).toContain('x2');
+        });
+
+        test('returns empty array for identity with no sessions', async () => {
+            expect(await storage.getIdentitySessionsData('nobody')).toEqual([]);
+        });
+    });
+
+    // ── getIdentityMcpSessions ───────────────────────────────────────────────
+    test.describe('getIdentityMcpSessions', () => {
+        test('returns only session IDs (not full objects)', async () => {
+            const identity = 'slim-user';
+            await storage.createSession(createMockSession({ sessionId: 'id-a', identity }));
+            await storage.createSession(createMockSession({ sessionId: 'id-b', identity }));
+
+            const ids = await storage.getIdentityMcpSessions(identity);
+            expect(ids.sort()).toEqual(['id-a', 'id-b']);
+        });
+    });
+
+    // ── getAllSessionIds ──────────────────────────────────────────────────────
+    test.describe('getAllSessionIds', () => {
+        test('returns session IDs across ALL identities', async () => {
+            await storage.createSession(createMockSession({ sessionId: 'g1', identity: 'u1' }));
+            await storage.createSession(createMockSession({ sessionId: 'g2', identity: 'u2' }));
+
+            const ids = await storage.getAllSessionIds();
+            expect(ids).toContain('g1');
+            expect(ids).toContain('g2');
+            expect(ids.length).toBe(2);
+        });
+    });
+
+    // ── clearAll ─────────────────────────────────────────────────────────────
+    test.describe('clearAll', () => {
+        test('wipes every session regardless of identity', async () => {
+            await storage.createSession(createMockSession({ sessionId: 'c1', identity: 'u1' }));
+            await storage.createSession(createMockSession({ sessionId: 'c2', identity: 'u2' }));
+
+            await storage.clearAll();
+
+            expect(await storage.getAllSessionIds()).toEqual([]);
+        });
+    });
+
+    // ── cleanupExpiredSessions ───────────────────────────────────────────────
+    test.describe('cleanupExpiredSessions', () => {
+        test('deletes rows where expires_at is in the past', async () => {
+            await storage.createSession(createMockSession({ sessionId: 'alive' }),  3600);  // future
+            await storage.createSession(createMockSession({ sessionId: 'zombie' }), -3600); // past
+
+            await storage.cleanupExpiredSessions();
+
+            const rows = mockSupabase._getSessions();
+            expect(rows.length).toBe(1);
+            expect(rows[0].session_id).toBe('alive');
+        });
+
+        test('is a no-op when there are no expired sessions', async () => {
+            await storage.createSession(createMockSession({ sessionId: 'fresh' }), 3600);
+            await storage.cleanupExpiredSessions();
+            expect(mockSupabase._getSessions().length).toBe(1);
+        });
+    });
+
+    // ── disconnect ───────────────────────────────────────────────────────────
+    test.describe('disconnect', () => {
+        test('resolves cleanly (no persistent connection to close)', async () => {
+            await expect(storage.disconnect()).resolves.toBeUndefined();
+        });
+    });
+});

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -57,6 +57,7 @@ export interface MockSession {
         expires_in?: number;
         refresh_token?: string;
     };
+    headers?: Record<string, string>;
 }
 
 /**

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     'adapters/mastra-adapter': 'src/adapters/mastra-adapter.ts',
     'adapters/agui-adapter': 'src/adapters/agui-adapter.ts',
     'adapters/agui-middleware': 'src/adapters/agui-middleware.ts',
+    'bin/mcp-ts': 'src/bin/mcp-ts.ts',
   },
   format: ['cjs', 'esm'],
   dts: {
@@ -41,4 +42,5 @@ export default defineConfig({
   // Preserve module structure for better tree-shaking
   bundle: true,
   minify: false,
+  shims: true,
 });


### PR DESCRIPTION
## Overview
This PR adds comprehensive Supabase storage support to the MCP-TS framework with a new CLI initialization command, standardized health checks across all storage backends, and enforced security best practices.

## Key Changes

### 1. **Supabase Storage Backend Implementation**
- ✅ New `SupabaseStorageBackend` for session persistence via PostgreSQL
- ✅ SQL migrations for `mcp_sessions` table with JSONB support for complex session fields
- ✅ Row Level Security (RLS) policies to ensure session isolation between users
- ✅ Auto-initialization via `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` environment variables
- ✅ Comprehensive test suite using mock Supabase client

### 2. **CLI Initialization Command**
- ✅ New `npx mcp-ts supabase-init` command to eject migrations to consumer projects
- ✅ Updated `tsup.config.ts` with CLI entry point and `__dirname` shims
- ✅ Updated `package.json` to expose the `mcp-ts` binary
- ✅ Supabase folder included in published package

### 3. **Storage Backend Standardization**
- ✅ Added `init()` method with runtime table/storage existence validation to all backends:
  - Redis
  - SQLite
  - File
  - Memory
  - Supabase (new)
- ✅ Standardized logging with `[mcp-ts][Storage]` prefix and ✓ confirmations
- ✅ Enhanced storage factory with auto-detection for Supabase

### 4. **Security Improvements**
- ✅ Enforce `SUPABASE_SERVICE_ROLE_KEY` as the standard (warn if anon key is used)
- ✅ Auto-detection for Supabase via `SUPABASE_URL` environment variable
- ✅ Health check validation at initialization time

## Files Changed
- 16 files modified
- **+1181** additions, **-66** deletions

## Testing
✅ Unit tests added for:
- Backend initialization checks
- Missing table error handling
- All storage operations via mock Supabase client

## Breaking Changes
⚠️ **None** - Fully backward compatible with existing storage backends

## Type Safety
✅ All code follows TypeScript strict mode guidelines

## Related Issues
Closes #[issue_number] (if applicable)

## Next Steps
- [ ] Review Supabase RLS policies for your use case
- [ ] Run `npx mcp-ts supabase-init` to set up the mcp_sessions table
- [ ] Update `.env` with your Supabase credentials (`SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`)
