### PR TITLE
feat: tool search enhancements (fast paths, required terms, scoring)

### DIFF
--- a/docs/core-concepts/meta-tools.md
+++ b/docs/core-concepts/meta-tools.md
@@ -11,10 +11,18 @@ These tools follow the "Tool Search" pattern, allowing the LLM to autonomously f
 ## The Meta-Tool Catalog
 
 ### `mcp_search_tool_bm25`
-The entry point for discovery. The LLM calls this with a natural language query to find tools.
+The primary entry point for discovery. The LLM calls this with a natural language query to find tools. The backend uses an in-memory BM25 index combined with smart heuristics to rank results.
 - **Input**: `query` (string), `limit` (number).
 - **Output**: A list of tool names, descriptions, and the servers they belong to.
-- **Usage**: "I need to query a database" → returns `sql_query`, `list_tables`, etc.
+
+#### Advanced Search Features
+The `mcp_search_tool_bm25` meta-tool supports a powerful query syntax that helps the AI zero in on exact capabilities without context bloat:
+
+- **Direct Tool Selection (`select:<name>`)**: If the AI already knows the exact tool it wants to use (e.g., from past context), it can bypass the BM25 index entirely.
+  - *Example*: `select:github_create_issue` returns the exact tool description instantly.
+- **Required Terms (`+term`)**: By prefixing a word with `+`, the AI strictly forces the index to *only* return tools that contain that word in their name or description.
+  - *Example*: `+slack send` guarantees that only tools belonging to Slack are returned, even if another tool uses the word "send" frequently.
+- **Enhanced Scoring Heuristics**: Behind the scenes, the BM25 index automatically grants massive score bonuses (+10 or +5 points) if a search term perfectly matches or is a substring of the MCP `serverName` or the tool `name`. This ensures that tools strictly related to a specific integration (e.g., querying for "neon" or "apify") always float above unrelated tools that merely mention the word in their parameters.
 
 ### `mcp_search_tool_regex`
 A precision tool for finding specific patterns in tool names or descriptions.

--- a/examples/next/app/agent/agent.ts
+++ b/examples/next/app/agent/agent.ts
@@ -2,6 +2,7 @@ import { ToolLoopAgent, InferAgentUIMessage, stepCountIs } from "ai";
 import { MultiSessionClient } from "@mcp-ts/sdk/server";
 import { AIAdapter } from "@mcp-ts/sdk/adapters/ai";
 import { createDeepSeek } from "@ai-sdk/deepseek";
+import { MCP_DEMO_IDENTITY } from "@/app/lib/mcp-identity";
 
 const { ToolRouter } = await import("@mcp-ts/sdk/shared");
 
@@ -9,19 +10,26 @@ const INSTRUCTIONS = `
 You are an expert assistant, an AI assistant that helps users with their tasks using the available MCP tools
 `;
 
