### PR TITLE
Fix tool lookup by server name fragments

### DIFF
--- a/src/shared/tool-index.ts
+++ b/src/shared/tool-index.ts
@@ -456,13 +456,20 @@ export class ToolIndex {
 
   /**
    * Get tool definition(s) by name.
-   * If namespace is provided, it tries to match sessionId or serverName.
+   * If namespace is provided, it matches exact session/server IDs or a
+   * case-insensitive fragment of the human-readable server name.
    */
   getTool(name: string, namespace?: string): IndexedTool[] {
     const list = this.tools.get(name) ?? [];
     if (!namespace) return list;
 
-    return list.filter((t) => t.sessionId === namespace || t.serverId === namespace);
+    const namespaceLower = namespace.toLowerCase();
+    return list.filter(
+      (t) =>
+        t.sessionId === namespace ||
+        t.serverId === namespace ||
+        t.serverName.toLowerCase().includes(namespaceLower)
+    );
   }
 
   /** All indexed tool names. */

--- a/tests/tool-index.test.ts
+++ b/tests/tool-index.test.ts
@@ -68,6 +68,35 @@ test.describe('ToolIndex', () => {
         );
     });
 
+    test('should resolve tools by exact IDs or server name fragments', async () => {
+        const index = new ToolIndex();
+        const tools: IndexedTool[] = [
+            {
+                name: 'query',
+                description: 'Query database tables',
+                inputSchema: { type: 'object', properties: {} },
+                serverName: 'Database MCP',
+                sessionId: 'session-db',
+                serverId: 'server-db',
+            },
+            {
+                name: 'query',
+                description: 'Query analytics warehouse',
+                inputSchema: { type: 'object', properties: {} },
+                serverName: 'Analytics Warehouse',
+                sessionId: 'session-analytics',
+                serverId: 'server-analytics',
+            },
+        ];
+
+        await index.buildIndex(tools);
+
+        expect(index.getTool('query', 'session-db')).toHaveLength(1);
+        expect(index.getTool('query', 'server-db')).toHaveLength(1);
+        expect(index.getTool('query', 'MCP')).toHaveLength(1);
+        expect(index.getTool('query', 'DATABASE')[0].serverName).toBe('Database MCP');
+    });
+
     test('should strip required-term prefixes before embedding query text', async () => {
         let embeddingQueryText: string | null = null;
         const embedFn = async (texts: string[]): Promise<number[][]> => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What is the type of this PR?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Which area of the project does this PR affect?

- [ ] `server` (MCP client, handlers)
- [ ] `client` (React, Vue, SSE client)
- [ ] `adapters` (Vercel AI, LangChain, Mastra, AG-UI)
- [ ] `storage` (Redis, SQLite, File, Memory backends)
- [ ] `docs` (Docusaurus documentation)
- [ ] `examples` (Example applications)
- [ ] `ci` (GitHub workflows)
- [x] Other

## Description of the change

Makes `ToolIndex.getTool()` keep exact matching for `sessionId` and `serverId`, while also allowing case-insensitive fragment matching against the human-readable `serverName`. This aligns schema/select lookups with search behavior for server name fragments.

Adds a regression test covering exact ID lookup and server-name fragment lookup.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] Code follows TypeScript strict mode guidelines
- [x] Tests added/updated
- [ ] Documentation updated (if user-facing change)
- [ ] Build succeeds (`npm run build`)
- [ ] Type check passes (`npm run type-check` fails on pre-existing syntax errors in `examples/next/app/oauth/callback/page.tsx`)
- [ ] All tests pass (`npm test` not run; focused regression suite passes)
- [x] Commit messages follow conventional format

## Related Issue

Closes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20abfd92-7822-4d84-948d-0d40c9f99f41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20abfd92-7822-4d84-948d-0d40c9f99f41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

