### PR TITLE
feat(toolrouter): enhance meta-search with server-scoped listing and rename primary tool

### DIFF
--- a/docs/changelog/2026-04-25.md
+++ b/docs/changelog/2026-04-25.md
@@ -7,7 +7,7 @@ description: "v1.5.2 — Tool search enhancements with direct selection, require
 
 ### Direct tool selection
 
-The [`mcp_search_tools`](/core-concepts/meta-tools) meta-tool now supports a `select:<name>` syntax that bypasses the search index entirely. When the LLM already knows which tool it wants, `select:github_create_issue` returns the exact tool description instantly — no ranking, no token overhead from irrelevant matches.
+The [`mcp_search_tool_bm25`](/core-concepts/meta-tools) meta-tool now supports a `select:<name>` syntax that bypasses the search index entirely. When the LLM already knows which tool it wants, `select:github_create_issue` returns the exact tool description instantly — no ranking, no token overhead from irrelevant matches.
 
 ### Required terms in search
 

--- a/docs/changelog/2026-04-25.md
+++ b/docs/changelog/2026-04-25.md
@@ -7,7 +7,7 @@ description: "v1.5.2 — Tool search enhancements with direct selection, require
 
 ### Direct tool selection
 
-The [`mcp_search_tool_bm25`](/core-concepts/meta-tools) meta-tool now supports a `select:<name>` syntax that bypasses the search index entirely. When the LLM already knows which tool it wants, `select:github_create_issue` returns the exact tool description instantly — no ranking, no token overhead from irrelevant matches.
+The [`mcp_search_tools`](/core-concepts/meta-tools) meta-tool now supports a `select:<name>` syntax that bypasses the search index entirely. When the LLM already knows which tool it wants, `select:github_create_issue` returns the exact tool description instantly — no ranking, no token overhead from irrelevant matches.
 
 ### Required terms in search
 

--- a/docs/core-concepts/meta-tools.md
+++ b/docs/core-concepts/meta-tools.md
@@ -20,12 +20,14 @@ The `mcp_search_tools` meta-tool supports a powerful query syntax that helps the
 
 - **Direct Tool Selection (`select:<name>`)**: If the AI already knows the exact tool it wants to use (e.g., from past context), it can bypass the BM25 index entirely.
   - *Example*: `select:github_create_issue` returns the exact tool description instantly.
+  - `select:` uses the same server scoping fields as search. If the connected server is named `Database MCP`, then `query: "select:list_tables", serverName: "database"` can resolve `list_tables` because `serverName` is treated as a case-insensitive fragment.
 - **Required Terms (`+term`)**: By prefixing a word with `+`, the AI strictly forces the index to *only* return tools that contain that word in their name or description.
   - *Example*: `+slack send` guarantees that only tools belonging to Slack are returned, even if another tool uses the word "send" frequently.
-- **Server Scoping**: Pass `serverId` or `serverName` to restrict results to one connected MCP server.
-  - *Example*: `query: "tables", serverName: "supabase"` searches only Supabase tools.
+- **Server Scoping**: Pass `serverId` or `serverName` to restrict results to one connected MCP server. Use `serverId` when you have the exact ID; use `serverName` when you only know a human-readable fragment.
+  - *Example*: `query: "tables", serverName: "database"` searches only servers with names or IDs containing `database`, such as `Database MCP`.
+  - *Example*: `query: "tables", serverId: "database-server"` searches only the exact server ID `database-server`.
 - **Deterministic Server Listing**: Pass `operation: "list"` with `serverId` or `serverName` when the user asks for every tool from a server.
-  - *Example*: `query: "supabase", operation: "list", serverName: "supabase"` returns the server's tools with `totalCount`, `returnedCount`, and `nextCursor` metadata.
+  - *Example*: `query: "database", operation: "list", serverName: "database"` returns the matching server's tools with `totalCount`, `returnedCount`, and `nextCursor` metadata.
 - **Live-Information Fallback**: If a temporal or current-information query has no direct BM25 match, the router retries with generic web/search/browser terms so connected web-search tools can still surface.
 - **Enhanced Scoring Heuristics**: Behind the scenes, the BM25 index automatically grants massive score bonuses (+10 or +5 points) if a search term perfectly matches or is a substring of the MCP `serverName` or the tool `name`. This ensures that tools strictly related to a specific integration (e.g., querying for "neon" or "apify") always float above unrelated tools that merely mention the word in their parameters.
 
@@ -44,13 +46,13 @@ A precision tool for finding specific patterns in tool names or descriptions.
 
 ### `mcp_get_tool_schema`
 Load the technical details for a specific tool.
-- **Input**: `toolName` (string), `serverName` (optional string).
+- **Input**: `toolName` (string), `serverId` (optional string).
 - **Output**: The full JSON `inputSchema` for the requested tool.
 - **Requirement**: The LLM *must* call this after searching to know what arguments a tool accepts.
 
 ### `mcp_execute_tool`
 The proxy executor for all discovered tools.
-- **Input**: `toolName` (string), `args` (object), `serverName` (optional string).
+- **Input**: `toolName` (string), `args` (object), `serverId` (optional string).
 - **Output**: The result of the actual MCP tool call.
 - **Privacy**: The SDK handles the routing to the correct MCP server automatically.
 
@@ -79,4 +81,4 @@ The `mcp-ts` SDK implements the following flow to minimize context usage while m
 
 1. **Context Density**: You can give an LLM access to 1,000 tools without using more than a few hundred tokens of "resting" context.
 2. **Reduced Hallucinations**: Because the LLM "finds" the tool definition right before using it, it is less likely to hallucinate parameters or use the wrong tool.
-3. **Multi-Server Conflict Resolution**: If two servers provide a tool named `search`, the Meta-Tools return the `serverName` as a namespace, allowing the LLM to specify which one to use.
+3. **Multi-Server Conflict Resolution**: If two servers provide a tool named `search`, the Meta-Tools return `serverName` and `serverId`. Use `serverName` fragments for discovery and `serverId` for exact schema lookup/execution.

--- a/docs/core-concepts/meta-tools.md
+++ b/docs/core-concepts/meta-tools.md
@@ -10,18 +10,23 @@ These tools follow the "Tool Search" pattern, allowing the LLM to autonomously f
 
 ## The Meta-Tool Catalog
 
-### `mcp_search_tool_bm25`
+### `mcp_search_tools`
 The primary entry point for discovery. The LLM calls this with a natural language query to find tools. The backend uses an in-memory BM25 index combined with smart heuristics to rank results.
-- **Input**: `query` (string), `limit` (number).
+- **Input**: `query` (string), `operation` (`"search"` or `"list"`), `serverId`/`serverName` (optional), `limit` (number), `cursor` (optional).
 - **Output**: A list of tool names, descriptions, and the servers they belong to.
 
 #### Advanced Search Features
-The `mcp_search_tool_bm25` meta-tool supports a powerful query syntax that helps the AI zero in on exact capabilities without context bloat:
+The `mcp_search_tools` meta-tool supports a powerful query syntax that helps the AI zero in on exact capabilities without context bloat:
 
 - **Direct Tool Selection (`select:<name>`)**: If the AI already knows the exact tool it wants to use (e.g., from past context), it can bypass the BM25 index entirely.
   - *Example*: `select:github_create_issue` returns the exact tool description instantly.
 - **Required Terms (`+term`)**: By prefixing a word with `+`, the AI strictly forces the index to *only* return tools that contain that word in their name or description.
   - *Example*: `+slack send` guarantees that only tools belonging to Slack are returned, even if another tool uses the word "send" frequently.
+- **Server Scoping**: Pass `serverId` or `serverName` to restrict results to one connected MCP server.
+  - *Example*: `query: "tables", serverName: "supabase"` searches only Supabase tools.
+- **Deterministic Server Listing**: Pass `operation: "list"` with `serverId` or `serverName` when the user asks for every tool from a server.
+  - *Example*: `query: "supabase", operation: "list", serverName: "supabase"` returns the server's tools with `totalCount`, `returnedCount`, and `nextCursor` metadata.
+- **Live-Information Fallback**: If a temporal or current-information query has no direct BM25 match, the router retries with generic web/search/browser terms so connected web-search tools can still surface.
 - **Enhanced Scoring Heuristics**: Behind the scenes, the BM25 index automatically grants massive score bonuses (+10 or +5 points) if a search term perfectly matches or is a substring of the MCP `serverName` or the tool `name`. This ensures that tools strictly related to a specific integration (e.g., querying for "neon" or "apify") always float above unrelated tools that merely mention the word in their parameters.
 
 ### `mcp_search_tool_regex`
@@ -53,7 +58,7 @@ The `mcp-ts` SDK implements the following flow to minimize context usage while m
     The SDK injects only the 4 Meta-Tools into the LLM context (cost: ~500 tokens).
   </Step>
   <Step title="Discovery (Search)">
-    When the user asks for a specific capability, the LLM calls `mcp_search_tool_bm25` or `mcp_search_tool_regex`.
+    When the user asks for a specific capability, the LLM calls `mcp_search_tools` or `mcp_search_tool_regex`.
   </Step>
   <Step title="Inspection (Get Schema)">
     Based on search results, the LLM calls `mcp_get_tool_schema` for the most relevant tool to see its parameters.

--- a/docs/core-concepts/meta-tools.md
+++ b/docs/core-concepts/meta-tools.md
@@ -29,6 +29,13 @@ The `mcp_search_tools` meta-tool supports a powerful query syntax that helps the
 - **Live-Information Fallback**: If a temporal or current-information query has no direct BM25 match, the router retries with generic web/search/browser terms so connected web-search tools can still surface.
 - **Enhanced Scoring Heuristics**: Behind the scenes, the BM25 index automatically grants massive score bonuses (+10 or +5 points) if a search term perfectly matches or is a substring of the MCP `serverName` or the tool `name`. This ensures that tools strictly related to a specific integration (e.g., querying for "neon" or "apify") always float above unrelated tools that merely mention the word in their parameters.
 
+
+### `mcp_list_servers`
+A diagnostic tool that allows the LLM to inspect which MCP servers are currently connected and available.
+- **Input**: `query` (optional string for filtering by server name or ID).
+- **Output**: A list of connected servers, their IDs, and tool counts.
+- **Usage**: Use this when `mcp_search_tools` returns no matches to discover what servers are active, then retry the search with a specific `serverId` or `serverName`.
+
 ### `mcp_search_tool_regex`
 A precision tool for finding specific patterns in tool names or descriptions.
 - **Input**: `query` (Regex string), `limit` (number).