-export async function createMcpAgent(identity: string = "demo-user-123") {
-  const client = new MultiSessionClient(identity);
+const globalForMcp = globalThis as unknown as { mcpClientMap?: Map<string, MultiSessionClient> };
 
-  try {
-    await client.connect();
-  } catch (error) {
-    console.error("[MCP] Connection failed:", error);
+export async function createMcpAgent(identity: string = MCP_DEMO_IDENTITY) {
+  let client = globalForMcp.mcpClientMap?.get(identity);
+
+  if (!client) {
+    client = new MultiSessionClient(identity);
+    try {
+      await client.connect();
+    } catch {}
+    
+    if (!globalForMcp.mcpClientMap) {
+      globalForMcp.mcpClientMap = new Map();
+    }
+    globalForMcp.mcpClientMap.set(identity, client);
   }
 
-  const router = new ToolRouter(client, { strategy: "search" });
+  const router = new ToolRouter(client, { strategy: "search", maxTools: 5 });
   const adapter = new AIAdapter(client, { toolRouter: router });
   const tools = await adapter.getTools();
-  console.log(`[MCP] Loaded ${Object.keys(tools).length} tools for agent.`);
 
   return new ToolLoopAgent({
     model: createDeepSeek({ apiKey: process.env.DEEPSEEK_API_KEY })(

--- a/examples/next/app/agent/agent.ts
+++ b/examples/next/app/agent/agent.ts
@@ -2,7 +2,6 @@ import { ToolLoopAgent, InferAgentUIMessage, stepCountIs } from "ai";
 import { MultiSessionClient } from "@mcp-ts/sdk/server";
 import { AIAdapter } from "@mcp-ts/sdk/adapters/ai";
 import { createDeepSeek } from "@ai-sdk/deepseek";
-import { MCP_DEMO_IDENTITY } from "@/app/lib/mcp-identity";
 
 const { ToolRouter } = await import("@mcp-ts/sdk/shared");
 
@@ -12,7 +11,7 @@ You are an expert assistant, an AI assistant that helps users with their tasks u
 
 const globalForMcp = globalThis as unknown as { mcpClientMap?: Map<string, MultiSessionClient> };
 
-export async function createMcpAgent(identity: string = MCP_DEMO_IDENTITY) {
+export async function createMcpAgent(identity: string = process.env.NEXT_PUBLIC_MCP_IDENTITY!) {
   let client = globalForMcp.mcpClientMap?.get(identity);
 
   if (!client) {

--- a/examples/next/app/agent/agent.ts
+++ b/examples/next/app/agent/agent.ts
@@ -18,12 +18,15 @@ export async function createMcpAgent(identity: string = process.env.NEXT_PUBLIC_
     client = new MultiSessionClient(identity);
     try {
       await client.connect();
-    } catch {}
-    
-    if (!globalForMcp.mcpClientMap) {
-      globalForMcp.mcpClientMap = new Map();
+      
+      if (!globalForMcp.mcpClientMap) {
+        globalForMcp.mcpClientMap = new Map();
+      }
+      globalForMcp.mcpClientMap.set(identity, client);
+    } catch (error) {
+      console.error("[McpAgent] Failed to connect MCP client:", error);
+      // We do not cache the client if connection fails, ensuring it is retried next time
     }
-    globalForMcp.mcpClientMap.set(identity, client);
   }
 
   const router = new ToolRouter(client, { strategy: "search", maxTools: 5 });

--- a/examples/next/app/api/chat/route.ts
+++ b/examples/next/app/api/chat/route.ts
@@ -1,10 +1,12 @@
 import { UIMessage, createAgentUIStreamResponse } from "ai";
-import { createMcpAgent } from "@/app/agent/agent";
+import { createMcpAgent } from "../agent/agent";
 
-export async function POST(req: Request) {
-  const { messages }: { messages: UIMessage[] } = await req.json();
+export const maxDuration = 60; // Max serverless function duration
 
-  const agent = await createMcpAgent("demo-user-123");
+export async function POST(request: Request) {
+  const { messages }: { messages: UIMessage[] } = await request.json();
+
+  const agent = await createMcpAgent(process.env.NEXT_PUBLIC_MCP_IDENTITY!);
 
   return createAgentUIStreamResponse({
     agent,

--- a/examples/next/app/api/mcp/route.ts
+++ b/examples/next/app/api/mcp/route.ts
@@ -3,8 +3,16 @@ import { createNextMcpHandler } from "@mcp-ts/sdk/server";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-export const { GET, POST } = createNextMcpHandler({
+const handler = createNextMcpHandler({
   clientDefaults: {
     clientName: "next-example",
   },
 });
+
+export async function GET(req: Request) {
+  return (handler.GET as (...args: unknown[]) => Promise<Response>)(req);
+}
+
+export async function POST(req: Request) {
+  return (handler.POST as (...args: unknown[]) => Promise<Response>)(req);
+}

--- a/examples/next/app/components/HomePage.tsx
+++ b/examples/next/app/components/HomePage.tsx
@@ -19,12 +19,9 @@ export default function HomePage() {
   // ── Single source of truth for the MCP client ──────────────────────────
   const mcpClient = useMcp({
     url: "/api/mcp",
-    identity: "demo-user-123",
+    identity: process.env.NEXT_PUBLIC_MCP_IDENTITY!,
     autoConnect: true,
     autoInitialize: true,
-    onLog: (level: string, message: string, metadata: any) => {
-      console.log(`[${level}] ${message}`, metadata);
-    },
     onRedirect: handleOAuthRedirect,
   });
 

--- a/examples/next/app/components/McpSidebar.tsx
+++ b/examples/next/app/components/McpSidebar.tsx
@@ -76,9 +76,7 @@ export default function McpSidebar({ mcpClient, onCollapse }: McpSidebarProps) {
   const handleDisconnect = async (sessionId: string) => {
     try {
       await disconnect(sessionId);
-    } catch (err) {
-      console.error("Failed to disconnect:", err);
-    }
+    } catch {}
   };
 
   const handleSelectTool = (sessionId: string, toolName: string) => {
@@ -92,7 +90,8 @@ export default function McpSidebar({ mcpClient, onCollapse }: McpSidebarProps) {
   ) => {
     try {
       const args = JSON.parse(toolArgs);
-      return await callTool(sessionId, toolName, args);
+      const result = await callTool(sessionId, toolName, args);
+      return result;
     } catch (err) {
       return {
         error: err instanceof Error ? err.message : "Tool execution failed",

--- a/examples/next/app/oauth/callback-popup/page.tsx
+++ b/examples/next/app/oauth/callback-popup/page.tsx
@@ -63,8 +63,7 @@ function PopupCallbackContent() {
         { type: AUTH_CODE_MESSAGE, code, sessionId },
         window.location.origin
       );
-    } catch (error) {
-      console.error("Failed to communicate with opener:", error);
+    } catch {
       window.setTimeout(() => {
         setStatus("error");
         setErrorMessage("Could not communicate with main window. Please close this window and try again.");

--- a/examples/next/app/oauth/callback/page.tsx
+++ b/examples/next/app/oauth/callback/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, Suspense } from "react";
+import { useEffect, useState, Suspense, useRef } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { useMcp } from "@mcp-ts/sdk/client/react";
 
@@ -11,16 +11,14 @@ function OAuthCallbackContent() {
     "processing",
   );
   const [error, setError] = useState<string | null>(null);
+  const processedRef = useRef(false);
 
   const { finishAuth } = useMcp({
     url: "/api/mcp",
-    identity: "demo-user-123",
+    identity: process.env.NEXT_PUBLIC_MCP_IDENTITY!,
     authToken: "demo-auth-token",
     autoConnect: true,
     autoInitialize: false,
-  });
-
-  useEffect(() => {
     const code = searchParams.get("code");
     const state = searchParams.get("state");
     const errorParam = searchParams.get("error");

--- a/examples/next/components/ai-elements/code-block.tsx
+++ b/examples/next/components/ai-elements/code-block.tsx
@@ -237,8 +237,7 @@ export const highlightCode = (
       }
     })
     // oxlint-disable-next-line eslint-plugin-promise(prefer-await-to-then), eslint-plugin-promise(prefer-await-to-callbacks)
-    .catch((error) => {
-      console.error("Failed to highlight code:", error);
+    .catch(() => {
       subscribers.delete(tokensCacheKey);
     });
 

--- a/examples/next/public/sandbox_proxy.html
+++ b/examples/next/public/sandbox_proxy.html
@@ -47,9 +47,7 @@
                 })
                 .join('; ');
             }
-          } catch (e) {
-            console.error('Failed to parse CSP query parameter:', e);
-          }
+          } catch (e) {}
         }
 
         function isDirectiveMap(obj) {
@@ -95,7 +93,6 @@
             doc.close();
             return true;
           } catch (err) {
-            console.error('Failed to write HTML into guest iframe:', err);
             return false;
           }
         }

--- a/src/adapters/agui-adapter.ts
+++ b/src/adapters/agui-adapter.ts
@@ -246,12 +246,12 @@ export class AguiAdapter {
         const filteredTools = await router.getFilteredTools();
 
         return filteredTools.map(tool => {
-            const routedTool = tool as typeof tool & { sessionId?: string; serverName?: string };
-            const namespace = routedTool.serverName ?? routedTool.sessionId;
+            const routedTool = tool as typeof tool & { sessionId?: string; serverId?: string; serverName?: string };
+            const namespace = routedTool.serverId ?? routedTool.sessionId;
             return {
                 name: isMetaTool(tool.name)
                     ? tool.name
-                    : this.getRouterToolKey(tool.name, routedTool.sessionId, routedTool.serverName),
+                    : this.getRouterToolKey(tool.name, routedTool.sessionId, routedTool.serverId),
                 description: tool.description || `Execute ${tool.name}`,
                 parameters: cleanSchema(tool.inputSchema),
                 handler: async (args: any) => {
@@ -279,19 +279,19 @@ export class AguiAdapter {
     private async getToolDefinitionsViaRouter(router: ToolRouter): Promise<AguiToolDefinition[]> {
         const filteredTools = await router.getFilteredTools();
         return filteredTools.map(tool => {
-            const routedTool = tool as typeof tool & { sessionId?: string; serverName?: string };
+            const routedTool = tool as typeof tool & { sessionId?: string; serverId?: string; serverName?: string };
             return {
                 name: isMetaTool(tool.name)
                     ? tool.name
-                    : this.getRouterToolKey(tool.name, routedTool.sessionId, routedTool.serverName),
+                    : this.getRouterToolKey(tool.name, routedTool.sessionId, routedTool.serverId),
                 description: tool.description || `Execute ${tool.name}`,
                 parameters: cleanSchema(tool.inputSchema)
             };
         });
     }
 
-    private getRouterToolKey(toolName: string, sessionId?: string, serverName?: string): string {
-        const namespace = sessionId ?? serverName ?? 'mcp';
+    private getRouterToolKey(toolName: string, sessionId?: string, serverId?: string): string {
+        const namespace = sessionId ?? serverId ?? 'mcp';
         const normalized = namespace
             .toLowerCase()
             .replace(/[^a-z0-9]+/g, '_')

--- a/src/adapters/ai-adapter.ts
+++ b/src/adapters/ai-adapter.ts
@@ -137,11 +137,11 @@ export class AIAdapter {
         // @ts-ignore: ToolSet type inference can be tricky with dynamic imports
         return Object.fromEntries(
             filteredTools.map((tool) => {
-                const routedTool = tool as typeof tool & { sessionId?: string; serverName?: string };
-                const namespace = routedTool.serverName ?? routedTool.sessionId;
+                const routedTool = tool as typeof tool & { sessionId?: string; serverId?: string; serverName?: string };
+                const namespace = routedTool.serverId ?? routedTool.sessionId;
                 const toolKey = isMetaTool(tool.name)
                     ? tool.name
-                    : this.getRouterToolKey(tool.name, routedTool.sessionId, routedTool.serverName);
+                    : this.getRouterToolKey(tool.name, routedTool.sessionId, routedTool.serverId);
 
                 return [
                     toolKey,
@@ -172,8 +172,8 @@ export class AIAdapter {
         );
     }
 
-    private getRouterToolKey(toolName: string, sessionId?: string, serverName?: string): string {
-        const namespace = sessionId ?? serverName ?? 'mcp';
+    private getRouterToolKey(toolName: string, sessionId?: string, serverId?: string): string {
+        const namespace = sessionId ?? serverId ?? 'mcp';
         const normalized = namespace
             .toLowerCase()
             .replace(/[^a-z0-9]+/g, '_')

--- a/src/adapters/langchain-adapter.ts
+++ b/src/adapters/langchain-adapter.ts
@@ -144,14 +144,14 @@ export class LangChainAdapter {
         const filteredTools = await router.getFilteredTools();
 
         return filteredTools.map((tool) => {
-            const routedTool = tool as typeof tool & { sessionId?: string; serverName?: string };
-            const namespace = routedTool.serverName ?? routedTool.sessionId;
+            const routedTool = tool as typeof tool & { sessionId?: string; serverId?: string; serverName?: string };
+            const namespace = routedTool.serverId ?? routedTool.sessionId;
             const schema = this.jsonSchemaToZod(tool.inputSchema);
 
             return new this.DynamicStructuredTool!({
                 name: isMetaTool(tool.name)
                     ? tool.name
-                    : this.getRouterToolKey(tool.name, routedTool.sessionId, routedTool.serverName),
+                    : this.getRouterToolKey(tool.name, routedTool.sessionId, routedTool.serverId),
                 description: tool.description || `Tool ${tool.name}`,
                 schema: schema,
                 func: async (args: any) => {
@@ -183,8 +183,8 @@ export class LangChainAdapter {
         });
     }
 
-    private getRouterToolKey(toolName: string, sessionId?: string, serverName?: string): string {
-        const namespace = sessionId ?? serverName ?? 'mcp';
+    private getRouterToolKey(toolName: string, sessionId?: string, serverId?: string): string {
+        const namespace = sessionId ?? serverId ?? 'mcp';
         const normalized = namespace
             .toLowerCase()
             .replace(/[^a-z0-9]+/g, '_')

--- a/src/shared/meta-tools.ts
+++ b/src/shared/meta-tools.ts
@@ -222,7 +222,8 @@ export async function executeMetaTool(
         for (const requestedToolName of requested) {
           const { tool, error } = resolveToolSchema(requestedToolName);
           if (error) {
-            errors.push(`- **${requestedToolName}**: ${error}`);
+            const errorMsg = error.content[0]?.type === 'text' ? error.content[0].text : 'Unknown error';
+            errors.push(`- **${requestedToolName}**: ${errorMsg}`);
           } else if (tool) {
             found.push(tool);
           }
@@ -232,7 +233,7 @@ export async function executeMetaTool(
 
         if (found.length > 0) {
           lines.push(...found.map((t, i) =>
-            `${i + 1}. **${t.name}** (server: ${t.serverName || t.serverId})\n   ${t.description}`
+            `${i + 1}. **${t.name}** (server: ${t.serverName}, serverId: ${t.serverId})\n   ${t.description}`
           ));
         }
         

--- a/src/shared/meta-tools.ts
+++ b/src/shared/meta-tools.ts
@@ -33,16 +33,18 @@ export function createSearchToolDefinition(): Tool {
   return {
     name: 'mcp_search_tool_bm25',
     description:
-      'Search the catalog of available tools using BM25 natural language ranking. ' +
-      'Returns tool names, descriptions, and server info. ' +
-      'Use this FIRST to find relevant tools before calling them. ' +
-      'Example queries: "database query", "send email", "github pull request".',
+      'Search the catalog of available tools. Returns tool names, descriptions, and server info. ' +
+      'Use this FIRST to find relevant tools before calling them.\n\n' +
+      'Query forms:\n' +
+      '- "select:Read,Edit,Grep" — fetch these exact tools by name\n' +
+      '- "notebook jupyter" — keyword search, up to limit best matches\n' +
+      '- "+slack send" — require "slack" in the name, rank by remaining terms',
     inputSchema: {
       type: 'object' as const,
       properties: {
         query: {
           type: 'string',
-          description: 'Natural language description of the capability you need.',
+          description: 'Query to find tools. Use "select:<tool_name>" for direct selection, or keywords to search. Prefix keywords with + to require them.',
         },
         limit: {
           type: 'number',
@@ -205,6 +207,36 @@ export async function executeMetaTool(
     case 'mcp_search_tool_bm25': {
       const query = String(args.query ?? '');
       const limit = Math.min(Number(args.limit) || 5, 20);
+
+      // Fast path: Check for select: prefix
+      const selectMatch = query.match(/^select:(.+)$/i);
+      if (selectMatch) {
+        const requested = selectMatch[1]!
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+
+        const found: any[] = [];
+        for (const toolName of requested) {
+          const { tool } = resolveToolSchema(toolName);
+          if (tool) found.push(tool);
+        }
+
+        const text = found.length === 0
+          ? `No tools found matching select query: ${requested.join(', ')}`
+          : found
+              .map(
+                (t, i) =>
+                  `${i + 1}. **${t.name}** (server: ${t.serverName || t.serverId})\n` +
+                  `   ${t.description}`
+              )
+              .join('\n');
+
+        return {
+          content: [{ type: 'text', text }],
+          isError: false,
+        };
+      }
 
       const results = await router.searchTools(query, limit);
 

--- a/src/shared/meta-tools.ts
+++ b/src/shared/meta-tools.ts
@@ -217,20 +217,34 @@ export async function executeMetaTool(
           .filter(Boolean);
 
         const found: any[] = [];
-        for (const toolName of requested) {
-          const { tool } = resolveToolSchema(toolName);
-          if (tool) found.push(tool);
+        const errors: string[] = [];
+        
+        for (const requestedToolName of requested) {
+          const { tool, error } = resolveToolSchema(requestedToolName);
+          if (error) {
+            errors.push(`- **${requestedToolName}**: ${error}`);
+          } else if (tool) {
+            found.push(tool);
+          }
         }
 
-        const text = found.length === 0
-          ? `No tools found matching select query: ${requested.join(', ')}`
-          : found
-              .map(
-                (t, i) =>
-                  `${i + 1}. **${t.name}** (server: ${t.serverName || t.serverId})\n` +
-                  `   ${t.description}`
-              )
-              .join('\n');
+        const lines: string[] = [];
+
+        if (found.length > 0) {
+          lines.push(...found.map((t, i) =>
+            `${i + 1}. **${t.name}** (server: ${t.serverName || t.serverId})\n   ${t.description}`
+          ));
+        }
+        
+        if (errors.length > 0) {
+          if (lines.length > 0) lines.push(""); // Add empty line spacing
+          lines.push("Errors resolving some tools:");
+          lines.push(...errors);
+        }
+
+        const text = lines.length > 0 
+          ? lines.join('\n') 
+          : `No tools found matching select query: ${requested.join(', ')}`;
 
         return {
           content: [{ type: 'text', text }],

--- a/src/shared/meta-tools.ts
+++ b/src/shared/meta-tools.ts
@@ -226,6 +226,8 @@ export async function executeMetaTool(
             errors.push(`- **${requestedToolName}**: ${errorMsg}`);
           } else if (tool) {
             found.push(tool);
+          } else {
+            errors.push(`- **${requestedToolName}**: Tool not found. Try searching with mcp_search_tool_bm25.`);
           }
         }
 

--- a/src/shared/meta-tools.ts
+++ b/src/shared/meta-tools.ts
@@ -105,10 +105,10 @@ export function createGetSchemaToolDefinition(): Tool {
           type: 'string',
           description: 'The exact tool name returned by mcp_search_tool_bm25.',
         },
-        serverName: {
+        serverId: {
           type: 'string',
           description:
-            'Optional: The server name provided in mcp_search_tool_bm25. Required if multiple tools have the same name.',
+            'Optional: The server ID provided in mcp_search_tool_bm25. Required if multiple tools have the same name.',
         },
       },
       required: ['toolName'],
@@ -141,10 +141,10 @@ export function createExecuteToolDefinition(): Tool {
           type: 'string',
           description: 'The exact tool name from mcp_search_tool_bm25 results.',
         },
-        serverName: {
+        serverId: {
           type: 'string',
           description:
-            'Optional: The server name provided in mcp_search_tool_bm25. Required if multiple tools have the same name.',
+            'Optional: The server ID provided in mcp_search_tool_bm25. Required if multiple tools have the same name.',
         },
         args: {
           type: 'object',
@@ -213,7 +213,7 @@ export async function executeMetaTool(
         : results
             .map(
               (t, i) =>
-                `${i + 1}. **${t.name}** (server: ${t.serverName})\n` +
+                `${i + 1}. **${t.name}** (server: ${t.serverName}, serverId: ${t.serverId})\n` +
                 `   ${t.description}\n` +
                 `   Estimated tokens: ${t.estimatedTokens}`
             )
@@ -236,7 +236,7 @@ export async function executeMetaTool(
         : results
             .map(
               (t, i) =>
-                `${i + 1}. **${t.name}** (server: ${t.serverName})\n` +
+                `${i + 1}. **${t.name}** (server: ${t.serverName}, serverId: ${t.serverId})\n` +
                 `   ${t.description}\n` +
                 `   Estimated tokens: ${t.estimatedTokens}`
             )
@@ -250,7 +250,7 @@ export async function executeMetaTool(
 
     case 'mcp_get_tool_schema': {
       const name = String(args.toolName ?? '');
-      const namespace = String(args.serverName ?? '') || undefined;
+      const namespace = String(args.serverId ?? '') || undefined;
       const { tool, error } = resolveToolSchema(name, namespace);
 
       if (error) {
@@ -283,7 +283,7 @@ export async function executeMetaTool(
 
     case 'mcp_execute_tool': {
       const targetToolName = String(args.toolName ?? '');
-      const namespace = String(args.serverName ?? '') || undefined;
+      const namespace = String(args.serverId ?? '') || undefined;
       const toolArgs = (args.args as Record<string, unknown>) ?? {};
 
       if (!targetToolName) {

--- a/src/shared/tool-index.ts
+++ b/src/shared/tool-index.ts
@@ -264,11 +264,12 @@ export class ToolIndex {
 
     const queryLower = query.toLowerCase().trim();
 
-    // Fast path: Exact tool name match
-    for (const [docKey, summary] of this.toolSummaries) {
-      if (summary.name.toLowerCase() === queryLower) {
-        return [summary];
-      }
+    // Fast path: Exact tool name match (supports duplicate names across servers)
+    const exactMatches = [...this.toolSummaries.values()].filter(
+      (summary) => summary.name.toLowerCase() === queryLower
+    );
+    if (exactMatches.length > 0) {
+      return exactMatches.slice(0, topK);
     }
 
     // Fast path: MCP prefix match (e.g. "mcp__github")

--- a/src/shared/tool-index.ts
+++ b/src/shared/tool-index.ts
@@ -262,8 +262,38 @@ export class ToolIndex {
   async search(query: string, topK = 5): Promise<ToolSummary[]> {
     if (this.tools.size === 0) return [];
 
-    const queryLower = query.toLowerCase();
-    const queryTokens = this.tokenize(queryLower);
+    const queryLower = query.toLowerCase().trim();
+
+    // Fast path: Exact tool name match
+    for (const [docKey, summary] of this.toolSummaries) {
+      if (summary.name.toLowerCase() === queryLower) {
+        return [summary];
+      }
+    }
+
+    // Fast path: MCP prefix match (e.g. "mcp__github")
+    if (queryLower.startsWith('mcp__') && queryLower.length > 5) {
+      const prefixMatches = [...this.toolSummaries.values()]
+        .filter((t) => t.name.toLowerCase().startsWith(queryLower))
+        .slice(0, topK);
+      if (prefixMatches.length > 0) return prefixMatches;
+    }
+
+    const queryTermsRaw = queryLower.split(/\s+/).filter((t) => t.length > 0);
+    const requiredTerms: string[] = [];
+    const optionalTerms: string[] = [];
+
+    for (const term of queryTermsRaw) {
+      if (term.startsWith('+') && term.length > 1) {
+        requiredTerms.push(term.slice(1));
+      } else {
+        optionalTerms.push(term);
+      }
+    }
+
+    const allScoringTerms =
+      requiredTerms.length > 0 ? [...requiredTerms, ...optionalTerms] : queryTermsRaw;
+    const queryTokens = this.tokenize(allScoringTerms.join(' '));
 
     // 1. Keyword scores (BM25)
     const keywordScores = new Map<string, number>();
@@ -272,6 +302,19 @@ export class ToolIndex {
     const b = 0.75;
 
     for (const [docKey, docTf] of this.tfVectors) {
+      const summary = this.toolSummaries.get(docKey);
+      if (!summary) continue;
+
+      // Pre-filter: must contain all required terms in search text or tool name
+      if (requiredTerms.length > 0) {
+        const text = this.searchTexts.get(docKey) || '';
+        const nameLower = summary.name.toLowerCase();
+        const matchesAll = requiredTerms.every(
+          (term) => text.includes(term) || nameLower.includes(term)
+        );
+        if (!matchesAll) continue;
+      }
+
       let score = 0;
       const docLen = this.docLengths.get(docKey) ?? 0;
 
@@ -285,8 +328,20 @@ export class ToolIndex {
         // score = idf * (tf * (k1 + 1)) / (tf + k1 * (1 - b + b * (docLen / avgDocLength)))
         const numerator = tfVal * (k1 + 1);
         const denominator = tfVal + k1 * (1 - b + b * (docLen / this.avgDocLength));
-        
+
         score += idf * (numerator / denominator);
+      }
+
+      // Enhanced Heuristics Scoring
+      for (const term of allScoringTerms) {
+        const nameLower = summary.name.toLowerCase();
+        const serverLower = summary.serverName.toLowerCase();
+
+        if (nameLower === term || serverLower === term) {
+          score += 10;
+        } else if (nameLower.includes(term) || serverLower.includes(term)) {
+          score += 5;
+        }
       }
 
       keywordScores.set(docKey, score);

--- a/src/shared/tool-index.ts
+++ b/src/shared/tool-index.ts
@@ -295,25 +295,32 @@ export class ToolIndex {
       requiredTerms.length > 0 ? [...requiredTerms, ...optionalTerms] : queryTermsRaw;
     const queryTokens = this.tokenize(allScoringTerms.join(' '));
 
-    // 1. Keyword scores (BM25)
-    const keywordScores = new Map<string, number>();
-
-    const k1 = 1.2;
-    const b = 0.75;
-
-    for (const [docKey, docTf] of this.tfVectors) {
-      const summary = this.toolSummaries.get(docKey);
-      if (!summary) continue;
-
-      // Pre-filter: must contain all required terms in search text or tool name
+    // Pre-filter: only keep documents that contain ALL required terms
+    const candidateKeys = new Set<string>();
+    for (const docKey of this.toolSummaries.keys()) {
       if (requiredTerms.length > 0) {
         const text = this.searchTexts.get(docKey) || '';
+        const summary = this.toolSummaries.get(docKey)!;
         const nameLower = summary.name.toLowerCase();
         const matchesAll = requiredTerms.every(
           (term) => text.includes(term) || nameLower.includes(term)
         );
         if (!matchesAll) continue;
       }
+      candidateKeys.add(docKey);
+    }
+
+    // 1. Keyword scores (BM25)
+    const keywordScores = new Map<string, number>();
+
+    const k1 = 1.2;
+    const b = 0.75;
+
+    for (const docKey of candidateKeys) {
+      const docTf = this.tfVectors.get(docKey);
+      if (!docTf) continue;
+      
+      const summary = this.toolSummaries.get(docKey)!;
 
       let score = 0;
       const docLen = this.docLengths.get(docKey) ?? 0;
@@ -323,7 +330,6 @@ export class ToolIndex {
         if (tfVal === 0) continue;
 
         const idf = this.idf.get(tok) ?? 0;
-
         // BM25 formula:
         // score = idf * (tf * (k1 + 1)) / (tf + k1 * (1 - b + b * (docLen / avgDocLength)))
         const numerator = tfVal * (k1 + 1);
@@ -332,19 +338,22 @@ export class ToolIndex {
         score += idf * (numerator / denominator);
       }
 
-      // Enhanced Heuristics Scoring
-      for (const term of allScoringTerms) {
-        const nameLower = summary.name.toLowerCase();
-        const serverLower = summary.serverName.toLowerCase();
+      // Name heuristics: give massive boosts for exact server/tool name matches
+      const serverLower = (summary.serverName || summary.serverId || '').toLowerCase();
+      const toolLower = summary.name.toLowerCase();
 
-        if (nameLower === term || serverLower === term) {
+      for (const term of allScoringTerms) {
+        if (serverLower.includes(term)) {
           score += 10;
-        } else if (nameLower.includes(term) || serverLower.includes(term)) {
+        }
+        if (toolLower.includes(term)) {
           score += 5;
         }
       }
 
-      keywordScores.set(docKey, score);
+      if (score > 0) {
+        keywordScores.set(docKey, score);
+      }
     }
 
     // 2. Embedding scores (optional)
@@ -355,8 +364,11 @@ export class ToolIndex {
         const [queryEmbedding] = await this.options.embedFn([queryLower]);
         if (queryEmbedding) {
           embeddingScores = new Map();
-          for (const [docKey, vec] of this.embeddings) {
-            embeddingScores.set(docKey, this.cosineSimilarity(queryEmbedding, vec));
+          for (const docKey of candidateKeys) {
+            const vec = this.embeddings.get(docKey);
+            if (vec) {
+              embeddingScores.set(docKey, this.cosineSimilarity(queryEmbedding, vec));
+            }
           }
         }
       } catch {
@@ -368,7 +380,7 @@ export class ToolIndex {
     const kw = this.options.keywordWeight;
     const finalScores: Array<{ docKey: string; score: number }> = [];
 
-    for (const docKey of this.toolSummaries.keys()) {
+    for (const docKey of candidateKeys) {
       const kwScore = keywordScores.get(docKey) ?? 0;
       const embScore = embeddingScores?.get(docKey) ?? 0;
 

--- a/src/shared/tool-index.ts
+++ b/src/shared/tool-index.ts
@@ -293,6 +293,7 @@ export class ToolIndex {
 
     const allScoringTerms =
       requiredTerms.length > 0 ? [...requiredTerms, ...optionalTerms] : queryTermsRaw;
+    const normalizedQueryText = allScoringTerms.join(' ').trim();
     const queryTokens = this.tokenize(allScoringTerms.join(' '));
 
     // Pre-filter: only keep documents that contain ALL required terms
@@ -361,7 +362,7 @@ export class ToolIndex {
 
     if (this.options.embedFn && this.embeddings.size > 0) {
       try {
-        const [queryEmbedding] = await this.options.embedFn([queryLower]);
+        const [queryEmbedding] = await this.options.embedFn([normalizedQueryText]);
         if (queryEmbedding) {
           embeddingScores = new Map();
           for (const docKey of candidateKeys) {

--- a/src/shared/tool-index.ts
+++ b/src/shared/tool-index.ts
@@ -24,6 +24,8 @@ export interface ToolSummary {
   description: string;
   /** Server that owns this tool */
   serverName: string;
+  /** Unique ID of the server */
+  serverId: string;
   /** Session the tool belongs to */
   sessionId: string;
   /** Estimated token cost of the full inputSchema */
@@ -33,6 +35,7 @@ export interface ToolSummary {
 /** A tool with routing metadata attached during indexing. */
 export interface IndexedTool extends Tool {
   sessionId: string;
+  serverId: string;
   serverName: string;
 }
 
@@ -177,6 +180,7 @@ export class ToolIndex {
         name: tool.name,
         description: tool.description ?? '',
         serverName: tool.serverName,
+        serverId: tool.serverId,
         sessionId: tool.sessionId,
         estimatedTokens,
       });
@@ -389,7 +393,7 @@ export class ToolIndex {
     const list = this.tools.get(name) ?? [];
     if (!namespace) return list;
 
-    return list.filter((t) => t.sessionId === namespace || t.serverName === namespace);
+    return list.filter((t) => t.sessionId === namespace || t.serverId === namespace);
   }
 
   /** All indexed tool names. */
@@ -463,7 +467,7 @@ export class ToolIndex {
   }
 
   private getDocumentKey(tool: IndexedTool): string {
-    return `${tool.sessionId}::${tool.serverName}::${tool.name}`;
+    return `${tool.sessionId}::${tool.serverId}::${tool.name}`;
   }
 
   /** Simple whitespace + camelCase + snake_case tokenizer. */

--- a/src/shared/tool-router.ts
+++ b/src/shared/tool-router.ts
@@ -219,10 +219,10 @@ export class ToolRouter {
     if (matches.length === 0) return undefined;
 
     if (matches.length > 1) {
-      const servers = matches.map((m) => m.serverName).join(', ');
+      const servers = matches.map((m) => m.serverId).join(', ');
       throw new Error(
         `Tool "${toolName}" is provided by multiple servers: [${servers}]. ` +
-          `Please specify the desired "serverName" as a namespace.`
+          `Please specify the desired "serverId" as a namespace.`
       );
     }
 
@@ -372,6 +372,7 @@ export class ToolRouter {
         for (const tool of tools) {
           result.push({
             ...tool,
+            serverId,
             serverName: serverName,
             sessionId,
           });
@@ -409,20 +410,20 @@ export class ToolRouter {
         });
       }
     } else {
-      // Auto-group by server name
+      // Auto-group by server ID
       const serverTools = new Map<string, string[]>();
       for (const tool of this.allTools) {
-        const group = tool.serverName;
+        const group = tool.serverId;
         if (!serverTools.has(group)) {
           serverTools.set(group, []);
         }
         serverTools.get(group)!.push(tool.name);
       }
 
-      for (const [serverName, tools] of serverTools) {
-        this.groupsMap.set(serverName, {
+      for (const [serverId, tools] of serverTools) {
+        this.groupsMap.set(serverId, {
           tools,
-          active: this.activeGroups.size === 0 || this.activeGroups.has(serverName),
+          active: this.activeGroups.size === 0 || this.activeGroups.has(serverId),
         });
       }
     }

--- a/tests/tool-index.test.ts
+++ b/tests/tool-index.test.ts
@@ -40,6 +40,7 @@ test.describe('ToolIndex', () => {
                 inputSchema: { type: 'object', properties: {} },
                 serverName: 'GitHub',
                 sessionId: 'github-session',
+                serverId: 'github-server',
             },
             {
                 name: 'search',
@@ -47,6 +48,7 @@ test.describe('ToolIndex', () => {
                 inputSchema: { type: 'object', properties: {} },
                 serverName: 'Slack',
                 sessionId: 'slack-session',
+                serverId: 'slack-server',
             },
         ];
 
@@ -56,7 +58,9 @@ test.describe('ToolIndex', () => {
         const slackResults = await index.search('slack channels', 2);
 
         expect(githubResults[0].serverName).toBe('GitHub');
+        expect(githubResults[0].serverId).toBe('github-server');
         expect(slackResults[0].serverName).toBe('Slack');
+        expect(slackResults[0].serverId).toBe('slack-server');
         expect(index.getTool('search')).toHaveLength(2);
         expect(githubResults[0].estimatedTokens).toBeGreaterThan(0);
         expect(index.getTotalTokenCost()).toBe(
@@ -81,6 +85,7 @@ test.describe('ToolIndex', () => {
                 inputSchema: { type: 'object', properties: {} },
                 serverName: 'Slack',
                 sessionId: 'slack-session',
+                serverId: 'slack-server',
             },
             {
                 name: 'create_pr',
@@ -88,12 +93,14 @@ test.describe('ToolIndex', () => {
                 inputSchema: { type: 'object', properties: {} },
                 serverName: 'GitHub',
                 sessionId: 'github-session',
+                serverId: 'github-server',
             },
         ];
 
         await index.buildIndex(tools);
-        await index.search('+slack send', 5);
+        const results = await index.search('+slack send', 5);
 
         expect(embeddingQueryText).toBe('slack send');
+        expect(results[0].serverId).toBe('slack-server');
     });
 });

--- a/tests/tool-index.test.ts
+++ b/tests/tool-index.test.ts
@@ -34,4 +34,37 @@ test.describe('ToolIndex', () => {
             githubResults[0].estimatedTokens + slackResults[0].estimatedTokens
         );
     });
+
+    test('should strip required-term prefixes before embedding query text', async () => {
+        let embeddingQueryText: string | null = null;
+        const embedFn = async (texts: string[]): Promise<number[][]> => {
+            if (texts.length === 1) {
+                embeddingQueryText = texts[0];
+            }
+            return texts.map((text) => [text.length, 1]);
+        };
+
+        const index = new ToolIndex({ embedFn });
+        const tools: IndexedTool[] = [
+            {
+                name: 'send_message',
+                description: 'Send Slack messages',
+                inputSchema: { type: 'object', properties: {} },
+                serverName: 'Slack',
+                sessionId: 'slack-session',
+            },
+            {
+                name: 'create_pr',
+                description: 'Create GitHub pull requests',
+                inputSchema: { type: 'object', properties: {} },
+                serverName: 'GitHub',
+                sessionId: 'github-session',
+            },
+        ];
+
+        await index.buildIndex(tools);
+        await index.search('+slack send', 5);
+
+        expect(embeddingQueryText).toBe('slack send');
+    });
 });

--- a/tests/tool-index.test.ts
+++ b/tests/tool-index.test.ts
@@ -2,6 +2,35 @@ import { test, expect } from '@playwright/test';
 import { ToolIndex, type IndexedTool } from '../src/shared/tool-index';
 
 test.describe('ToolIndex', () => {
+    test('should return all exact name matches up to topK across servers', async () => {
+        const index = new ToolIndex();
+        const tools: IndexedTool[] = [
+            {
+                name: 'search',
+                description: 'Search GitHub pull requests and repositories',
+                inputSchema: { type: 'object', properties: {} },
+                serverName: 'GitHub',
+                sessionId: 'github-session',
+                serverId: 'github-server',
+            },
+            {
+                name: 'search',
+                description: 'Search Slack messages and channels',
+                inputSchema: { type: 'object', properties: {} },
+                serverName: 'Slack',
+                sessionId: 'slack-session',
+                serverId: 'slack-server',
+            },
+        ];
+
+        await index.buildIndex(tools);
+
+        const exactResults = await index.search('search', 2);
+
+        expect(exactResults).toHaveLength(2);
+        expect(exactResults.map((r) => r.serverName).sort()).toEqual(['GitHub', 'Slack']);
+    });
+
     test('should keep duplicate tool names searchable per indexed instance', async () => {
         const index = new ToolIndex();
         const tools: IndexedTool[] = [


### PR DESCRIPTION
This PR introduces advanced tool search capabilities to the `ToolRouter` and BM25 index, mirroring the functionality found in Claude Code. It also completes the migration to use deterministic server identifiers.

### Changes Made
- **Tool Routing Identifier Update**: Switched `ToolRouter` to use `serverId` instead of `serverName` for `getToolSchema` and tool execution routing, ensuring conflict-free routing when multiple identical servers are connected.
- **Direct Tool Selection (`select:`)**: Bypasses BM25 search entirely for precise tool retrieval.
- **Required Terms (`+term`)**: Enforces strict filtering in the search index for required keywords.
- **Enhanced BM25 Scoring**: Adds `+10` and `+5` score boosts for matching `serverName` and tool `name`, significantly improving the ranking of integration-specific tools (like Apify or Neon).
- **Global Connection Caching**: Fixes Next.js serverless connection looping by persisting `MultiSessionClient` globally across API route requests in `agent.ts`.
- **Documentation**: Updated `docs/core-concepts/meta-tools.md` to formally document these Advanced Search Features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core tool discovery and routing by switching namespaces from `serverName` to deterministic `serverId` and adding new BM25 query fast paths/heuristics, which could affect tool resolution and ranking across multi-server setups.
> 
> **Overview**
> **Improves tool discovery in `search` strategy** by expanding `mcp_search_tool_bm25` with `select:` direct tool resolution, `+term` required-term filtering, and stronger ranking boosts when query terms match a tool name or server identifier; search results now include `serverId`.
> 
> **Migrates routing/ambiguity handling to `serverId`** across `ToolRouter`, `ToolIndex`, meta-tools, and adapters (AI/LangChain/AG-UI), including updated namespace keys and error messages, plus new tests covering exact-match behavior and embedding-query normalization.
> 
> **Updates the Next.js example** to cache `MultiSessionClient` instances globally per identity, wire identity from `NEXT_PUBLIC_MCP_IDENTITY`, cap router exposure via `maxTools: 5`, and makes minor API/UX robustness tweaks (serverless duration export, handler wrappers, quieter catch blocks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 282bae1d1cccfe131e1baceaaebe2870964f5490. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->