### PR TITLE
feat: add reconnect method to React and Vue MCP client hooks

### DIFF
--- a/src/client/react/use-mcp.ts
+++ b/src/client/react/use-mcp.ts
@@ -119,6 +119,17 @@ export interface McpClient {
   disconnect: (sessionId: string) => Promise<void>;
 
   /**
+   * Reconnect to an MCP server (disconnects existing session first)
+   */
+  reconnect: (params: {
+    serverId: string;
+    serverName: string;
+    serverUrl: string;
+    callbackUrl: string;
+    transportType?: 'sse' | 'streamable_http';
+  }) => Promise<string>;
+
+  /**
    * Get connection by session ID
    */
   getConnection: (sessionId: string) => McpConnection | undefined;
@@ -467,6 +478,41 @@ export function useMcp(options: UseMcpOptions): McpClient {
   );
 
   /**
+   * Reconnect to an MCP server (tears down existing session, then connects fresh)
+   */
+  const reconnect = useCallback(
+    async (params: {
+      serverId: string;
+      serverName: string;
+      serverUrl: string;
+      callbackUrl: string;
+      transportType?: 'sse' | 'streamable_http';
+    }): Promise<string> => {
+      if (!clientRef.current) {
+        throw new Error('SSE client not initialized');
+      }
+
+      // Find and disconnect existing session for the same server
+      const existing = connections.find(
+        (c: McpConnection) => c.serverId === params.serverId || c.serverUrl === params.serverUrl
+      );
+      if (existing) {
+        await clientRef.current.disconnectFromServer(existing.sessionId);
+        if (isMountedRef.current) {
+          setConnections((prev: McpConnection[]) =>
+            prev.filter((c: McpConnection) => c.sessionId !== existing.sessionId)
+          );
+        }
+      }
+
+      // Connect fresh
+      const result = await clientRef.current.connectToServer(params);
+      return result.sessionId;
+    },
+    [connections]
+  );
+
+  /**
    * Disconnect from an MCP server
    */
   const disconnect = useCallback(async (sessionId: string): Promise<void> => {
@@ -635,6 +681,7 @@ export function useMcp(options: UseMcpOptions): McpClient {
       status,
       isInitializing,
       connect,
+      reconnect,
       disconnect,
       getConnection,
       getConnectionByServerId,
@@ -658,6 +705,7 @@ export function useMcp(options: UseMcpOptions): McpClient {
       status,
       isInitializing,
       connect,
+      reconnect,
       disconnect,
       getConnection,
       getConnectionByServerId,

--- a/src/client/vue/use-mcp.ts
+++ b/src/client/vue/use-mcp.ts
@@ -118,6 +118,17 @@ export interface McpClient {
     disconnect: (sessionId: string) => Promise<void>;
 
     /**
+     * Reconnect to an MCP server (disconnects existing session first)
+     */
+    reconnect: (params: {
+        serverId: string;
+        serverName: string;
+        serverUrl: string;
+        callbackUrl: string;
+        transportType?: 'sse' | 'streamable_http';
+    }) => Promise<string>;
+
+    /**
      * Get connection by session ID
      */
     getConnection: (sessionId: string) => McpConnection | undefined;
@@ -458,6 +469,36 @@ export function useMcp(options: UseMcpOptions): McpClient {
     };
 
     /**
+     * Reconnect to an MCP server (tears down existing session, then connects fresh)
+     */
+    const reconnect = async (params: {
+        serverId: string;
+        serverName: string;
+        serverUrl: string;
+        callbackUrl: string;
+        transportType?: 'sse' | 'streamable_http';
+    }): Promise<string> => {
+        if (!clientRef.value) {
+            throw new Error('SSE client not initialized');
+        }
+
+        // Find and disconnect existing session for the same server
+        const existing = connections.value.find(
+            (c) => c.serverId === params.serverId || c.serverUrl === params.serverUrl
+        );
+        if (existing) {
+            await clientRef.value.disconnectFromServer(existing.sessionId);
+            if (isMountedRef.value) {
+                connections.value = connections.value.filter((c) => c.sessionId !== existing.sessionId);
+            }
+        }
+
+        // Connect fresh
+        const result = await clientRef.value.connectToServer(params);
+        return result.sessionId;
+    };
+
+    /**
      * Disconnect from an MCP server
      */
     const disconnect = async (sessionId: string): Promise<void> => {
@@ -607,6 +648,7 @@ export function useMcp(options: UseMcpOptions): McpClient {
         status: status as unknown as { value: 'connecting' | 'connected' | 'disconnected' | 'error' },
         isInitializing: isInitializing as unknown as { value: boolean },
         connect,
+        reconnect,
         disconnect,
         getConnection,
         getConnectionByServerId,


### PR DESCRIPTION
## What is the type of this PR?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Which area of the project does this PR affect?

- [ ] `server` (MCP client, handlers)
- [x] `client` (React, Vue, SSE client)
- [ ] `adapters` (Vercel AI, LangChain, Mastra, AG-UI)
- [ ] `storage` (Redis, SQLite, File, Memory backends)
- [ ] `docs` (Docusaurus documentation)
- [ ] `examples` (Example applications)
- [ ] `ci` (GitHub workflows)
- [ ] Other

## Description of the change

This PR adds a `reconnect` method to both React and Vue `useMcp` hooks, providing a clean API for reconnecting to MCP servers with automatic cleanup of existing sessions.

### Key Features:
1. **Unified Reconnection API**: Single method for disconnecting and reconnecting
2. **Automatic Session Cleanup**: Finds and disconnects existing sessions before connecting fresh
3. **Framework Support**: Implemented for both React and Vue hooks
4. **Type Safety**: Full TypeScript support with proper interfaces

### Implementation Details:
- **React**: Added `reconnect` method to `useMcp` hook
- **Vue**: Added `reconnect` method to `useMcp` hook
- **Parameters**: Supports all connection parameters including optional transport type
- **Behavior**: Disconnects existing session → Removes from state → Connects fresh → Returns new session ID

### Usage Example (React):
```typescript
const { reconnect } = useMcp();

// Reconnect to a server
const newSessionId = await reconnect({
  serverId: 'github',
  serverName: 'GitHub',
  serverUrl: 'https://connect.composio.dev/mcp',
  callbackUrl: 'http://localhost:3000/callback',
  transportType: 'sse'
});
```

### Benefits:
- **Simplified State Management**: No need to manually track and clean up old sessions
- **Improved User Experience**: Single method call for reconnection scenarios
- **Consistent Behavior**: Same API across React and Vue frameworks
- **Error Prevention**: Prevents duplicate connections to the same server

## Is this a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] Code follows TypeScript strict mode guidelines
- [ ] Tests added/updated
- [ ] Documentation updated (if user-facing change)
- [ ] Build succeeds (`npm run build`)
- [ ] Type check passes (`npm run type-check`)
- [ ] All tests pass (`npm test`)
- [x] Commit messages follow conventional format

## Related Issue

<!-- If your PR fixes an open issue, link it here. -->

Closes #