@@ -55,7 +62,7 @@ The `mcp-ts` SDK implements the following flow to minimize context usage while m
 
 <Steps>
   <Step title="Initial Injection">
-    The SDK injects only the 4 Meta-Tools into the LLM context (cost: ~500 tokens).
+    The SDK injects only the 5 Meta-Tools into the LLM context (cost: ~500 tokens).
   </Step>
   <Step title="Discovery (Search)">
     When the user asks for a specific capability, the LLM calls `mcp_search_tools` or `mcp_search_tool_regex`.

--- a/docs/core-concepts/tool-router.md
+++ b/docs/core-concepts/tool-router.md
@@ -21,7 +21,7 @@ In this strategy, every discovered tool is passed through to the LLM.
 - **Best for**: Small projects with fewer than 10-15 tools.
 
 ### 2. The `search` Strategy (Scalability)
-This is the most advanced strategy. Instead of exposing your real tools, the SDK injects 4 system **Meta-Tools**. The LLM then "searches" for the tools it needs on-demand.
+This is the most advanced strategy. Instead of exposing your real tools, the SDK injects 5 system **Meta-Tools**. The LLM then "searches" for the tools it needs on-demand.
 - **Pros**: Virtually unlimited scalability (1000+ tools), minimal token usage, higher accuracy.
 - **Cons**: Requires a 2-turn flow for tool discovery.
 - **Best for**: Enterprise applications and deep tool catalogs.

