### PR TITLE
Fix AG-UI continuation tool-call args JSON normalization (LangGraph crash)

### DIFF
--- a/src/adapters/agui-middleware.ts
+++ b/src/adapters/agui-middleware.ts
@@ -95,6 +95,10 @@ export class McpMiddleware extends Middleware {
         }
     }
 
+    private normalizeArgsString(argsString: string): string {
+        return JSON.stringify(this.parseArgs(argsString));
+    }
+
     private async executeTool(toolName: string, args: Record<string, any>): Promise<string> {
         const tool = this.tools.find(t => t.name === toolName);
         if (!tool?.handler) {
@@ -376,7 +380,7 @@ export class McpMiddleware extends Middleware {
                 const toolCalls = [];
                 for (const toolCallId of state.pendingMcpCalls) {
                     const name = state.toolCallNames.get(toolCallId);
-                    const args = state.toolCallArgsBuffer.get(toolCallId) || '{}';
+                    const args = this.normalizeArgsString(state.toolCallArgsBuffer.get(toolCallId) || '{}');
                     if (name) {
                         toolCalls.push({
                             id: toolCallId,

--- a/tests/adapters/agui-middleware.test.ts
+++ b/tests/adapters/agui-middleware.test.ts
@@ -241,6 +241,73 @@ test.describe('McpMiddleware', () => {
     expect(seenRunIds).toEqual(['run-1', 'run-1']);
   });
 
+  test('normalizes duplicated streamed tool args in assistant history', async () => {
+    const toolResults: string[] = [];
+    const tools: AguiTool[] = [
+      {
+        name: 'mcp_search_tool_bm25',
+        description: 'Search available tools',
+        parameters: { type: 'object', properties: { query: { type: 'string' } } },
+        handler: ({ query }) => {
+          toolResults.push(query);
+          return `result for ${query}`;
+        },
+      },
+    ];
+    const input = createInput('find tools');
+    let continuationInput: RunAgentInput | undefined;
+    const next = createAgent([
+      (agentInput, subscriber) => {
+        subscriber.next({
+          type: EventType.TEXT_MESSAGE_CONTENT,
+          messageId: 'assistant-1',
+          delta: 'Let me search.',
+        } as BaseEvent);
+        subscriber.next({
+          type: EventType.TOOL_CALL_START,
+          toolCallId: 'call-1',
+          toolCallName: 'mcp_search_tool_bm25',
+        } as BaseEvent);
+        subscriber.next({
+          type: EventType.TOOL_CALL_ARGS,
+          toolCallId: 'call-1',
+          delta: JSON.stringify({ query: 'copilotkit' }),
+        } as BaseEvent);
+        subscriber.next({
+          type: EventType.TOOL_CALL_ARGS,
+          toolCallId: 'call-1',
+          delta: JSON.stringify({ query: 'copilotkit' }),
+        } as BaseEvent);
+        subscriber.next({
+          type: EventType.TOOL_CALL_END,
+          toolCallId: 'call-1',
+        } as BaseEvent);
+        subscriber.next({
+          type: EventType.RUN_FINISHED,
+          threadId: 'thread-1',
+          runId: agentInput.runId,
+        } as BaseEvent);
+        subscriber.complete();
+      },
+      (agentInput, subscriber) => {
+        continuationInput = agentInput;
+        subscriber.next({
+          type: EventType.RUN_FINISHED,
+          threadId: 'thread-1',
+          runId: agentInput.runId,
+        } as BaseEvent);
+        subscriber.complete();
+      },
+    ]);
+
+    await collectEvents(createMcpMiddleware({ tools })(input, next));
+
+    const assistantMessage = continuationInput?.messages.at(-2) as any;
+    const argsString = assistantMessage.toolCalls[0].function.arguments;
+    expect(JSON.parse(argsString)).toEqual({ query: 'copilotkit' });
+    expect(toolResults).toEqual(['copilotkit']);
+  });
+
   test('does not rediscover resolved LangGraph snapshot tool calls', async () => {
     let handlerCalls = 0;
     const tools: AguiTool[] = [


### PR DESCRIPTION
Fixes #85.

## Problem
LangGraph's Python AG-UI adapter parses `toolCalls[].function.arguments` with `json.loads(...)`. When streamed `TOOL_CALL_ARGS` chunks are duplicated (e.g. `{...}{...}`), the middleware could execute the MCP tool correctly (tolerant parse) but still write the raw duplicated string into the reconstructed assistant tool-call message used for continuation history.

That invalid JSON then crashes LangGraph with `JSONDecodeError: Extra data`, which terminates the stream and surfaces as `RUN_ERROR` / `INCOMPLETE_STREAM` in CopilotKit.

## Fix
Normalize buffered args before putting them into the reconstructed assistant history tool call (`function.arguments`). This ensures continuation history always contains valid JSON.

## Tests
- Adds regression: duplicated streamed `TOOL_CALL_ARGS` yields parseable `function.arguments` in continuation history.
- `npm test -- tests/adapters/agui-middleware.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the continuation message reconstruction path for tool calls; incorrect normalization could alter tool arguments passed into subsequent agent runs, but the change is small and covered by a regression test.
> 
> **Overview**
> Prevents LangGraph continuation crashes when streamed `TOOL_CALL_ARGS` chunks are duplicated by **normalizing buffered tool-call arguments to valid JSON** before writing them into reconstructed assistant `toolCalls[].function.arguments`.
> 
> Adds a regression test ensuring duplicated arg chunks like `{...}{...}` still execute the MCP tool correctly and produce a parseable `function.arguments` string in continuation history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c30c9136cae7f8016ce3afe286e418f423c1b42d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->