### PR TITLE
feat: add support for static Authorization headers in MCP connections

### DIFF
--- a/src/server/handlers/sse-handler.ts
+++ b/src/server/handlers/sse-handler.ts
@@ -73,6 +73,16 @@ export interface SSEHandlerOptions {
 
 const DEFAULT_HEARTBEAT_INTERVAL = 30000;
 
+function normalizeHeaders(headers?: Record<string, string>): Record<string, string> | undefined {
+  if (!headers || typeof headers !== 'object') return undefined;
+
+  const entries = Object.entries(headers)
+    .map(([key, value]) => [key.trim(), String(value).trim()] as const)
+    .filter(([key, value]) => key.length > 0 && value.length > 0);
+
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
 // ============================================
 // SSEConnectionManager Class
 // ============================================
@@ -238,6 +248,7 @@ export class SSEConnectionManager {
    */
   private async connect(params: ConnectParams): Promise<ConnectResult> {
     const { serverName, serverUrl, callbackUrl, transportType } = params;
+    const headers = normalizeHeaders(params.headers);
 
     // Normalize serverId to max 12 chars to keep tool names under 64 chars (DeepSeek/OpenAI limits)
     // Tool name format: tool_<serverId>_<toolName> - with 12 char serverId leaves 46 chars for tool name
@@ -280,6 +291,7 @@ export class SSEConnectionManager {
         serverUrl,
         callbackUrl,
         transportType,
+        headers,
         ...clientMetadata, // Spread client metadata (clientName, clientUri, logoUri, policyUri)
       });
 

--- a/src/server/mcp/oauth-client.ts
+++ b/src/server/mcp/oauth-client.ts
@@ -238,9 +238,11 @@ export class MCPClient {
     }
 
     const baseUrl = new URL(this.serverUrl);
+    const hasAuthorizationHeader = Object.keys(this.headers || {})
+      .some((key) => key.toLowerCase() === 'authorization');
     const transportOptions = {
-      authProvider: this.oauthProvider!,
-      ...(this.headers && { headers: this.headers }),
+      ...(!hasAuthorizationHeader && { authProvider: this.oauthProvider! }),
+      ...(this.headers && { requestInit: { headers: this.headers } }),
       /**
        * Custom fetch implementation to handle connection timeouts.
        * Observation: SDK 1.24.0+ connections may hang indefinitely in some environments.
@@ -359,6 +361,7 @@ export class MCPClient {
         serverUrl: this.serverUrl,
         callbackUrl: this.callbackUrl,
         transportType: this.transportType || 'streamable_http',
+        headers: this.headers,
         createdAt: this.createdAt,
         active: false,
       }, Math.floor(STATE_EXPIRATION_MS / 1000)); // Short TTL until connection succeeds
@@ -388,6 +391,7 @@ export class MCPClient {
       serverUrl: this.serverUrl,
       callbackUrl: this.callbackUrl,
       transportType: (this.transportType || 'streamable_http') as TransportType,
+      headers: this.headers,
       createdAt: this.createdAt || Date.now(),
       active,
     };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -204,6 +204,7 @@ export interface ConnectParams {
   serverUrl: string;
   callbackUrl: string;
   transportType?: TransportType;
+  headers?: Record<string, string>;
 }
 
 export interface DisconnectParams {

--- a/tests/oauth-client.test.ts
+++ b/tests/oauth-client.test.ts
@@ -104,3 +104,34 @@ test.describe('MCPClient.getMcpServerConfig', () => {
         expect(config).toEqual({});
     });
 });
+
+test.describe('MCPClient static Authorization headers', () => {
+    test.afterEach(() => {
+        _setStorageInstanceForTesting(null);
+    });
+
+    test('passes Authorization through requestInit and disables OAuth provider on the transport', async () => {
+        _setStorageInstanceForTesting(new MemoryStorageBackend());
+
+        const client = new MCPClient({
+            identity: 'test-user',
+            sessionId: 'static-auth-session',
+            serverId: 'static-auth-server',
+            serverName: 'Static Auth Server',
+            serverUrl: 'https://example.com/mcp',
+            callbackUrl: 'https://app.local/auth/callback',
+            transportType: 'streamable_http',
+            headers: {
+                Authorization: 'Bearer static-token',
+            },
+        });
+
+        await (client as any).initialize();
+        const transport = (client as any).getTransport('streamable_http');
+
+        expect((transport as any)._requestInit?.headers).toEqual({
+            Authorization: 'Bearer static-token',
+        });
+        expect((transport as any)._authProvider).toBeUndefined();
+    });
+});

--- a/tests/sse-handler-resume-auth.test.ts
+++ b/tests/sse-handler-resume-auth.test.ts
@@ -168,5 +168,54 @@ test.describe('SSEConnectionManager connect duplicate handling', () => {
       manager.dispose();
     }
   });
+
+  test('passes custom headers from connect params into the MCP client', async () => {
+    const storage = new MemoryStorageBackend();
+    _setStorageInstanceForTesting(storage);
+
+    const manager = new SSEConnectionManager(
+      { identity: 'user-4' },
+      () => { }
+    );
+
+    const originalConnect = (MCPClient.prototype as any).connect;
+    const originalListTools = (MCPClient.prototype as any).listTools;
+
+    let seenHeaders: Record<string, string> | undefined;
+
+    (MCPClient.prototype as any).connect = async function () {
+      seenHeaders = (this as any).headers;
+    };
+
+    (MCPClient.prototype as any).listTools = async function () {
+      return { tools: [] };
+    };
+
+    try {
+      const response = await manager.handleRequest({
+        id: '4',
+        method: 'connect',
+        params: {
+          serverId: 'srv-4',
+          serverName: 'Server Four',
+          serverUrl: 'https://example.com/mcp-headers',
+          callbackUrl: 'https://app.local/oauth/callback',
+          headers: {
+            Authorization: 'Bearer github_pat_test',
+            'X-Empty': '',
+          },
+        },
+      } as any);
+
+      expect((response as any).error).toBeUndefined();
+      expect(seenHeaders).toEqual({
+        Authorization: 'Bearer github_pat_test',
+      });
+    } finally {
+      (MCPClient.prototype as any).connect = originalConnect;
+      (MCPClient.prototype as any).listTools = originalListTools;
+      manager.dispose();
+    }
+  });
 });
 


### PR DESCRIPTION
This PR adds support for passing static `Authorization` headers (e.g., `Bearer <token>`) when establishing MCP connections, providing a simpler alternative to OAuth-based authentication for server setups that use static tokens or API keys.

## Changes

### Type definitions
- **`src/shared/types.ts`**: Added optional `headers?: Record<string, string>` field to `ConnectParams`

### Server-side SSE handler
- **`src/server/handlers/sse-handler.ts`**: Added `normalizeHeaders()` helper that sanitizes headers — trims whitespace from keys/values and filters out empty entries — and passes them through the SSE connection manager into the MCP client

### OAuth/MCP client
- **`src/server/mcp/oauth-client.ts`**:
  - Detects when a static `Authorization` header is provided and **disables the OAuth provider** (static auth and OAuth are mutually exclusive)
  - Passes headers via `requestInit` (standard `fetch` init) instead of the SDK's `headers` property for correct transport compatibility
  - Preserves headers in connection state persistence (`setConnectParams`) and in `getMcpServerConfig()` responses

### Tests
- **`tests/oauth-client.test.ts`**: Verifies Authorization headers pass through `requestInit` and OAuth provider is correctly omitted
- **`tests/sse-handler-resume-auth.test.ts`**: Verifies custom headers from connect params flow correctly into the MCP client, including filtering of empty values

Closes #99