--- a/docs/reference/tool-router.md
+++ b/docs/reference/tool-router.md
@@ -37,7 +37,7 @@ const router = new ToolRouter(client: MCPClient | MultiSessionClient, {
 
 **Methods:**
 - `getFilteredTools()` - Get tools based on current strategy
-- `searchTools(query, topK?, options?)` - Search via BM25 + embeddings, optionally scoped by `serverId` or `serverName`
+- `searchTools(query, topK?, options?)` - Search via BM25 + embeddings, optionally scoped by exact `serverId` or fragment-based `serverName`
 - `searchToolsRegex(pattern, topK?)` - Search via regex pattern
 - `listServers(options?)` - List connected indexed servers with tool counts
 - `listTools(options?)` - Deterministically list indexed tools, optionally scoped by server and paginated with `cursor`
@@ -73,14 +73,20 @@ const results = await index.search("query", 5);
 // Regex search
 const regexResults = index.searchRegex("get_.*_data", 5);
 
-// Search only one server
-const supabaseResults = await index.search("tables", 5, {
-  serverName: "supabase",
+// Search one server by human-readable name fragment.
+// This matches a server named "Database MCP".
+const databaseResults = await index.search("tables", 5, {
+  serverName: "database",
 });
 
-// List every tool from one server with pagination metadata
+// Search one server by exact stable ID.
+const exactServerResults = await index.search("tables", 5, {
+  serverId: "database-server",
+});
+
+// List every tool from one server with pagination metadata.
 const listed = index.listTools({
-  serverName: "supabase",
+  serverName: "database",
   limit: 100,
 });
 console.log(listed.totalCount, listed.tools);

--- a/docs/reference/tool-router.md
+++ b/docs/reference/tool-router.md
@@ -37,8 +37,10 @@ const router = new ToolRouter(client: MCPClient | MultiSessionClient, {
 
 **Methods:**
 - `getFilteredTools()` - Get tools based on current strategy
-- `searchTools(query, topK?)` - Search via BM25 + embeddings
+- `searchTools(query, topK?, options?)` - Search via BM25 + embeddings, optionally scoped by `serverId` or `serverName`
 - `searchToolsRegex(pattern, topK?)` - Search via regex pattern
+- `listServers(options?)` - List connected indexed servers with tool counts
+- `listTools(options?)` - Deterministically list indexed tools, optionally scoped by server and paginated with `cursor`
 - `refresh()` - Re-index tools from all connected clients
 - `setStrategy(strategy)` - Change tool selection strategy at runtime
 
@@ -70,6 +72,18 @@ const results = await index.search("query", 5);
 
 // Regex search
 const regexResults = index.searchRegex("get_.*_data", 5);
+
+// Search only one server
+const supabaseResults = await index.search("tables", 5, {
+  serverName: "supabase",
+});
+
+// List every tool from one server with pagination metadata
+const listed = index.listTools({
+  serverName: "supabase",
+  limit: 100,
+});
+console.log(listed.totalCount, listed.tools);
 ```
 
 ### `SchemaCompressor`

--- a/src/server/mcp/oauth-client.ts
+++ b/src/server/mcp/oauth-client.ts
@@ -1126,9 +1126,10 @@ export class MCPClient {
    * @returns Server name or undefined
    */
   getServerName(): string | undefined {
-    const info = (this.client as any)?.getServerVersion();
-    console.log('server info ->', info);
-    return info?.title ?? info?.name ?? this.serverName;
+    // Temporarily avoid deriving serverName from serverVersion metadata.
+    // const info = (this.client as any)?.getServerVersion();
+    // return info?.title ?? info?.name ?? this.serverName;
+    return this.serverName;
   }
 
   /**
@@ -1228,4 +1229,3 @@ export class MCPClient {
   }
 
 }
-

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -103,6 +103,7 @@ export {
 
 export {
   createSearchToolDefinition,
+  createListServersToolDefinition,
   createRegexSearchToolDefinition,
   createGetSchemaToolDefinition,
   createExecuteToolDefinition,

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -87,6 +87,9 @@ export {
 export {
   ToolIndex,
   type ToolSummary,
+  type ToolServerSummary,
+  type ToolSearchOptions,
+  type ToolListResult,
   type IndexedTool,
   type ToolIndexOptions,
   type EmbedFn,

--- a/src/shared/meta-tools.ts
+++ b/src/shared/meta-tools.ts
@@ -17,7 +17,7 @@
 
 import type { Tool, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { ToolRouter } from './tool-router.js';
-import type { IndexedTool } from './tool-index.js';
+import type { IndexedTool, ToolLookupOptions } from './tool-index.js';
 
 // ---------------------------------------------------------------------------
 // Tool Definitions
@@ -235,9 +235,13 @@ export async function executeMetaTool(
   router: ToolRouter,
   callToolFn?: CallToolFn
 ): Promise<CallToolResult | null> {
-  const resolveToolSchema = (name: string, namespace?: string): { tool?: IndexedTool; error?: CallToolResult } => {
+  const resolveToolSchema = (
+    name: string,
+    namespace?: string,
+    options?: ToolLookupOptions
+  ): { tool?: IndexedTool; error?: CallToolResult } => {
     try {
-      return { tool: router.getToolSchema(name, namespace) };
+      return { tool: router.getToolSchema(name, namespace, options) };
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err);
       return {
@@ -250,7 +254,8 @@ export async function executeMetaTool(
   };
 
   switch (toolName) {
-    case 'mcp_search_tools': {
+    case 'mcp_search_tools':
+    case 'mcp_search_tool_bm25': {
       const query = String(args.query ?? '');
       const operation = String(args.operation ?? 'search');
       const serverId = String(args.serverId ?? '') || undefined;
@@ -303,6 +308,8 @@ export async function executeMetaTool(
       // Fast path: Check for select: prefix
       const selectMatch = query.match(/^select:(.+)$/i);
       if (selectMatch) {
+        await router.listTools({ serverId, serverName, limit: 1 });
+
         const requested = selectMatch[1]!
           .split(',')
           .map((s) => s.trim())
@@ -314,7 +321,9 @@ export async function executeMetaTool(
         const namespace = serverId ?? serverName;
 
         for (const requestedToolName of requested) {
-          const { tool, error } = resolveToolSchema(requestedToolName, namespace);
+          const { tool, error } = resolveToolSchema(requestedToolName, namespace, {
+            allowServerNameFragment: Boolean(serverName && !serverId),
+          });
           if (error) {
             const errorMsg = error.content[0]?.type === 'text' ? error.content[0].text : 'Unknown error';
             errors.push(`- **${requestedToolName}**: ${errorMsg}`);
@@ -525,6 +534,7 @@ function formatToolSummaries(
 export function isMetaTool(toolName: string): boolean {
   return (
     toolName === 'mcp_search_tools' ||
+    toolName === 'mcp_search_tool_bm25' ||
     toolName === 'mcp_list_servers' ||
     toolName === 'mcp_search_tool_regex' ||
     toolName === 'mcp_get_tool_schema' ||

--- a/src/shared/meta-tools.ts
+++ b/src/shared/meta-tools.ts
@@ -254,8 +254,7 @@ export async function executeMetaTool(
   };
 
   switch (toolName) {
-    case 'mcp_search_tools':
-    case 'mcp_search_tool_bm25': {
+    case 'mcp_search_tools': {
       const query = String(args.query ?? '');
       const operation = String(args.operation ?? 'search');
       const serverId = String(args.serverId ?? '') || undefined;
@@ -534,7 +533,6 @@ function formatToolSummaries(
 export function isMetaTool(toolName: string): boolean {
   return (
     toolName === 'mcp_search_tools' ||
-    toolName === 'mcp_search_tool_bm25' ||
     toolName === 'mcp_list_servers' ||
     toolName === 'mcp_search_tool_regex' ||
     toolName === 'mcp_get_tool_schema' ||

--- a/src/shared/meta-tools.ts
+++ b/src/shared/meta-tools.ts
@@ -77,6 +77,31 @@ export function createSearchToolDefinition(): Tool {
 }
 
 /**
+ * Creates the `mcp_list_servers` tool definition.
+ *
+ * This tool lets the LLM inspect connected MCP servers before doing
+ * server-scoped tool discovery.
+ */
+export function createListServersToolDefinition(): Tool {
+  return {
+    name: 'mcp_list_servers',
+    description:
+      'List connected MCP servers and their tool counts. ' +
+      'Use this when mcp_search_tools returns no matches, then retry mcp_search_tools with serverId or serverName.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        query: {
+          type: 'string',
+          description:
+            'Optional server filter text. Matches server name or serverId, e.g. "web" or "supabase".',
+        },
+      },
+    },
+  };
+}
+
+/**
  * Creates the `mcp_search_tool_regex` tool definition.
  * 
  * Matches Anthropic's tool_search_tool_regex exactly (takes a 'query' regex pattern).
@@ -198,7 +223,7 @@ export type CallToolFn = (
 /**
  * Execute a meta-tool call and return the result in MCP CallToolResult format.
  *
- * @param toolName - One of the meta-tool names (mcp_search_tools, mcp_search_tool_regex, etc.)
+ * @param toolName - One of the meta-tool names (mcp_search_tools, mcp_list_servers, mcp_search_tool_regex, etc.)
  * @param args - The arguments from the LLM's tool call
  * @param router - The ToolRouter to query
  * @param callToolFn - Optional callback for executing real tools (required for mcp_execute_tool)
@@ -327,8 +352,30 @@ export async function executeMetaTool(
       const results = await router.searchTools(query, limit, searchOptions);
 
       const text = results.length === 0
-        ? 'No tools found matching your query. Try different keywords.'
+        ? 'No tools found matching your query. Call mcp_list_servers to inspect connected servers, then retry mcp_search_tools with serverId or serverName.'
         : formatToolSummaries(results).join('\n');
+
+      return {
+        content: [{ type: 'text', text }],
+        isError: false,
+      };
+    }
+
+    case 'mcp_list_servers': {
+      const query = String(args.query ?? '').trim();
+      const servers = await router.listServers({
+        serverName: query || undefined,
+      });
+
+      const text = servers.length === 0
+        ? 'No connected servers found.'
+        : servers
+            .map(
+              (server, i) =>
+                `${i + 1}. **${server.serverName}** (serverId: ${server.serverId}, sessionId: ${server.sessionId})\n` +
+                `   Tool count: ${server.toolCount}`
+            )
+            .join('\n');
 
       return {
         content: [{ type: 'text', text }],
@@ -478,6 +525,7 @@ function formatToolSummaries(
 export function isMetaTool(toolName: string): boolean {
   return (
     toolName === 'mcp_search_tools' ||
+    toolName === 'mcp_list_servers' ||
     toolName === 'mcp_search_tool_regex' ||
     toolName === 'mcp_get_tool_schema' ||
     toolName === 'mcp_execute_tool'

--- a/src/shared/meta-tools.ts
+++ b/src/shared/meta-tools.ts
@@ -7,7 +7,7 @@
  * only the tools it actually needs.
  *
  * Meta-tools:
- *   • `mcp_search_tool_bm25`  — BM25 natural language search
+ *   • `mcp_search_tools`      — Search/list available tools
  *   • `mcp_search_tool_regex` — Regex pattern search
  *   • `mcp_get_tool_schema`   — Get full inputSchema for a discovered tool
  *   • `mcp_execute_tool`      — Execute a discovered tool
@@ -24,7 +24,7 @@ import type { IndexedTool } from './tool-index.js';
 // ---------------------------------------------------------------------------
 
 /**
- * Creates the `mcp_search_tool_bm25` tool definition.
+ * Creates the `mcp_search_tools` tool definition.
  *
  * This tool lets the LLM search the full catalog of available MCP tools
  * using a BM25 natural-language query. Returns tool names and descriptions
@@ -32,7 +32,7 @@ import type { IndexedTool } from './tool-index.js';
  */
 export function createSearchToolDefinition(): Tool {
   return {
-    name: 'mcp_search_tool_bm25',
+    name: 'mcp_search_tools',
     description:
       'Search the catalog of available tools. Returns tool names, descriptions, and server info. ' +
       'Use this FIRST to find relevant tools before calling them.\n\n' +
@@ -47,9 +47,28 @@ export function createSearchToolDefinition(): Tool {
           type: 'string',
           description: 'Query to find tools. Use "select:<tool_name>" for direct selection, or keywords to search. Prefix keywords with + to require them.',
         },
+        operation: {
+          type: 'string',
+          enum: ['search', 'list'],
+          description:
+            'Operation to perform. Use "search" to find relevant tools by capability. Use "list" with serverId or serverName when the user asks for every tool from a connected MCP server.',
+        },
+        serverId: {
+          type: 'string',
+          description: 'Optional server ID to restrict search/list results to one MCP server.',
+        },
+        serverName: {
+          type: 'string',
+          description:
+            'Optional server name fragment to restrict search/list results to matching MCP servers, e.g. "supabase".',
+        },
         limit: {
           type: 'number',
-          description: 'Maximum number of results to return (default: 5, max: 20).',
+          description: 'Maximum number of results to return (default: 5 for search, 20 for list; max: 20 for search, 100 for list).',
+        },
+        cursor: {
+          type: 'string',
+          description: 'Optional pagination cursor returned by operation "list".',
         },
       },
       required: ['query'],
@@ -89,7 +108,7 @@ export function createRegexSearchToolDefinition(): Tool {
 /**
  * Creates the `mcp_get_tool_schema` tool definition.
  *
- * After discovering tools via `mcp_search_tool_bm25` or
+ * After discovering tools via `mcp_search_tools` or
  * `mcp_search_tool_regex`, the LLM calls this to load the full
  * inputSchema for a specific tool so it can construct the correct
  * arguments.
@@ -99,7 +118,7 @@ export function createGetSchemaToolDefinition(): Tool {
     name: 'mcp_get_tool_schema',
     description:
       'Get the full input schema (parameters) for a specific tool. ' +
-      'Call this after mcp_search_tool_bm25 to get the parameter details ' +
+      'Call this after mcp_search_tools to get the parameter details ' +
       'needed to call a tool correctly. ' +
       'Do NOT call the discovered tool directly; after reading the schema, call mcp_execute_tool.',
     inputSchema: {
@@ -107,12 +126,12 @@ export function createGetSchemaToolDefinition(): Tool {
       properties: {
         toolName: {
           type: 'string',
-          description: 'The exact tool name returned by mcp_search_tool_bm25.',
+          description: 'The exact tool name returned by mcp_search_tools.',
         },
         serverId: {
           type: 'string',
           description:
-            'Optional: The server ID provided in mcp_search_tool_bm25. Required if multiple tools have the same name.',
+            'Optional: The server ID provided in mcp_search_tools. Required if multiple tools have the same name.',
         },
       },
       required: ['toolName'],
@@ -124,7 +143,7 @@ export function createGetSchemaToolDefinition(): Tool {
  * Creates the `mcp_execute_tool` tool definition.
  *
  * This is the execution meta-tool — the LLM calls this to execute any
- * tool discovered via `mcp_search_tool_bm25` or `mcp_search_tool_regex`.
+ * tool discovered via `mcp_search_tools` or `mcp_search_tool_regex`.
  * The LLM should first call `mcp_get_tool_schema` to know the correct
  * arguments.
  *
@@ -135,7 +154,7 @@ export function createExecuteToolDefinition(): Tool {
   return {
     name: 'mcp_execute_tool',
     description:
-      'Execute a tool that was discovered via mcp_search_tool_bm25. ' +
+      'Execute a tool that was discovered via mcp_search_tools. ' +
       'You MUST call mcp_get_tool_schema first to know the correct parameters. ' +
       'Pass the exact tool name and its arguments.',
     inputSchema: {
@@ -143,12 +162,12 @@ export function createExecuteToolDefinition(): Tool {
       properties: {
         toolName: {
           type: 'string',
-          description: 'The exact tool name from mcp_search_tool_bm25 results.',
+          description: 'The exact tool name from mcp_search_tools results.',
         },
         serverId: {
           type: 'string',
           description:
-            'Optional: The server ID provided in mcp_search_tool_bm25. Required if multiple tools have the same name.',
+            'Optional: The server ID provided in mcp_search_tools. Required if multiple tools have the same name.',
         },
         args: {
           type: 'object',
@@ -179,7 +198,7 @@ export type CallToolFn = (
 /**
  * Execute a meta-tool call and return the result in MCP CallToolResult format.
  *
- * @param toolName - One of the meta-tool names (mcp_search_tool_bm25, mcp_search_tool_regex, etc.)
+ * @param toolName - One of the meta-tool names (mcp_search_tools, mcp_search_tool_regex, etc.)
  * @param args - The arguments from the LLM's tool call
  * @param router - The ToolRouter to query
  * @param callToolFn - Optional callback for executing real tools (required for mcp_execute_tool)
@@ -206,9 +225,55 @@ export async function executeMetaTool(
   };
 
   switch (toolName) {
-    case 'mcp_search_tool_bm25': {
+    case 'mcp_search_tools': {
       const query = String(args.query ?? '');
+      const operation = String(args.operation ?? 'search');
+      const serverId = String(args.serverId ?? '') || undefined;
+      const serverName = String(args.serverName ?? '') || undefined;
+
+      if (operation === 'list') {
+        const limit = Math.min(Number(args.limit) || 20, 100);
+        const cursor = String(args.cursor ?? '') || undefined;
+        const result = await router.listTools({
+          serverId,
+          serverName: serverName ?? (!serverId && query ? query : undefined),
+          limit,
+          cursor,
+        });
+
+        const serverText = result.servers.length > 0
+          ? result.servers
+              .map((server) => `${server.serverName} (serverId: ${server.serverId}, tools: ${server.toolCount})`)
+              .join(', ')
+          : 'none';
+
+        const lines: string[] = [
+          'operation: list',
+          `servers: ${serverText}`,
+          `totalCount: ${result.totalCount}`,
+          `returnedCount: ${result.returnedCount}`,
+          `nextCursor: ${result.nextCursor ?? 'null'}`,
+          '',
+        ];
+
+        if (result.tools.length > 0) {
+          lines.push(...formatToolSummaries(result.tools));
+        } else {
+          lines.push(
+            serverId || serverName
+              ? 'No tools found for the requested server scope.'
+              : 'No tools found. Try operation "search" or provide serverId/serverName.'
+          );
+        }
+
+        return {
+          content: [{ type: 'text', text: lines.join('\n') }],
+          isError: false,
+        };
+      }
+
       const limit = Math.min(Number(args.limit) || 5, 20);
+      const searchOptions = { serverId, serverName };
 
       // Fast path: Check for select: prefix
       const selectMatch = query.match(/^select:(.+)$/i);
@@ -221,15 +286,17 @@ export async function executeMetaTool(
         const found: any[] = [];
         const errors: string[] = [];
         
+        const namespace = serverId ?? serverName;
+
         for (const requestedToolName of requested) {
-          const { tool, error } = resolveToolSchema(requestedToolName);
+          const { tool, error } = resolveToolSchema(requestedToolName, namespace);
           if (error) {
             const errorMsg = error.content[0]?.type === 'text' ? error.content[0].text : 'Unknown error';
             errors.push(`- **${requestedToolName}**: ${errorMsg}`);
           } else if (tool) {
             found.push(tool);
           } else {
-            errors.push(`- **${requestedToolName}**: Tool not found. Try searching with mcp_search_tool_bm25.`);
+            errors.push(`- **${requestedToolName}**: Tool not found. Try searching with mcp_search_tools.`);
           }
         }
 
@@ -257,18 +324,11 @@ export async function executeMetaTool(
         };
       }
 
-      const results = await router.searchTools(query, limit);
+      const results = await router.searchTools(query, limit, searchOptions);
 
       const text = results.length === 0
         ? 'No tools found matching your query. Try different keywords.'
-        : results
-            .map(
-              (t, i) =>
-                `${i + 1}. **${t.name}** (server: ${t.serverName}, serverId: ${t.serverId})\n` +
-                `   ${t.description}\n` +
-                `   Estimated tokens: ${t.estimatedTokens}`
-            )
-            .join('\n');
+        : formatToolSummaries(results).join('\n');
 
       return {
         content: [{ type: 'text', text }],
@@ -284,14 +344,7 @@ export async function executeMetaTool(
 
       const text = results.length === 0
         ? 'No tools matched your regex pattern. Try a broader pattern.'
-        : results
-            .map(
-              (t, i) =>
-                `${i + 1}. **${t.name}** (server: ${t.serverName}, serverId: ${t.serverId})\n` +
-                `   ${t.description}\n` +
-                `   Estimated tokens: ${t.estimatedTokens}`
-            )
-            .join('\n');
+        : formatToolSummaries(results).join('\n');
 
       return {
         content: [{ type: 'text', text }],
@@ -313,7 +366,7 @@ export async function executeMetaTool(
           content: [
             {
               type: 'text',
-              text: `Tool "${name}" not found. Use mcp_search_tool_bm25 to find available tools first.`,
+              text: `Tool "${name}" not found. Use mcp_search_tools to find available tools first.`,
             },
           ],
           isError: true,
@@ -362,7 +415,7 @@ export async function executeMetaTool(
           content: [
             {
               type: 'text',
-              text: `Tool "${targetToolName}" not found. Use mcp_search_tool_bm25 to discover available tools first.`,
+              text: `Tool "${targetToolName}" not found. Use mcp_search_tools to discover available tools first.`,
             },
           ],
           isError: true,
@@ -404,10 +457,27 @@ export async function executeMetaTool(
   }
 }
 
+function formatToolSummaries(
+  tools: Array<{
+    name: string;
+    description: string;
+    serverName: string;
+    serverId: string;
+    estimatedTokens: number;
+  }>
+): string[] {
+  return tools.map(
+    (t, i) =>
+      `${i + 1}. **${t.name}** (server: ${t.serverName}, serverId: ${t.serverId})\n` +
+      `   ${t.description}\n` +
+      `   Estimated tokens: ${t.estimatedTokens}`
+  );
+}
+
 /** Check if a tool name is one of the meta-tools. */
 export function isMetaTool(toolName: string): boolean {
   return (
-    toolName === 'mcp_search_tool_bm25' ||
+    toolName === 'mcp_search_tools' ||
     toolName === 'mcp_search_tool_regex' ||
     toolName === 'mcp_get_tool_schema' ||
     toolName === 'mcp_execute_tool'

--- a/src/shared/tool-index.ts
+++ b/src/shared/tool-index.ts
@@ -498,7 +498,7 @@ export class ToolIndex {
       (t) =>
         t.sessionId === namespace ||
         t.serverId === namespace ||
-        t.serverName.toLowerCase() === namespaceLower
+        t.serverName.toLowerCase().includes(namespaceLower)
     );
   }
 

--- a/src/shared/tool-index.ts
+++ b/src/shared/tool-index.ts
@@ -61,6 +61,14 @@ export interface ToolListResult {
   servers: ToolServerSummary[];
 }
 
+export interface ToolLookupOptions {
+  /**
+   * Allow namespace to match a fragment of serverName after exact
+   * sessionId/serverId matching fails.
+   */
+  allowServerNameFragment?: boolean;
+}
+
 /** A tool with routing metadata attached during indexing. */
 export interface IndexedTool extends Tool {
   sessionId: string;
@@ -488,9 +496,9 @@ export class ToolIndex {
   /**
    * Get tool definition(s) by name.
    * If namespace is provided, exact sessionId/serverId matches take precedence.
-   * Falls back to serverName fragment matching only when no exact identifier matches.
+   * Falls back to serverName fragment matching only when explicitly allowed.
    */
-  getTool(name: string, namespace?: string): IndexedTool[] {
+  getTool(name: string, namespace?: string, options: ToolLookupOptions = {}): IndexedTool[] {
     const list = this.tools.get(name) ?? [];
     if (!namespace) return list;
 
@@ -498,6 +506,8 @@ export class ToolIndex {
       (t) => t.sessionId === namespace || t.serverId === namespace
     );
     if (exactMatches.length > 0) return exactMatches;
+
+    if (!options.allowServerNameFragment) return [];
 
     const namespaceLower = namespace.toLowerCase();
     return list.filter((t) => t.serverName.toLowerCase().includes(namespaceLower));

--- a/src/shared/tool-index.ts
+++ b/src/shared/tool-index.ts
@@ -487,19 +487,20 @@ export class ToolIndex {
 
   /**
    * Get tool definition(s) by name.
-   * If namespace is provided, it tries to match sessionId or serverName.
+   * If namespace is provided, exact sessionId/serverId matches take precedence.
+   * Falls back to serverName fragment matching only when no exact identifier matches.
    */
   getTool(name: string, namespace?: string): IndexedTool[] {
     const list = this.tools.get(name) ?? [];
     if (!namespace) return list;
 
-    const namespaceLower = namespace.toLowerCase();
-    return list.filter(
-      (t) =>
-        t.sessionId === namespace ||
-        t.serverId === namespace ||
-        t.serverName.toLowerCase().includes(namespaceLower)
+    const exactMatches = list.filter(
+      (t) => t.sessionId === namespace || t.serverId === namespace
     );
+    if (exactMatches.length > 0) return exactMatches;
+
+    const namespaceLower = namespace.toLowerCase();
+    return list.filter((t) => t.serverName.toLowerCase().includes(namespaceLower));
   }
 
   /** All indexed tool names. */

--- a/src/shared/tool-index.ts
+++ b/src/shared/tool-index.ts
@@ -32,6 +32,35 @@ export interface ToolSummary {
   estimatedTokens: number;
 }
 
+/** Server-level summary derived from indexed tools. */
+export interface ToolServerSummary {
+  /** Human-readable server name */
+  serverName: string;
+  /** Stable server identifier */
+  serverId: string;
+  /** Session the server belongs to */
+  sessionId: string;
+  /** Number of indexed tools for this server */
+  toolCount: number;
+}
+
+/** Optional filters for search and listing. */
+export interface ToolSearchOptions {
+  /** Restrict results to this server ID. */
+  serverId?: string;
+  /** Restrict results to servers whose name or ID matches this value. */
+  serverName?: string;
+}
+
+/** Paginated tool listing result. */
+export interface ToolListResult {
+  tools: ToolSummary[];
+  totalCount: number;
+  returnedCount: number;
+  nextCursor?: string;
+  servers: ToolServerSummary[];
+}
+
 /** A tool with routing metadata attached during indexing. */
 export interface IndexedTool extends Tool {
   sessionId: string;
@@ -259,14 +288,14 @@ export class ToolIndex {
    *
    *   `score = keywordWeight × keyword_score + (1 - keywordWeight) × cosine_score`
    */
-  async search(query: string, topK = 5): Promise<ToolSummary[]> {
+  async search(query: string, topK = 5, options: ToolSearchOptions = {}): Promise<ToolSummary[]> {
     if (this.tools.size === 0) return [];
 
     const queryLower = query.toLowerCase().trim();
 
     // Fast path: Exact tool name match (supports duplicate names across servers)
     const exactMatches = [...this.toolSummaries.values()].filter(
-      (summary) => summary.name.toLowerCase() === queryLower
+      (summary) => summary.name.toLowerCase() === queryLower && this.matchesServer(summary, options)
     );
     if (exactMatches.length > 0) {
       return exactMatches.slice(0, topK);
@@ -275,7 +304,7 @@ export class ToolIndex {
     // Fast path: MCP prefix match (e.g. "mcp__github")
     if (queryLower.startsWith('mcp__') && queryLower.length > 5) {
       const prefixMatches = [...this.toolSummaries.values()]
-        .filter((t) => t.name.toLowerCase().startsWith(queryLower))
+        .filter((t) => t.name.toLowerCase().startsWith(queryLower) && this.matchesServer(t, options))
         .slice(0, topK);
       if (prefixMatches.length > 0) return prefixMatches;
     }
@@ -300,9 +329,11 @@ export class ToolIndex {
     // Pre-filter: only keep documents that contain ALL required terms
     const candidateKeys = new Set<string>();
     for (const docKey of this.toolSummaries.keys()) {
+      const summary = this.toolSummaries.get(docKey)!;
+      if (!this.matchesServer(summary, options)) continue;
+
       if (requiredTerms.length > 0) {
         const text = this.searchTexts.get(docKey) || '';
-        const summary = this.toolSummaries.get(docKey)!;
         const nameLower = summary.name.toLowerCase();
         const matchesAll = requiredTerms.every(
           (term) => text.includes(term) || nameLower.includes(term)
@@ -462,12 +493,69 @@ export class ToolIndex {
     const list = this.tools.get(name) ?? [];
     if (!namespace) return list;
 
-    return list.filter((t) => t.sessionId === namespace || t.serverId === namespace);
+    const namespaceLower = namespace.toLowerCase();
+    return list.filter(
+      (t) =>
+        t.sessionId === namespace ||
+        t.serverId === namespace ||
+        t.serverName.toLowerCase() === namespaceLower
+    );
   }
 
   /** All indexed tool names. */
   getToolNames(): string[] {
     return [...this.tools.keys()];
+  }
+
+  /** List indexed servers with tool counts. */
+  listServers(options: ToolSearchOptions = {}): ToolServerSummary[] {
+    const servers = new Map<string, ToolServerSummary>();
+
+    for (const summary of this.toolSummaries.values()) {
+      if (!this.matchesServer(summary, options)) continue;
+
+      const key = `${summary.sessionId}::${summary.serverId}`;
+      const existing = servers.get(key);
+      if (existing) {
+        existing.toolCount += 1;
+      } else {
+        servers.set(key, {
+          serverName: summary.serverName,
+          serverId: summary.serverId,
+          sessionId: summary.sessionId,
+          toolCount: 1,
+        });
+      }
+    }
+
+    return [...servers.values()].sort((a, b) => {
+      const byName = a.serverName.localeCompare(b.serverName);
+      return byName !== 0 ? byName : a.serverId.localeCompare(b.serverId);
+    });
+  }
+
+  /** List tools deterministically, optionally scoped to a server. */
+  listTools(options: ToolSearchOptions & { limit?: number; cursor?: string } = {}): ToolListResult {
+    const offset = Math.max(Number(options.cursor) || 0, 0);
+    const limit = Math.max(Number(options.limit) || 20, 1);
+    const tools = [...this.toolSummaries.values()]
+      .filter((summary) => this.matchesServer(summary, options))
+      .sort((a, b) => {
+        const byServer = a.serverName.localeCompare(b.serverName);
+        if (byServer !== 0) return byServer;
+        return a.name.localeCompare(b.name);
+      });
+
+    const page = tools.slice(offset, offset + limit);
+    const nextOffset = offset + page.length;
+
+    return {
+      tools: page,
+      totalCount: tools.length,
+      returnedCount: page.length,
+      nextCursor: nextOffset < tools.length ? String(nextOffset) : undefined,
+      servers: this.listServers(options),
+    };
   }
 
   /** Number of indexed tools (including duplicates). */
@@ -537,6 +625,23 @@ export class ToolIndex {
 
   private getDocumentKey(tool: IndexedTool): string {
     return `${tool.sessionId}::${tool.serverId}::${tool.name}`;
+  }
+
+  private matchesServer(summary: ToolSummary, options: ToolSearchOptions): boolean {
+    if (options.serverId && summary.serverId !== options.serverId) {
+      return false;
+    }
+
+    if (options.serverName) {
+      const serverNameQuery = options.serverName.toLowerCase();
+      const serverName = summary.serverName.toLowerCase();
+      const serverId = summary.serverId.toLowerCase();
+      if (!serverName.includes(serverNameQuery) && !serverId.includes(serverNameQuery)) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   /** Simple whitespace + camelCase + snake_case tokenizer. */

--- a/src/shared/tool-router.ts
+++ b/src/shared/tool-router.ts
@@ -40,6 +40,7 @@ import {
 import { SchemaCompressor, type CompactTool } from './schema-compressor.js';
 import {
   createSearchToolDefinition,
+  createListServersToolDefinition,
   createRegexSearchToolDefinition,
   createGetSchemaToolDefinition,
   createExecuteToolDefinition,
@@ -487,6 +488,7 @@ export class ToolRouter {
   private getMetaToolDefinitions(): Tool[] {
     return [
       createSearchToolDefinition(),
+      createListServersToolDefinition(),
       createRegexSearchToolDefinition(),
       createGetSchemaToolDefinition(),
       createExecuteToolDefinition(),

--- a/src/shared/tool-router.ts
+++ b/src/shared/tool-router.ts
@@ -210,17 +210,7 @@ export class ToolRouter {
   ): Promise<ToolSummary[]> {
     await this.ensureInitialized();
     const limit = topK ?? this.maxTools;
-    const results = await this.index.search(query, limit, options);
-    if (results.length > 0) {
-      return results;
-    }
-
-    const fallbackQuery = this.getFallbackSearchQuery(query);
-    if (!fallbackQuery) {
-      return results;
-    }
-
-    return this.index.search(fallbackQuery, limit, options);
+    return this.index.search(query, limit, options);
   }
 
   /**
@@ -503,17 +493,4 @@ export class ToolRouter {
     ];
   }
 
-  private getFallbackSearchQuery(query: string): string | undefined {
-    const normalized = query.toLowerCase();
-    const asksForLiveInformation =
-      /\b(today|yesterday|latest|recent|current|now|live|news|score|scores|won|winner|weather|price|stock|match|game)\b/.test(
-        normalized
-      );
-
-    if (!asksForLiveInformation) {
-      return undefined;
-    }
-
-    return `${query} web search internet browser current latest news live score`;
-  }
 }

--- a/src/shared/tool-router.ts
+++ b/src/shared/tool-router.ts
@@ -28,7 +28,15 @@
 
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { ToolClient, ToolClientProvider } from './types.js';
-import { ToolIndex, type IndexedTool, type ToolSummary, type EmbedFn } from './tool-index.js';
+import {
+  ToolIndex,
+  type IndexedTool,
+  type ToolListResult,
+  type ToolSearchOptions,
+  type ToolServerSummary,
+  type ToolSummary,
+  type EmbedFn,
+} from './tool-index.js';
 import { SchemaCompressor, type CompactTool } from './schema-compressor.js';
 import {
   createSearchToolDefinition,
@@ -159,7 +167,7 @@ export class ToolRouter {
    * This is the main method adapters should call.
    *
    * - `all`    → returns all tools (unchanged behavior)
-   * - `search` → returns only meta-tools (mcp_search_tool_bm25, mcp_get_tool_schema, mcp_execute_tool)
+   * - `search` → returns only meta-tools (mcp_search_tools, mcp_get_tool_schema, mcp_execute_tool)
    * - `groups` → returns tools from active groups only
    */
   async getFilteredTools(): Promise<Tool[]> {
@@ -195,9 +203,24 @@ export class ToolRouter {
    * Search tools by natural-language query.
    * Works regardless of strategy.
    */
-  async searchTools(query: string, topK?: number): Promise<ToolSummary[]> {
+  async searchTools(
+    query: string,
+    topK?: number,
+    options: ToolSearchOptions = {}
+  ): Promise<ToolSummary[]> {
     await this.ensureInitialized();
-    return this.index.search(query, topK ?? this.maxTools);
+    const limit = topK ?? this.maxTools;
+    const results = await this.index.search(query, limit, options);
+    if (results.length > 0) {
+      return results;
+    }
+
+    const fallbackQuery = this.getFallbackSearchQuery(query);
+    if (!fallbackQuery) {
+      return results;
+    }
+
+    return this.index.search(fallbackQuery, limit, options);
   }
 
   /**
@@ -207,6 +230,18 @@ export class ToolRouter {
   async searchToolsRegex(pattern: string, topK?: number): Promise<ToolSummary[]> {
     await this.ensureInitialized();
     return this.index.searchRegex(pattern, topK ?? this.maxTools);
+  }
+
+  /** List connected MCP servers with indexed tool counts. */
+  async listServers(options: ToolSearchOptions = {}): Promise<ToolServerSummary[]> {
+    await this.ensureInitialized();
+    return this.index.listServers(options);
+  }
+
+  /** List tools deterministically, optionally scoped to a server. */
+  async listTools(options: ToolSearchOptions & { limit?: number; cursor?: string } = {}): Promise<ToolListResult> {
+    await this.ensureInitialized();
+    return this.index.listTools(options);
   }
 
   /**
@@ -318,7 +353,7 @@ export class ToolRouter {
       throw new Error(
         `Tool "${toolName}" not found${
           namespace ? ` on server "${namespace}"` : ''
-        }. Use mcp_search_tool_bm25 or mcp_search_tool_regex to discover available tools.`
+        }. Use mcp_search_tools or mcp_search_tool_regex to discover available tools.`
       );
     }
 
@@ -466,5 +501,19 @@ export class ToolRouter {
       createGetSchemaToolDefinition(),
       createExecuteToolDefinition(),
     ];
+  }
+
+  private getFallbackSearchQuery(query: string): string | undefined {
+    const normalized = query.toLowerCase();
+    const asksForLiveInformation =
+      /\b(today|yesterday|latest|recent|current|now|live|news|score|scores|won|winner|weather|price|stock|match|game)\b/.test(
+        normalized
+      );
+
+    if (!asksForLiveInformation) {
+      return undefined;
+    }
+
+    return `${query} web search internet browser current latest news live score`;
   }
 }

--- a/src/shared/tool-router.ts
+++ b/src/shared/tool-router.ts
@@ -31,6 +31,7 @@ import type { ToolClient, ToolClientProvider } from './types.js';
 import {
   ToolIndex,
   type IndexedTool,
+  type ToolLookupOptions,
   type ToolListResult,
   type ToolSearchOptions,
   type ToolServerSummary,
@@ -239,8 +240,12 @@ export class ToolRouter {
    * Get the full tool definition by name.
    * If tool name is ambiguous, use namespace to specify the server.
    */
-  getToolSchema(toolName: string, namespace?: string): IndexedTool | undefined {
-    const matches = this.index.getTool(toolName, namespace);
+  getToolSchema(
+    toolName: string,
+    namespace?: string,
+    options: ToolLookupOptions = {}
+  ): IndexedTool | undefined {
+    const matches = this.index.getTool(toolName, namespace, options);
 
     if (matches.length === 0) return undefined;
 

--- a/tests/adapters/agui-middleware.test.ts
+++ b/tests/adapters/agui-middleware.test.ts
@@ -82,7 +82,7 @@ test.describe('McpMiddleware', () => {
   test('waits for continuation terminal event after a fast MCP tool result', async () => {
     const tools: AguiTool[] = [
       {
-        name: 'mcp_search_tool_bm25',
+        name: 'mcp_search_tools',
         description: 'Search available tools',
         parameters: { type: 'object', properties: { query: { type: 'string' } } },
         handler: () => 'No tools found matching your query. Try different keywords.',
@@ -95,7 +95,7 @@ test.describe('McpMiddleware', () => {
     const next = createAgent(
       [
         (agentInput, subscriber) => {
-          startToolRun(agentInput, subscriber, 'call-1', 'mcp_search_tool_bm25', 'IPL match today cricket');
+          startToolRun(agentInput, subscriber, 'call-1', 'mcp_search_tools', 'IPL match today cricket');
           setTimeout(() => subscriber.complete(), 10);
         },
         (agentInput, subscriber) => {
@@ -141,7 +141,7 @@ test.describe('McpMiddleware', () => {
     const toolResults: string[] = [];
     const tools: AguiTool[] = [
       {
-        name: 'mcp_search_tool_bm25',
+        name: 'mcp_search_tools',
         description: 'Search available tools',
         parameters: { type: 'object', properties: { query: { type: 'string' } } },
         handler: ({ query }) => {
@@ -156,11 +156,11 @@ test.describe('McpMiddleware', () => {
     const next = createAgent(
       [
         (agentInput, subscriber) => {
-          startToolRun(agentInput, subscriber, 'call-1', 'mcp_search_tool_bm25', 'first search');
+          startToolRun(agentInput, subscriber, 'call-1', 'mcp_search_tools', 'first search');
           setTimeout(() => subscriber.complete(), 10);
         },
         (agentInput, subscriber) => {
-          startToolRun(agentInput, subscriber, 'call-2', 'mcp_search_tool_bm25', 'second search');
+          startToolRun(agentInput, subscriber, 'call-2', 'mcp_search_tools', 'second search');
           setTimeout(() => subscriber.complete(), 10);
         },
         (agentInput, subscriber) => {
@@ -191,7 +191,7 @@ test.describe('McpMiddleware', () => {
   test('preserves normalized text content in assistant history for continuation', async () => {
     const tools: AguiTool[] = [
       {
-        name: 'mcp_search_tool_bm25',
+        name: 'mcp_search_tools',
         description: 'Search available tools',
         parameters: { type: 'object', properties: { query: { type: 'string' } } },
         handler: () => 'No tools found matching your query. Try different keywords.',
@@ -203,7 +203,7 @@ test.describe('McpMiddleware', () => {
     const next = createAgent(
       [
         (agentInput, subscriber) => {
-          startToolRun(agentInput, subscriber, 'call-1', 'mcp_search_tool_bm25', 'IPL match today cricket');
+          startToolRun(agentInput, subscriber, 'call-1', 'mcp_search_tools', 'IPL match today cricket');
           setTimeout(() => subscriber.complete(), 10);
         },
         (nextInput, subscriber) => {
@@ -229,7 +229,7 @@ test.describe('McpMiddleware', () => {
       toolCalls: [
         expect.objectContaining({
           id: 'call-1',
-          function: expect.objectContaining({ name: 'mcp_search_tool_bm25' }),
+          function: expect.objectContaining({ name: 'mcp_search_tools' }),
         }),
       ],
     });
@@ -245,7 +245,7 @@ test.describe('McpMiddleware', () => {
     const toolResults: string[] = [];
     const tools: AguiTool[] = [
       {
-        name: 'mcp_search_tool_bm25',
+        name: 'mcp_search_tools',
         description: 'Search available tools',
         parameters: { type: 'object', properties: { query: { type: 'string' } } },
         handler: ({ query }) => {
@@ -266,7 +266,7 @@ test.describe('McpMiddleware', () => {
         subscriber.next({
           type: EventType.TOOL_CALL_START,
           toolCallId: 'call-1',
-          toolCallName: 'mcp_search_tool_bm25',
+          toolCallName: 'mcp_search_tools',
         } as BaseEvent);
         subscriber.next({
           type: EventType.TOOL_CALL_ARGS,
@@ -376,7 +376,7 @@ test.describe('McpMiddleware', () => {
     let continuationInput: RunAgentInput | undefined;
     const tools: AguiTool[] = [
       {
-        name: 'mcp_search_tool_bm25',
+        name: 'mcp_search_tools',
         description: 'Search available tools',
         parameters: { type: 'object', properties: { query: { type: 'string' } } },
         handler: ({ query }) => `result for ${query}`,
@@ -398,7 +398,7 @@ test.describe('McpMiddleware', () => {
                   id: 'call-1',
                   type: 'function',
                   function: {
-                    name: 'mcp_search_tool_bm25',
+                    name: 'mcp_search_tools',
                     arguments: JSON.stringify({ query: 'first search' }),
                   },
                 },
@@ -513,7 +513,7 @@ test.describe('McpMiddleware', () => {
   test('filters final full-history snapshots after MCP continuations to preserve streamed UI order', async () => {
     const tools: AguiTool[] = [
       {
-        name: 'mcp_search_tool_bm25',
+        name: 'mcp_search_tools',
         description: 'Search available tools',
         parameters: { type: 'object', properties: { query: { type: 'string' } } },
         handler: () => 'catalog result',
@@ -535,7 +535,7 @@ test.describe('McpMiddleware', () => {
                   id: 'call-1',
                   type: 'function',
                   function: {
-                    name: 'mcp_search_tool_bm25',
+                    name: 'mcp_search_tools',
                     arguments: JSON.stringify({ query: 'all tools' }),
                   },
                 },
@@ -593,7 +593,7 @@ test.describe('McpMiddleware', () => {
     let handlerCalls = 0;
     const tools: AguiTool[] = [
       {
-        name: 'mcp_search_tool_bm25',
+        name: 'mcp_search_tools',
         description: 'Search available tools',
         parameters: { type: 'object', properties: { query: { type: 'string' } } },
         handler: () => {
@@ -618,7 +618,7 @@ test.describe('McpMiddleware', () => {
                   id: 'call-1',
                   type: 'function',
                   function: {
-                    name: 'mcp_search_tool_bm25',
+                    name: 'mcp_search_tools',
                     arguments: JSON.stringify({ query: 'all tools' }),
                   },
                 },

--- a/tests/meta-tools.test.ts
+++ b/tests/meta-tools.test.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '@playwright/test';
-import { createSearchToolDefinition, executeMetaTool, isMetaTool } from '../src/shared/meta-tools';
+import {
+    createListServersToolDefinition,
+    createSearchToolDefinition,
+    executeMetaTool,
+    isMetaTool,
+} from '../src/shared/meta-tools';
 import { ToolRouter } from '../src/shared/tool-router';
 
 function createRouterClient(
@@ -32,7 +37,9 @@ function createRouterClient(
 test.describe('executeMetaTool', () => {
     test('should expose the generic search tools meta-tool name', async () => {
         expect(createSearchToolDefinition().name).toBe('mcp_search_tools');
+        expect(createListServersToolDefinition().name).toBe('mcp_list_servers');
         expect(isMetaTool('mcp_search_tools')).toBe(true);
+        expect(isMetaTool('mcp_list_servers')).toBe(true);
     });
 
     test('should return structured errors for ambiguous schema lookup', async () => {
@@ -174,7 +181,30 @@ test.describe('executeMetaTool', () => {
 
         expect(result?.isError).toBe(false);
         const text = (result?.content[0] as any).text;
-        expect(text).toContain('No tools found matching your query');
+        expect(text).toContain('Call mcp_list_servers');
+    });
+
+    test('should list connected servers for server-aware recovery', async () => {
+        const router = new ToolRouter([
+            createRouterClient('web-server', 'Web Search', [
+                { name: 'web_search', description: 'Search the web' },
+            ]) as any,
+            createRouterClient('supabase-server', 'Supabase MCP', [
+                { name: 'list_tables', description: 'List tables' },
+            ]) as any,
+        ], { strategy: 'search' });
+
+        const result = await executeMetaTool(
+            'mcp_list_servers',
+            {},
+            router
+        );
+
+        expect(result?.isError).toBe(false);
+        const text = (result?.content[0] as any).text;
+        expect(text).toContain('Web Search');
+        expect(text).toContain('Supabase MCP');
+        expect(text).toContain('Tool count: 1');
     });
 
     test('should execute the search tools meta-tool name', async () => {

--- a/tests/meta-tools.test.ts
+++ b/tests/meta-tools.test.ts
@@ -150,7 +150,7 @@ test.describe('executeMetaTool', () => {
         expect(text).not.toContain('web_search');
     });
 
-    test('should fall back from temporal fuzzy questions to connected web search tools', async () => {
+    test('should not infer unrelated tools for temporal fuzzy questions without direct lexical match', async () => {
         const router = new ToolRouter([
             createRouterClient('web-server', 'Web Search', [
                 {
@@ -174,7 +174,7 @@ test.describe('executeMetaTool', () => {
 
         expect(result?.isError).toBe(false);
         const text = (result?.content[0] as any).text;
-        expect(text).toContain('web_search');
+        expect(text).toContain('No tools found matching your query');
     });
 
     test('should execute the search tools meta-tool name', async () => {

--- a/tests/meta-tools.test.ts
+++ b/tests/meta-tools.test.ts
@@ -39,7 +39,6 @@ test.describe('executeMetaTool', () => {
         expect(createSearchToolDefinition().name).toBe('mcp_search_tools');
         expect(createListServersToolDefinition().name).toBe('mcp_list_servers');
         expect(isMetaTool('mcp_search_tools')).toBe(true);
-        expect(isMetaTool('mcp_search_tool_bm25')).toBe(true);
         expect(isMetaTool('mcp_list_servers')).toBe(true);
     });
 
@@ -217,23 +216,6 @@ test.describe('executeMetaTool', () => {
 
         const result = await executeMetaTool(
             'mcp_search_tools',
-            { query: 'web', limit: 5 },
-            router
-        );
-
-        expect(result?.isError).toBe(false);
-        expect((result?.content[0] as any).text).toContain('web_search');
-    });
-
-    test('should keep the old BM25 search meta-tool name as a compatibility alias', async () => {
-        const router = new ToolRouter([
-            createRouterClient('web-server', 'Web Search', [
-                { name: 'web_search', description: 'Search the web' },
-            ]) as any,
-        ], { strategy: 'search' });
-
-        const result = await executeMetaTool(
-            'mcp_search_tool_bm25',
             { query: 'web', limit: 5 },
             router
         );

--- a/tests/meta-tools.test.ts
+++ b/tests/meta-tools.test.ts
@@ -39,6 +39,7 @@ test.describe('executeMetaTool', () => {
         expect(createSearchToolDefinition().name).toBe('mcp_search_tools');
         expect(createListServersToolDefinition().name).toBe('mcp_list_servers');
         expect(isMetaTool('mcp_search_tools')).toBe(true);
+        expect(isMetaTool('mcp_search_tool_bm25')).toBe(true);
         expect(isMetaTool('mcp_list_servers')).toBe(true);
     });
 
@@ -113,17 +114,17 @@ test.describe('executeMetaTool', () => {
     });
 
     test('should list every tool from a matching server without search-result truncation', async () => {
-        const supabaseTools = Array.from({ length: 29 }, (_, index) => ({
-            name: `supabase_tool_${index + 1}`,
-            description: `Supabase database capability ${index + 1}`,
+        const databaseTools = Array.from({ length: 29 }, (_, index) => ({
+            name: `database_tool_${index + 1}`,
+            description: `Database capability ${index + 1}`,
         }));
         const router = new ToolRouter([
-            createRouterClient('supabase-server', 'Supabase MCP', supabaseTools) as any,
+            createRouterClient('database-server', 'Database MCP', databaseTools) as any,
         ], { strategy: 'search' });
 
         const result = await executeMetaTool(
             'mcp_search_tools',
-            { query: 'supabase', operation: 'list', serverName: 'supabase', limit: 100 },
+            { query: 'database', operation: 'list', serverName: 'database', limit: 100 },
             router
         );
 
@@ -131,14 +132,14 @@ test.describe('executeMetaTool', () => {
         const text = (result?.content[0] as any).text;
         expect(text).toContain('totalCount: 29');
         expect(text).toContain('returnedCount: 29');
-        expect(text).toContain('supabase_tool_1');
-        expect(text).toContain('supabase_tool_29');
+        expect(text).toContain('database_tool_1');
+        expect(text).toContain('database_tool_29');
     });
 
     test('should search within a server when serverName is provided', async () => {
         const router = new ToolRouter([
-            createRouterClient('supabase-server', 'Supabase MCP', [
-                { name: 'search_projects', description: 'Search Supabase projects' },
+            createRouterClient('database-server', 'Database MCP', [
+                { name: 'search_projects', description: 'Search database projects' },
             ]) as any,
             createRouterClient('web-server', 'Web Search', [
                 { name: 'web_search', description: 'Search the web' },
@@ -147,7 +148,7 @@ test.describe('executeMetaTool', () => {
 
         const result = await executeMetaTool(
             'mcp_search_tools',
-            { query: 'search', serverName: 'supabase', limit: 10 },
+            { query: 'search', serverName: 'database', limit: 10 },
             router
         );
 
@@ -189,7 +190,7 @@ test.describe('executeMetaTool', () => {
             createRouterClient('web-server', 'Web Search', [
                 { name: 'web_search', description: 'Search the web' },
             ]) as any,
-            createRouterClient('supabase-server', 'Supabase MCP', [
+            createRouterClient('database-server', 'Database MCP', [
                 { name: 'list_tables', description: 'List tables' },
             ]) as any,
         ], { strategy: 'search' });
@@ -203,7 +204,7 @@ test.describe('executeMetaTool', () => {
         expect(result?.isError).toBe(false);
         const text = (result?.content[0] as any).text;
         expect(text).toContain('Web Search');
-        expect(text).toContain('Supabase MCP');
+        expect(text).toContain('Database MCP');
         expect(text).toContain('Tool count: 1');
     });
 
@@ -222,5 +223,41 @@ test.describe('executeMetaTool', () => {
 
         expect(result?.isError).toBe(false);
         expect((result?.content[0] as any).text).toContain('web_search');
+    });
+
+    test('should keep the old BM25 search meta-tool name as a compatibility alias', async () => {
+        const router = new ToolRouter([
+            createRouterClient('web-server', 'Web Search', [
+                { name: 'web_search', description: 'Search the web' },
+            ]) as any,
+        ], { strategy: 'search' });
+
+        const result = await executeMetaTool(
+            'mcp_search_tool_bm25',
+            { query: 'web', limit: 5 },
+            router
+        );
+
+        expect(result?.isError).toBe(false);
+        expect((result?.content[0] as any).text).toContain('web_search');
+    });
+
+    test('should resolve select queries using serverName fragments', async () => {
+        const router = new ToolRouter([
+            createRouterClient('database-server', 'Database MCP', [
+                { name: 'list_tables', description: 'List database tables' },
+            ]) as any,
+        ], { strategy: 'search' });
+
+        const result = await executeMetaTool(
+            'mcp_search_tools',
+            { query: 'select:list_tables', serverName: 'database' },
+            router
+        );
+
+        expect(result?.isError).toBe(false);
+        const text = (result?.content[0] as any).text;
+        expect(text).toContain('list_tables');
+        expect(text).toContain('Database MCP');
     });
 });

--- a/tests/meta-tools.test.ts
+++ b/tests/meta-tools.test.ts
@@ -1,7 +1,40 @@
 import { test, expect } from '@playwright/test';
-import { executeMetaTool } from '../src/shared/meta-tools';
+import { createSearchToolDefinition, executeMetaTool, isMetaTool } from '../src/shared/meta-tools';
+import { ToolRouter } from '../src/shared/tool-router';
+
+function createRouterClient(
+    serverId: string,
+    serverName: string,
+    tools: Array<{
+        name: string;
+        description?: string;
+        inputSchema?: Record<string, unknown>;
+    }>
+) {
+    return {
+        isConnected: () => true,
+        getServerId: () => serverId,
+        getServerName: () => serverName,
+        getSessionId: () => `${serverId}-session`,
+        listTools: async () => ({
+            tools: tools.map((tool) => ({
+                inputSchema: { type: 'object' as const, properties: {} },
+                ...tool,
+            })),
+        }),
+        callTool: async (name: string, args: Record<string, unknown>) => ({
+            content: [{ type: 'text' as const, text: `${serverName}:${name}:${JSON.stringify(args)}` }],
+            isError: false,
+        }),
+    };
+}
 
 test.describe('executeMetaTool', () => {
+    test('should expose the generic search tools meta-tool name', async () => {
+        expect(createSearchToolDefinition().name).toBe('mcp_search_tools');
+        expect(isMetaTool('mcp_search_tools')).toBe(true);
+    });
+
     test('should return structured errors for ambiguous schema lookup', async () => {
         const router = {
             getToolSchema: () => {
@@ -70,5 +103,94 @@ test.describe('executeMetaTool', () => {
             })
         );
         expect(schema.executionInstructions.note).toContain('Do not call this discovered tool directly');
+    });
+
+    test('should list every tool from a matching server without search-result truncation', async () => {
+        const supabaseTools = Array.from({ length: 29 }, (_, index) => ({
+            name: `supabase_tool_${index + 1}`,
+            description: `Supabase database capability ${index + 1}`,
+        }));
+        const router = new ToolRouter([
+            createRouterClient('supabase-server', 'Supabase MCP', supabaseTools) as any,
+        ], { strategy: 'search' });
+
+        const result = await executeMetaTool(
+            'mcp_search_tools',
+            { query: 'supabase', operation: 'list', serverName: 'supabase', limit: 100 },
+            router
+        );
+
+        expect(result?.isError).toBe(false);
+        const text = (result?.content[0] as any).text;
+        expect(text).toContain('totalCount: 29');
+        expect(text).toContain('returnedCount: 29');
+        expect(text).toContain('supabase_tool_1');
+        expect(text).toContain('supabase_tool_29');
+    });
+
+    test('should search within a server when serverName is provided', async () => {
+        const router = new ToolRouter([
+            createRouterClient('supabase-server', 'Supabase MCP', [
+                { name: 'search_projects', description: 'Search Supabase projects' },
+            ]) as any,
+            createRouterClient('web-server', 'Web Search', [
+                { name: 'web_search', description: 'Search the web' },
+            ]) as any,
+        ], { strategy: 'search' });
+
+        const result = await executeMetaTool(
+            'mcp_search_tools',
+            { query: 'search', serverName: 'supabase', limit: 10 },
+            router
+        );
+
+        expect(result?.isError).toBe(false);
+        const text = (result?.content[0] as any).text;
+        expect(text).toContain('search_projects');
+        expect(text).not.toContain('web_search');
+    });
+
+    test('should fall back from temporal fuzzy questions to connected web search tools', async () => {
+        const router = new ToolRouter([
+            createRouterClient('web-server', 'Web Search', [
+                {
+                    name: 'web_search',
+                    description: 'Search the web for current information and recent results',
+                    inputSchema: {
+                        type: 'object',
+                        properties: {
+                            query: { type: 'string', description: 'Search query' },
+                        },
+                    },
+                },
+            ]) as any,
+        ], { strategy: 'search' });
+
+        const result = await executeMetaTool(
+            'mcp_search_tools',
+            { query: "who won yesterday's ipl match", limit: 5 },
+            router
+        );
+
+        expect(result?.isError).toBe(false);
+        const text = (result?.content[0] as any).text;
+        expect(text).toContain('web_search');
+    });
+
+    test('should execute the search tools meta-tool name', async () => {
+        const router = new ToolRouter([
+            createRouterClient('web-server', 'Web Search', [
+                { name: 'web_search', description: 'Search the web' },
+            ]) as any,
+        ], { strategy: 'search' });
+
+        const result = await executeMetaTool(
+            'mcp_search_tools',
+            { query: 'web', limit: 5 },
+            router
+        );
+
+        expect(result?.isError).toBe(false);
+        expect((result?.content[0] as any).text).toContain('web_search');
     });
 });

--- a/tests/tool-index.perf.test.ts
+++ b/tests/tool-index.perf.test.ts
@@ -63,7 +63,7 @@ async function measureIndexPerformance(
     await index.buildIndex(tools);
     const buildMs = performance.now() - buildStart;
 
-    const bm25Queries = [
+    const searchQueries = [
         'github pull request repository',
         'slack channel messages',
         'database query records',
@@ -71,11 +71,11 @@ async function measureIndexPerformance(
         'search workflow query',
     ];
 
-    const bm25Start = performance.now();
+    const searchStart = performance.now();
     for (let i = 0; i < 100; i++) {
-        await index.search(bm25Queries[i % bm25Queries.length], 10);
+        await index.search(searchQueries[i % searchQueries.length], 10);
     }
-    const bm25Ms = performance.now() - bm25Start;
+    const searchMs = performance.now() - searchStart;
 
     const regexStart = performance.now();
     for (let i = 0; i < 100; i++) {
@@ -93,7 +93,7 @@ async function measureIndexPerformance(
         datasetSize: tools.length,
         duplicateNames: 200,
         buildMs: Number(buildMs.toFixed(2)),
-        avgBm25Ms: Number((bm25Ms / 100).toFixed(4)),
+        avgSearchMs: Number((searchMs / 100).toFixed(4)),
         avgRegexMs: Number((regexMs / 100).toFixed(4)),
         totalTokenLookupMs: Number(totalTokenMs.toFixed(4)),
         totalTokenCost,
@@ -105,19 +105,19 @@ async function measureIndexPerformance(
 function assertWithinBudget(
     result: {
         buildMs: number;
-        avgBm25Ms: number;
+        avgSearchMs: number;
         avgRegexMs: number;
         totalTokenLookupMs: number;
     },
     budget: {
         buildMs: number;
-        avgBm25Ms: number;
+        avgSearchMs: number;
         avgRegexMs: number;
         totalTokenLookupMs: number;
     }
 ) {
     expect(result.buildMs).toBeLessThan(budget.buildMs);
-    expect(result.avgBm25Ms).toBeLessThan(budget.avgBm25Ms);
+    expect(result.avgSearchMs).toBeLessThan(budget.avgSearchMs);
     expect(result.avgRegexMs).toBeLessThan(budget.avgRegexMs);
     expect(result.totalTokenLookupMs).toBeLessThan(budget.totalTokenLookupMs);
 }
@@ -136,7 +136,7 @@ test.describe('ToolIndex performance', () => {
         expect(result.totalTokenCost).toBeGreaterThan(0);
         assertWithinBudget(result, {
             buildMs: 1000,
-            avgBm25Ms: 5,
+            avgSearchMs: 5,
             avgRegexMs: 3,
             totalTokenLookupMs: 1,
         });
@@ -160,7 +160,7 @@ test.describe('ToolIndex performance', () => {
         expect(result.totalTokenCost).toBeGreaterThan(0);
         assertWithinBudget(result, {
             buildMs: 3000,
-            avgBm25Ms: 5,
+            avgSearchMs: 5,
             avgRegexMs: 3,
             totalTokenLookupMs: 1,
         });
@@ -187,7 +187,7 @@ test.describe('ToolIndex performance', () => {
         expect(result.totalTokenCost).toBeGreaterThan(0);
         assertWithinBudget(result, {
             buildMs: 1000,
-            avgBm25Ms: 5,
+            avgSearchMs: 5,
             avgRegexMs: 3,
             totalTokenLookupMs: 1,
         });

--- a/tests/tool-index.test.ts
+++ b/tests/tool-index.test.ts
@@ -68,6 +68,35 @@ test.describe('ToolIndex', () => {
         );
     });
 
+    test('should prefer exact namespace matches before fuzzy server names', async () => {
+        const index = new ToolIndex();
+        const tools: IndexedTool[] = [
+            {
+                name: 'search',
+                description: 'Search GitHub pull requests and repositories',
+                inputSchema: { type: 'object', properties: {} },
+                serverName: 'GitHub',
+                sessionId: 'github-session',
+                serverId: 'github',
+            },
+            {
+                name: 'search',
+                description: 'Search enterprise GitHub resources',
+                inputSchema: { type: 'object', properties: {} },
+                serverName: 'GitHub Enterprise',
+                sessionId: 'enterprise-session',
+                serverId: 'enterprise',
+            },
+        ];
+
+        await index.buildIndex(tools);
+
+        const results = index.getTool('search', 'github');
+
+        expect(results).toHaveLength(1);
+        expect(results[0].serverId).toBe('github');
+    });
+
     test('should strip required-term prefixes before embedding query text', async () => {
         let embeddingQueryText: string | null = null;
         const embedFn = async (texts: string[]): Promise<number[][]> => {

--- a/tests/tool-index.test.ts
+++ b/tests/tool-index.test.ts
@@ -97,6 +97,30 @@ test.describe('ToolIndex', () => {
         expect(results[0].serverId).toBe('github');
     });
 
+    test('should require explicit opt-in before matching namespace against serverName fragments', async () => {
+        const index = new ToolIndex();
+        const tools: IndexedTool[] = [
+            {
+                name: 'search',
+                description: 'Search database tables',
+                inputSchema: { type: 'object', properties: {} },
+                serverName: 'Database MCP',
+                sessionId: 'database-session',
+                serverId: 'database-server',
+            },
+        ];
+
+        await index.buildIndex(tools);
+
+        expect(index.getTool('search', 'database')).toEqual([]);
+
+        const fragmentResults = index.getTool('search', 'database', {
+            allowServerNameFragment: true,
+        });
+        expect(fragmentResults).toHaveLength(1);
+        expect(fragmentResults[0].serverName).toBe('Database MCP');
+    });
+
     test('should strip required-term prefixes before embedding query text', async () => {
         let embeddingQueryText: string | null = null;
         const embedFn = async (texts: string[]): Promise<number[][]> => {


### PR DESCRIPTION
## Detailed PR Description  

### Type of PR  
- [x] **Feature**  

### Area(s) Affected  
- **`server`** – MCP client, handlers (e.g., `oauth-client.ts`)  
- **`client`** – React/Vue/SSE client updates (implicit via new APIs)  
- **`adapters`** – AG‑UI, Vercel AI, LangChain, Mastra integrations (tests updated)  
- **`storage`** – Indexing/back‑end changes (ToolIndex extensions)  
- **`docs`** – Docusaurus documentation (`meta-tools.md`, `tool-router.md`)  
- **`examples`** – Example applications that invoke the renamed tool  
- **`ci`** – Test suite adjustments (new/updated tests)  

### Description of Changes  

1. **Meta‑tool rename & consolidation**  
   * Renamed the primary discovery tool from **`mcp_search_tool_bm25`** to **`mcp_search_tools`**.  
   * Updated all references (documentation, tests, tool definitions) to the new name.  

2. **Server‑scoped search & deterministic listing**  
   * Added a new `operation` field (`"search"` | `"list"`) to the meta‑tool input schema.  
   * Implemented **server‑scoped search**: `ToolRouter.searchTools()` now accepts optional `serverId` / `serverName` filters via a new `ToolSearchOptions` type.  
   * Introduced a **listing mode** (`operation: "list"`) that returns a paginated, deterministic list of tools per server.  

3. **New public APIs**  
   * `ToolRouter.listServers(options?)` – returns an array of `ToolServerSummary` (server name, id, session, tool count).  
   * `ToolRouter.listTools(options?)` – returns a `ToolListResult` containing tools for a given server with pagination support.  

4. **ToolIndex extensions**  
   * Added `ToolServerSummary`, `ToolSearchOptions`, and `ToolListResult` types.  
   * Implemented server‑level aggregation logic and filtering inside `ToolIndex`.  

5. **Meta‑tool execution updates**  
   * `executeMetaTool` now normalises results for both search and list operations, and resolves `select:` look‑ups within an optional server namespace.  
   * Updated `createSearchToolDefinition` to expose the new input schema (`query`, `operation`, `serverId`, `serverName`, `limit`, `page`).  

6. **Fallback temporal‑query behaviour**  
   * `ToolRouter.searchTools()` now falls back to a “web/browser” keyword search when the BM25 index returns no hits, improving robustness.  

7. **MCP client adjustment**  
   * `MCPClient.getServerName()` no longer derives the name from `serverVersion` metadata; it now returns the configured `serverName` directly (temporary change noted).  

8. **Documentation & tests**  
   * Updated `docs/core-concepts/meta-tools.md` and `docs/reference/tool-router.md` to reflect the renamed tool, new operation modes, and new APIs.  
   * Adjusted existing tests (`agui-middleware.test.ts`, `meta-tools.test.ts`, `tool-index.perf.test.ts`) to use `mcp_search_tools` and to cover server‑scoped search/listing.  

### Why These Changes?  

* **Improved discoverability** – Server‑scoped search lets LLMs retrieve tools that are relevant to a specific server context, reducing noise and latency.  
* **Deterministic pagination** – The new `list` operation provides a stable, paginated view of available tools, essential for UI components and large deployments.  
* **Cleaner API surface** – Consolidating all meta‑search capabilities under a single tool (`mcp_search_tools`) simplifies integration and documentation.  
* **Future‑proofing** – Adding explicit server filters and list APIs prepares the platform for multi‑tenant scenarios and richer tooling ecosystems.  
* **Documentation consistency** – Updating docs and tests ensures developers have accurate guidance and that CI validates the new behaviour.  

---

### Checklist (completed)  

- [x] Code follows TypeScript strict‑mode guidelines  
- [x] Tests added/updated  
- [x] Documentation updated (user‑facing changes)  
- [x] Build succeeds (`npm run build`)  
- [x] Type check passes (`npm run type-check`)  
- [x] All tests pass (`npm test`)  
- [x] Commit messages follow conventional format  

---  

**Summary** – This PR refactors and consolidates the meta‑tool suite, introduces server‑scoped search and deterministic listing, renames the primary tool for clarity, and updates the entire codebase, tests, and documentation to reflect these enhancements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new ToolRouter/ToolIndex APIs and renames the primary meta-tool, which can break existing integrations relying on the old meta-tool name/signature or search behavior. Changes also affect multi-server routing/namespace resolution and pagination, so regressions could impact tool discovery/execution in production.
> 
> **Overview**
> Updates the `search` strategy meta-tool set by renaming `mcp_search_tool_bm25` to `mcp_search_tools`, expanding its schema with `operation: "search"|"list"`, server scoping (`serverId`/`serverName`), and pagination (`cursor`), and adding a new `mcp_list_servers` meta-tool for server introspection/recovery.
> 
> Extends `ToolRouter`/`ToolIndex` with server-filtered search plus new `listServers()` and `listTools()` APIs (including server aggregation metadata), and tightens namespace resolution to prefer exact `serverId`/`sessionId` matches with optional fragment matching when explicitly enabled.
> 
> Adjusts MCP client server-name reporting to return the configured `serverName` directly, and updates docs and tests to reflect the new meta-tool names and server-scoped discovery/listing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3255ba3ab32b7e6538dd8d1539f154df60168695. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->