### PR TITLE
fix(react): stabilize MCP Apps renderer and useMcp client identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,6 @@ export function ToolRenderer() {
     name: "*",
     render: ({ name, args, result, status }) => (
       <McpAppRenderer
-        mcpClient={mcpClient}
         name={name}
         input={args}
         result={result}

--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -641,17 +641,17 @@ interface McpAppMetadata {
 
 #### `McpAppRenderer` Component
 
-Stable, memoized component for rendering MCP apps. Prevents iframe flickering by maintaining component identity across renders.
+Returned from `useMcpApps(mcpClient)` together with `getAppMetadata`. The hook closes over `mcpClient`, so each `<McpAppRenderer />` only needs the active tool call: `name`, optional `input` / `result`, and `status`.
 
 **Props:**
 
 ```typescript
 interface McpAppRendererProps {
-  metadata: McpAppMetadata;           // Stable metadata from getAppMetadata
+  name: string;                        // Tool name; SDK matches this to server tool / app metadata
   input?: Record<string, unknown>;     // Tool arguments
   result?: unknown;                    // Tool execution result
   status: 'executing' | 'inProgress' | 'complete' | 'idle';
-  className?: string;                 // Custom CSS classes for container
+  className?: string;                  // Custom CSS classes for container
 }
 ```
 
@@ -662,15 +662,11 @@ import { useMcpApps } from '@mcp-ts/sdk/client/react';
 
 function ToolCallRenderer({ name, args, result, status }) {
   const { mcpClient } = useMcpContext();
-  const { getAppMetadata, McpAppRenderer } = useMcpApps(mcpClient);
-  
-  const metadata = getAppMetadata(name);
-  
-  if (!metadata) return null;
-  
+  const { McpAppRenderer } = useMcpApps(mcpClient);
+
   return (
     <McpAppRenderer
-      metadata={metadata}
+      name={name}
       input={args}
       result={result}
       status={status}

--- a/docs/docs/mcp-apps.md
+++ b/docs/docs/mcp-apps.md
@@ -88,7 +88,6 @@ function ToolRenderer() {
     name: "*",
     render: ({ name, args, result, status }) => (
       <McpAppRenderer
-        mcpClient={mcpClient}
         name={name}
         input={args}
         result={result}
@@ -165,7 +164,8 @@ sequenceDiagram
 
 ```typescript
 function useMcpApps(mcpClient: McpClient | null): {
-  McpAppRenderer: React.FC<McpAppRendererProps>;
+  getAppMetadata: (toolName: string) => McpAppMetadata | undefined;
+  McpAppRenderer: React.NamedExoticComponent<McpAppRendererProps>;
 }
 ```
 
@@ -173,13 +173,13 @@ function useMcpApps(mcpClient: McpClient | null): {
 - `mcpClient` - The MCP client from `useMcp()` or context
 
 **Returns:**
-- `McpAppRenderer` - Stable component for rendering MCP apps
+- `getAppMetadata` — Returns UI metadata for a tool if the server exposed an MCP App for it. Use this when you need to branch in your own UI (for example, show a badge only for tools with an app). You do not need it just to render: `McpAppRenderer` looks up metadata from the tool `name` on its own.
+- `McpAppRenderer` — Renders the app iframe for the client you passed into `useMcpApps`. Give it only the current tool call: `name`, `input`, `result`, and `status`.
 
 ### McpAppRenderer Props
 
 ```typescript
 interface McpAppRendererProps {
-  mcpClient: McpClient | null;           // MCP client for metadata lookup
   name: string;                            // Tool name to render
   input?: Record<string, unknown>;        // Tool arguments
   result?: unknown;                        // Tool execution result
@@ -212,7 +212,6 @@ function ToolRenderer() {
     name: "*",
     render: (props) => (
       <McpAppRenderer
-        mcpClient={mcpClient}
         name={props.name}
         input={props.args}
         result={props.result}
@@ -236,7 +235,6 @@ function MyToolRenderer({ toolName, args, result, status }) {
   
   return (
     <McpAppRenderer
-      mcpClient={mcpClient}
       name={toolName}
       input={args}
       result={result}

--- a/examples/agents/src/components/ToolRenderer.tsx
+++ b/examples/agents/src/components/ToolRenderer.tsx
@@ -26,7 +26,6 @@ const ToolCallRenderer: React.FC<RenderProps> = (props) => {
         status={normalizedStatus} 
       />
       <McpAppRenderer
-        mcpClient={mcpClient}
         name={name}
         input={args}
         result={result}

--- a/src/client/react/index.ts
+++ b/src/client/react/index.ts
@@ -10,7 +10,11 @@ export { useMcp, type UseMcpOptions, type McpClient, type McpConnection } from '
 export { useAppHost } from './use-app-host.js';
 
 // Simplified MCP Apps Hook - the main API
-export { useMcpApps } from './use-mcp-apps.js';
+export {
+  useMcpApps,
+  type McpAppRendererProps,
+  type McpAppMetadata,
+} from './use-mcp-apps.js';
 
 // Re-export shared types and client from main entry
 export * from '../index.js';

--- a/src/client/react/use-mcp-apps.tsx
+++ b/src/client/react/use-mcp-apps.tsx
@@ -4,7 +4,15 @@
  * Provides utilities for rendering interactive UI components from MCP servers.
  */
 
-import React, { useState, useEffect, useCallback, useRef, memo } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  memo,
+  useMemo,
+  type MutableRefObject,
+} from 'react';
 import { useAppHost } from './use-app-host.js';
 import type { SSEClient } from '../core/sse-client.js';
 
@@ -33,8 +41,8 @@ export interface McpAppMetadata {
   sessionId: string;
 }
 
-interface McpAppRendererProps {
-  mcpClient: McpClient | null;
+/** Props for {@link useMcpApps}'s `McpAppRenderer` (client is supplied via the hook). */
+export interface McpAppRendererProps {
   name: string;
   input?: Record<string, unknown>;
   result?: unknown;
@@ -43,90 +51,68 @@ interface McpAppRendererProps {
   className?: string;
 }
 
-/**
- * Simplified MCP App renderer - users just pass tool name and data
- * Internal hook handles metadata lookup and SSE client retrieval
- */
-const McpAppRenderer = memo(function McpAppRenderer({
-  mcpClient,
+type McpAppViewProps = McpAppRendererProps & {
+  /**
+   * Ref avoids tying `McpAppRenderer` identity to `mcpClient`: when `connections` updates, `useMcp()` still
+   * returns a new object (correct for `useEffect` deps), but the iframe must not remount.
+   */
+  clientRef: MutableRefObject<McpClient | null>;
+};
+
+/** Renders one MCP App in a sandboxed iframe; reads the latest client from `clientRef` each render. */
+const McpAppView = memo(function McpAppView({
+  clientRef,
   name,
   input,
   result,
   status,
   className,
-}: McpAppRendererProps) {
-  const getAppMetadata = useCallback((): McpAppMetadata | undefined => {
-    if (!mcpClient) return undefined;
-
-    const extractedName = extractToolName(name);
-
-    for (const conn of mcpClient.connections) {
-      for (const tool of conn.tools) {
-        const candidateName = extractToolName(tool.name);
-        const resourceUri =
-          tool.mcpApp?.resourceUri ??
-          tool._meta?.ui?.resourceUri ??
-          tool._meta?.['ui/resourceUri'];
-
-        if (resourceUri && candidateName === extractedName) {
-          return {
-            toolName: candidateName,
-            resourceUri,
-            sessionId: conn.sessionId,
-          };
-        }
-      }
-    }
-
-    return undefined;
-  }, [mcpClient, name]);
-
-  const metadata = getAppMetadata();
+}: McpAppViewProps) {
+  const mcpClient = clientRef.current;
+  const metadata = getMcpAppMetadata(mcpClient, name);
   const sseClient = mcpClient?.sseClient ?? null;
+  const resourceUri = metadata?.resourceUri;
+  const appSessionId = metadata?.sessionId;
 
-  if (!metadata || !sseClient) {
-    return null;
-  }
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const { host, error: hostError } = useAppHost(sseClient as SSEClient, iframeRef);
   const [isLaunched, setIsLaunched] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
-  // Track which data has been sent to prevent duplicates
   const sentInputRef = useRef(false);
   const sentResultRef = useRef(false);
   const lastInputRef = useRef(input);
   const lastResultRef = useRef(result);
   const lastStatusRef = useRef(status);
 
-  // Launch the app when host is ready
   useEffect(() => {
-    if (!host || !metadata.resourceUri || !metadata.sessionId) return;
+    setIsLaunched(false);
+    setError(null);
+  }, [resourceUri, appSessionId]);
+
+  useEffect(() => {
+    if (!host || !resourceUri || !appSessionId) return;
 
     host
-      .launch(metadata.resourceUri, metadata.sessionId)
+      .launch(resourceUri, appSessionId)
       .then(() => setIsLaunched(true))
       .catch((err) => setError(err instanceof Error ? err : new Error(String(err))));
-  }, [host, metadata.resourceUri, metadata.sessionId]);
+  }, [host, resourceUri, appSessionId]);
 
-  // Send tool input when available or when it changes
   useEffect(() => {
-    if (!host || !isLaunched || !input) return;
-    
-    // Send if never sent, or if input changed
+    if (!host || !isLaunched || !resourceUri || !appSessionId || !input) return;
+
     if (!sentInputRef.current || JSON.stringify(input) !== JSON.stringify(lastInputRef.current)) {
       sentInputRef.current = true;
       lastInputRef.current = input;
       host.sendToolInput(input);
     }
-  }, [host, isLaunched, input]);
+  }, [host, isLaunched, input, resourceUri, appSessionId, name]);
 
-  // Send tool result when complete or when it changes
   useEffect(() => {
-    if (!host || !isLaunched || result === undefined) return;
+    if (!host || !isLaunched || !resourceUri || !appSessionId || result === undefined) return;
     if (status !== 'complete') return;
 
-    // Send if never sent, or if result changed
     if (!sentResultRef.current || JSON.stringify(result) !== JSON.stringify(lastResultRef.current)) {
       sentResultRef.current = true;
       lastResultRef.current = result;
@@ -136,9 +122,8 @@ const McpAppRenderer = memo(function McpAppRenderer({
           : result;
       host.sendToolResult(formattedResult);
     }
-  }, [host, isLaunched, result, status]);
+  }, [host, isLaunched, result, status, resourceUri, appSessionId, name]);
 
-  // Reset sent flags when tool status resets to executing (new tool call)
   useEffect(() => {
     if (status === 'executing' && lastStatusRef.current !== 'executing') {
       sentInputRef.current = false;
@@ -147,7 +132,10 @@ const McpAppRenderer = memo(function McpAppRenderer({
     lastStatusRef.current = status;
   }, [status]);
 
-  // Display errors
+  if (!metadata || !sseClient) {
+    return null;
+  }
+
   const displayError = error || hostError;
   if (displayError) {
     return (
@@ -176,72 +164,61 @@ const McpAppRenderer = memo(function McpAppRenderer({
 });
 
 /**
- * Simple hook to get MCP app metadata
+ * Helpers scoped to one `mcpClient`. Pass the client here once; `McpAppRenderer` only needs per-tool props (`name`, `input`, `result`, `status`).
  *
- * @param mcpClient - The MCP client from useMcp() or context
- * @returns Object with getAppMetadata function and McpAppRenderer component
- *
- * @example
- * ```tsx
- * function ToolRenderer(props) {
- *   const { getAppMetadata, McpAppRenderer } = useMcpApps(mcpClient);
- *   const metadata = getAppMetadata(props.name);
- *
- *   if (!metadata) return null;
- *   return (
- *     <McpAppRenderer
- *       metadata={metadata}
- *       input={props.args}
- *       result={props.result}
- *       status={props.status}
- *     />
- *   );
- * }
- * ```
+ * @param mcpClient - From `useMcp()` or context (for example `useMcpContext()`).
  */
 export function useMcpApps(mcpClient: McpClient | null) {
-  /**
-   * Get MCP app metadata for a tool name
-   * This is fast and can be called on every render
-   */
+  // Stable `McpAppRenderer` type: parent re-renders and `connections` updates must not remount the iframe.
+  const clientRef = useRef(mcpClient);
+  clientRef.current = mcpClient;
+
   const getAppMetadata = useCallback(
-    (toolName: string): McpAppMetadata | undefined => {
-      if (!mcpClient) return undefined;
-
-      const extractedName = extractToolName(toolName);
-
-      for (const conn of mcpClient.connections) {
-        for (const tool of conn.tools) {
-          const candidateName = extractToolName(tool.name);
-          // Check both locations: direct mcpApp or _meta.ui
-          const resourceUri =
-            tool.mcpApp?.resourceUri ??
-            tool._meta?.ui?.resourceUri ??
-            tool._meta?.['ui/resourceUri'];
-
-          if (resourceUri && candidateName === extractedName) {
-            return {
-              toolName: candidateName,
-              resourceUri,
-              sessionId: conn.sessionId,
-            };
-          }
-        }
-      }
-
-      return undefined;
-    },
-    [mcpClient]
+    (toolName: string) => getMcpAppMetadata(clientRef.current, toolName),
+    []
   );
+
+  const McpAppRenderer = useMemo(() => {
+    const Renderer = memo(function McpAppRenderer(props: McpAppRendererProps) {
+      return <McpAppView clientRef={clientRef} {...props} />;
+    });
+    Renderer.displayName = 'McpAppRenderer';
+    return Renderer;
+  }, []);
 
   return { getAppMetadata, McpAppRenderer };
 }
 
-/**
- * Extract the base tool name, removing any prefixes
- */
 function extractToolName(fullName: string): string {
-  // Handle patterns like "tool_abc123_get-time" -> "get-time"
   const match = fullName.match(/(?:tool_[^_]+_)?(.+)$/);
   return match?.[1] || fullName;
+}
+
+function getMcpAppMetadata(
+  mcpClient: McpClient | null,
+  toolName: string
+): McpAppMetadata | undefined {
+  if (!mcpClient) return undefined;
+
+  const extractedName = extractToolName(toolName);
+
+  for (const conn of mcpClient.connections) {
+    for (const tool of conn.tools) {
+      const candidateName = extractToolName(tool.name);
+      const resourceUri =
+        tool.mcpApp?.resourceUri ??
+        tool._meta?.ui?.resourceUri ??
+        tool._meta?.['ui/resourceUri'];
+
+      if (resourceUri && candidateName === extractedName) {
+        return {
+          toolName: candidateName,
+          resourceUri,
+          sessionId: conn.sessionId,
+        };
+      }
+    }
+  }
+
+  return undefined;
 }

--- a/src/client/react/use-mcp.ts
+++ b/src/client/react/use-mcp.ts
@@ -4,7 +4,7 @@
  * Based on Cloudflare's agents pattern
  */
 
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { SSEClient, type SSEClientOptions } from '../core/sse-client';
 import type { McpConnectionEvent, McpConnectionState } from '../../shared/events';
 import type {
@@ -227,6 +227,8 @@ export function useMcp(options: UseMcpOptions): McpClient {
     'disconnected'
   );
   const [isInitializing, setIsInitializing] = useState(false);
+  /** Mirrored from `clientRef` so the public `McpClient` object can be memoized when the instance is ready. */
+  const [sseClient, setSseClient] = useState<SSEClient | null>(null);
 
   /**
    * Initialize SSE client
@@ -258,6 +260,7 @@ export function useMcp(options: UseMcpOptions): McpClient {
 
     const client = new SSEClient(clientOptions);
     clientRef.current = client;
+    setSseClient(client);
 
     if (autoConnect) {
       client.connect();
@@ -615,27 +618,52 @@ export function useMcp(options: UseMcpOptions): McpClient {
     [getConnection]
   );
 
-  return {
-    connections,
-    status,
-    isInitializing,
-    connect,
-    disconnect,
-    getConnection,
-    getConnectionByServerId,
-    isServerConnected,
-    getTools,
-    refresh,
-    connectSSE,
-    disconnectSSE,
-    finishAuth,
-    resumeAuth,
-    callTool,
-    listTools,
-    listPrompts,
-    getPrompt,
-    listResources,
-    readResource,
-    sseClient: clientRef.current,
-  };
+  return useMemo(
+    () => ({
+      connections,
+      status,
+      isInitializing,
+      connect,
+      disconnect,
+      getConnection,
+      getConnectionByServerId,
+      isServerConnected,
+      getTools,
+      refresh,
+      connectSSE,
+      disconnectSSE,
+      finishAuth,
+      resumeAuth,
+      callTool,
+      listTools,
+      listPrompts,
+      getPrompt,
+      listResources,
+      readResource,
+      sseClient,
+    }),
+    [
+      connections,
+      status,
+      isInitializing,
+      connect,
+      disconnect,
+      getConnection,
+      getConnectionByServerId,
+      isServerConnected,
+      getTools,
+      refresh,
+      connectSSE,
+      disconnectSSE,
+      finishAuth,
+      resumeAuth,
+      callTool,
+      listTools,
+      listPrompts,
+      getPrompt,
+      listResources,
+      readResource,
+      sseClient,
+    ]
+  );
 }


### PR DESCRIPTION
## Summary
Stops MCP App iframes from remounting on every parent re-render and aligns `useMcp()` with stable client object identity when underlying state is unchanged.

## Changes
- **useMcpApps**: `McpAppRenderer` no longer takes a duplicate `mcpClient` prop; stable renderer via ref + `McpAppView`; shared `getMcpAppMetadata`; effect deps use primitives (`resourceUri`, `sessionId`) to avoid spurious runs.
- **useMcp**: Memoize returned `McpClient` object; mirror SSE instance in `sseClient` state so memo invalidates when the client attaches/detaches.
- **Docs & example**: README, api-reference, mcp-apps guide; agents `ToolRenderer` updated.
- **Exports**: `McpAppRendererProps` (and related types) from `@mcp-ts/sdk/client/react`.

## Testing
- `npm test` (Playwright): 111 passed, 1 skipped
- `npm run build`