### PR TITLE
feat: Index nested tool schema metadata

### DIFF
--- a/benchmarks/benchmark.md
+++ b/benchmarks/benchmark.md
@@ -24,7 +24,7 @@ benchmarks/results/live-report.md
 
 Live benchmark runs use actual connected MCP servers from `examples/next`.
 
-The measured token counts are estimated with `ToolIndex.estimateTokens`, the same estimator used by the SDK benchmark harness. Latency values are measured locally with Node.js `performance.now()` and reported as average, p50, p95, and p99 search latency.
+The measured token counts are estimated by the benchmark harness in `benchmarks/token-estimator.mjs`. Latency values are measured locally with Node.js `performance.now()` and reported as average, p50, p95, and p99 search latency.
 
 The benchmark measures:
 
@@ -111,5 +111,4 @@ While these results highlight dramatic improvements in schema context management
 1. **End-to-End Latency**: Overall agent performance also depends on model reasoning, network round-trips to MCP servers, and tool execution time.
 2. **Cost Savings**: Reduction in input tokens directly translates to lower operational costs when using usage-based LLM APIs.
 3. **Model Focus**: Smaller context windows often lead to improved model performance and fewer "lost in the middle" errors.
-
 

--- a/benchmarks/token-estimator.mjs
+++ b/benchmarks/token-estimator.mjs
@@ -1,0 +1,50 @@
+const CALIBRATION_DIVISOR = 3.6;
+
+function classifyChar(ch) {
+  const code = ch.charCodeAt(0);
+  if (code <= 0x20 || ch === '{' || ch === '}' || ch === '[' || ch === ']' || ch === ':' || ch === ',') return 1.0;
+  if (code >= 0x21 && code <= 0x2f) return 1.5;
+  if (code >= 0x30 && code <= 0x39) return 2.0;
+  if (code >= 0x41 && code <= 0x5a) return 3.5;
+  if (code >= 0x61 && code <= 0x7a) return 4.0;
+  return 2.5;
+}
+
+function stringifyJson(value) {
+  const seen = new WeakSet();
+  return JSON.stringify(value, (_key, nestedValue) => {
+    if (!nestedValue || typeof nestedValue !== 'object') {
+      return nestedValue;
+    }
+
+    if (seen.has(nestedValue)) {
+      return '[Circular]';
+    }
+
+    seen.add(nestedValue);
+    return nestedValue;
+  });
+}
+
+export function estimateTextTokens(text) {
+  let weightedLen = 0;
+  const source = String(text);
+
+  for (let i = 0; i < source.length; i++) {
+    weightedLen += 1 / classifyChar(source[i]);
+  }
+
+  return Math.ceil(weightedLen / (1 / CALIBRATION_DIVISOR));
+}
+
+export function estimateToolTokens(tool) {
+  const parts = [tool.name];
+  if (tool.description) parts.push(tool.description);
+  if (tool.inputSchema) parts.push(stringifyJson(tool.inputSchema));
+
+  return estimateTextTokens(parts.join(' '));
+}
+
+export function estimateToolsTokens(tools) {
+  return tools.reduce((sum, tool) => sum + estimateToolTokens(tool), 0);
+}

--- a/benchmarks/toolrouter-efficiency.mjs
+++ b/benchmarks/toolrouter-efficiency.mjs
@@ -12,6 +12,7 @@ import {
   createRegexSearchToolDefinition,
   createSearchToolDefinition,
 } from '../dist/shared/index.mjs';
+import { estimateToolTokens, estimateToolsTokens } from './token-estimator.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const resultsDir = resolve(__dirname, 'results');
@@ -105,7 +106,7 @@ function getMetaToolTokens() {
     createExecuteToolDefinition(),
   ];
 
-  return metaTools.reduce((sum, tool) => sum + ToolIndex.estimateTokens(tool), 0);
+  return estimateToolsTokens(metaTools);
 }
 
 function formatSearchResultText(results) {
@@ -113,10 +114,27 @@ function formatSearchResultText(results) {
     .map((tool, index) => {
       const serverId = tool.serverId ? `, serverId: ${tool.serverId}` : '';
       return `${index + 1}. ${tool.name} (server: ${tool.serverName}${serverId})\n` +
-        `   ${tool.description}\n` +
-        `   Estimated tokens: ${tool.estimatedTokens}`;
+        `   ${tool.description}`;
     })
     .join('\n');
+}
+
+function getToolKey(tool) {
+  return `${tool.sessionId ?? ''}::${tool.serverId ?? ''}::${tool.name}`;
+}
+
+function buildToolTokenIndex(tools) {
+  const tokenIndex = new Map();
+
+  for (const tool of tools) {
+    tokenIndex.set(getToolKey(tool), estimateToolTokens(tool));
+  }
+
+  return tokenIndex;
+}
+
+function getSummaryTokenCost(summary, tokenIndex) {
+  return tokenIndex.get(getToolKey(summary)) ?? 0;
 }
 
 export async function runScenario(options) {
@@ -142,6 +160,7 @@ export async function runToolCatalogScenario(options) {
   const buildStart = performance.now();
   await index.buildIndex(tools);
   const buildMs = performance.now() - buildStart;
+  const toolTokenIndex = buildToolTokenIndex(tools);
 
   for (let i = 0; i < warmupIterations; i++) {
     await index.search(SEARCH_QUERIES[i % SEARCH_QUERIES.length], 5);
@@ -161,14 +180,16 @@ export async function runToolCatalogScenario(options) {
     }
   }
 
-  const fullUpfrontTokens = index.getTotalTokenCost();
+  const fullUpfrontTokens = estimateToolsTokens(tools);
   const toolRouterInitialTokens = getMetaToolTokens();
   const discoveryTokens =
     toolRouterInitialTokens + estimatePlainTextTokens(formatSearchResultText(firstResults));
-  const selectedOneToolTokens = firstResults[0]?.estimatedTokens ?? 0;
+  const selectedOneToolTokens = firstResults[0]
+    ? getSummaryTokenCost(firstResults[0], toolTokenIndex)
+    : 0;
   const selectedThreeToolTokens = firstResults
     .slice(0, 3)
-    .reduce((sum, tool) => sum + (tool.estimatedTokens ?? 0), 0);
+    .reduce((sum, tool) => sum + getSummaryTokenCost(tool, toolTokenIndex), 0);
   const oneToolTaskTokens = discoveryTokens + selectedOneToolTokens;
   const threeToolTaskTokens = discoveryTokens + selectedThreeToolTokens;
 

--- a/docs/reference/tool-router.md
+++ b/docs/reference/tool-router.md
@@ -94,15 +94,11 @@ console.log(listed.totalCount, listed.tools);
 
 ### `SchemaCompressor`
 
-Utility for reducing tool schema token overhead by yielding compact representations (name + description + inline parameterHint).
+Utility for yielding compact tool representations (name + description + inline parameterHint) without the full `inputSchema`.
 
 ```typescript
 import { SchemaCompressor } from '@mcp-ts/sdk/shared';
 
 // Get a compact schema omitting full `inputSchema`
 const compact = SchemaCompressor.toCompact(tool);
-
-// Estimate token savings across all tools
-const stats = SchemaCompressor.estimateSavings(tools);
-console.log(stats.savingsPercent); // e.g., "82.3%"
 ```

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -98,7 +98,6 @@ export {
 export {
   SchemaCompressor,
   type CompactTool,
-  type CompressionStats,
 } from './schema-compressor.js';
 
 export {

--- a/src/shared/meta-tools.ts
+++ b/src/shared/meta-tools.ts
@@ -518,14 +518,12 @@ function formatToolSummaries(
     description: string;
     serverName: string;
     serverId: string;
-    estimatedTokens: number;
   }>
 ): string[] {
   return tools.map(
     (t, i) =>
       `${i + 1}. **${t.name}** (server: ${t.serverName}, serverId: ${t.serverId})\n` +
-      `   ${t.description}\n` +
-      `   Estimated tokens: ${t.estimatedTokens}`
+      `   ${t.description}`
   );
 }
 

--- a/src/shared/schema-compressor.ts
+++ b/src/shared/schema-compressor.ts
@@ -1,14 +1,13 @@
 /**
- * SchemaCompressor — Utilities for reducing tool schema token overhead.
+ * SchemaCompressor — Utilities for compact tool representations.
  *
  * Provides compact representations of tools (name + description only,
- * no inputSchema) and token savings estimation.
+ * no inputSchema).
  *
  * @packageDocumentation
  */
 
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
-import { ToolIndex } from './tool-index.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -26,17 +25,6 @@ export interface CompactTool {
    * e.g. "(location: string, unit?: 'celsius' | 'fahrenheit')"
    */
   parameterHint?: string;
-}
-
-export interface CompressionStats {
-  /** Estimated tokens for the *full* tool list. */
-  fullTokens: number;
-  /** Estimated tokens for the *compact* tool list. */
-  compactTokens: number;
-  /** Absolute token savings. */
-  savedTokens: number;
-  /** Percentage savings as a human-readable string, e.g. "82.3%". */
-  savingsPercent: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -92,33 +80,5 @@ export class SchemaCompressor {
   static compactAll(tools: Tool[], options?: { maxTools?: number }): CompactTool[] {
     const limited = options?.maxTools ? tools.slice(0, options.maxTools) : tools;
     return limited.map((t) => SchemaCompressor.toCompact(t));
-  }
-
-  /**
-   * Estimate token savings from using compact vs full tool schemas.
-   */
-  static estimateSavings(tools: Tool[]): CompressionStats {
-    let fullTokens = 0;
-    let compactTokens = 0;
-
-    for (const tool of tools) {
-      fullTokens += ToolIndex.estimateTokens(tool);
-
-      // Compact form: name + description + parameterHint
-      const compact = SchemaCompressor.toCompact(tool);
-      const text = [compact.name, compact.description ?? '', compact.parameterHint ?? ''].join(' ');
-      // Simple estimation for compact: ~4 chars per token for plain text
-      compactTokens += Math.ceil(text.length / 4);
-    }
-
-    const saved = fullTokens - compactTokens;
-    const pct = fullTokens > 0 ? ((saved / fullTokens) * 100).toFixed(1) : '0.0';
-
-    return {
-      fullTokens,
-      compactTokens,
-      savedTokens: saved,
-      savingsPercent: `${pct}%`,
-    };
   }
 }

--- a/src/shared/tool-index.ts
+++ b/src/shared/tool-index.ts
@@ -617,21 +617,98 @@ export class ToolIndex {
     const parts: string[] = [tool.name];
     if (tool.description) parts.push(tool.description);
 
-    // Include property names and descriptions from schema
     if (tool.inputSchema && typeof tool.inputSchema === 'object') {
-      const schema = tool.inputSchema as Record<string, unknown>;
-      const props = schema.properties as Record<string, { description?: string }> | undefined;
-      if (props) {
-        for (const [key, val] of Object.entries(props)) {
-          parts.push(key);
-          if (val && typeof val === 'object' && val.description) {
-            parts.push(val.description);
-          }
-        }
-      }
+      this.collectSchemaSearchText(tool.inputSchema, parts);
     }
 
     return parts.join(' ');
+  }
+
+  /** Recursively collect JSON Schema argument names and descriptions. */
+  private collectSchemaSearchText(
+    schema: unknown,
+    parts: string[],
+    seen = new WeakSet<object>()
+  ): void {
+    if (!schema || typeof schema !== 'object') return;
+    if (seen.has(schema)) return;
+    seen.add(schema);
+
+    if (Array.isArray(schema)) {
+      for (const item of schema) {
+        this.collectSchemaSearchText(item, parts, seen);
+      }
+      return;
+    }
+
+    const schemaObject = schema as Record<string, unknown>;
+    this.pushStringValue(schemaObject.description, parts);
+    this.pushStringValue(schemaObject.title, parts);
+
+    const properties = schemaObject.properties;
+    if (properties && typeof properties === 'object' && !Array.isArray(properties)) {
+      for (const [propertyName, propertySchema] of Object.entries(properties)) {
+        parts.push(propertyName);
+        this.collectSchemaSearchText(propertySchema, parts, seen);
+      }
+    }
+
+    const patternProperties = schemaObject.patternProperties;
+    if (
+      patternProperties &&
+      typeof patternProperties === 'object' &&
+      !Array.isArray(patternProperties)
+    ) {
+      for (const [propertyPattern, propertySchema] of Object.entries(patternProperties)) {
+        parts.push(propertyPattern);
+        this.collectSchemaSearchText(propertySchema, parts, seen);
+      }
+    }
+
+    const dependentSchemas = schemaObject.dependentSchemas;
+    if (
+      dependentSchemas &&
+      typeof dependentSchemas === 'object' &&
+      !Array.isArray(dependentSchemas)
+    ) {
+      for (const [propertyName, dependentSchema] of Object.entries(dependentSchemas)) {
+        parts.push(propertyName);
+        this.collectSchemaSearchText(dependentSchema, parts, seen);
+      }
+    }
+
+    for (const key of [
+      'items',
+      'additionalProperties',
+      'contains',
+      'propertyNames',
+      'if',
+      'then',
+      'else',
+      'not',
+    ]) {
+      this.collectSchemaSearchText(schemaObject[key], parts, seen);
+    }
+
+    for (const key of ['allOf', 'anyOf', 'oneOf', 'prefixItems']) {
+      this.collectSchemaSearchText(schemaObject[key], parts, seen);
+    }
+
+    for (const key of ['$defs', 'definitions']) {
+      const definitions = schemaObject[key];
+      if (definitions && typeof definitions === 'object' && !Array.isArray(definitions)) {
+        for (const [definitionName, definitionSchema] of Object.entries(definitions)) {
+          parts.push(definitionName);
+          this.collectSchemaSearchText(definitionSchema, parts, seen);
+        }
+      }
+    }
+  }
+
+  private pushStringValue(value: unknown, parts: string[]): void {
+    if (typeof value === 'string' && value.trim()) {
+      parts.push(value);
+    }
   }
 
   private getDocumentKey(tool: IndexedTool): string {

--- a/src/shared/tool-index.ts
+++ b/src/shared/tool-index.ts
@@ -28,8 +28,6 @@ export interface ToolSummary {
   serverId: string;
   /** Session the tool belongs to */
   sessionId: string;
-  /** Estimated token cost of the full inputSchema */
-  estimatedTokens: number;
 }
 
 /** Server-level summary derived from indexed tools. */
@@ -170,9 +168,6 @@ export class ToolIndex {
   /** BM25: average document length across the entire index. */
   private avgDocLength = 0;
 
-  /** Cached total estimated token cost across all indexed tools. */
-  private totalTokenCost = 0;
-
   private options: Required<ToolIndexOptions>;
 
   constructor(options: ToolIndexOptions = {}) {
@@ -199,7 +194,6 @@ export class ToolIndex {
     this.embeddings.clear();
     this.docLengths.clear();
     this.avgDocLength = 0;
-    this.totalTokenCost = 0;
 
     // 1. Populate tool map + search text
     const allTokenSets: Map<string, Set<string>> = new Map();
@@ -212,16 +206,13 @@ export class ToolIndex {
         this.tools.set(tool.name, []);
       }
       this.tools.get(tool.name)!.push(tool);
-      const estimatedTokens = ToolIndex.estimateTokens(tool);
       this.toolSummaries.set(docKey, {
         name: tool.name,
         description: tool.description ?? '',
         serverName: tool.serverName,
         serverId: tool.serverId,
         sessionId: tool.sessionId,
-        estimatedTokens,
       });
-      this.totalTokenCost += estimatedTokens;
 
       const text = this.buildSearchableText(tool).toLowerCase();
       this.searchTexts.set(docKey, text);
@@ -578,11 +569,6 @@ export class ToolIndex {
     return count;
   }
 
-  /** Total estimated token cost of all indexed tool schemas. */
-  getTotalTokenCost(): number {
-    return this.totalTokenCost;
-  }
-
   // -----------------------------------------------------------------------
   // Static Helpers
   // -----------------------------------------------------------------------
@@ -596,7 +582,7 @@ export class ToolIndex {
   static estimateTokens(tool: Tool): number {
     const parts: string[] = [tool.name];
     if (tool.description) parts.push(tool.description);
-    if (tool.inputSchema) parts.push(JSON.stringify(tool.inputSchema));
+    if (tool.inputSchema) parts.push(ToolIndex.safeStringify(tool.inputSchema));
 
     const text = parts.join(' ');
     let weightedLen = 0;
@@ -606,6 +592,26 @@ export class ToolIndex {
     }
 
     return Math.ceil(weightedLen / (1 / CALIBRATION_DIVISOR));
+  }
+
+  private static safeStringify(value: unknown): string {
+    const seen = new WeakSet<object>();
+    const json = JSON.stringify(value, (_key, nestedValue) => {
+      if (typeof nestedValue === 'bigint') {
+        return nestedValue.toString();
+      }
+
+      if (nestedValue && typeof nestedValue === 'object') {
+        if (seen.has(nestedValue)) {
+          return '[Circular]';
+        }
+        seen.add(nestedValue);
+      }
+
+      return nestedValue;
+    });
+
+    return json ?? '';
   }
 
   // -----------------------------------------------------------------------

--- a/src/shared/tool-index.ts
+++ b/src/shared/tool-index.ts
@@ -105,41 +105,6 @@ export interface ToolIndexOptions {
 }
 
 // ---------------------------------------------------------------------------
-// Token Estimation
-// ---------------------------------------------------------------------------
-
-/**
- * Character-class weights for accurate-ish token estimation without a real
- * tokenizer.  Empirically calibrated against cl100k_base on typical JSON
- * Schema payloads.
- *
- * | Char class        | Approx chars per token |
- * |--------------------|------------------------|
- * | Whitespace / punct | 1–2                    |
- * | English words      | ~4                     |
- * | JSON keys/values   | ~3.5                   |
- *
- * We walk the string once and accumulate a weighted character count, then
- * divide by a calibrated divisor.
- */
-const CALIBRATION_DIVISOR = 3.6;
-
-function classifyChar(ch: string): number {
-  const code = ch.charCodeAt(0);
-  // whitespace / common JSON structural chars  →  high token density
-  if (code <= 0x20 || ch === '{' || ch === '}' || ch === '[' || ch === ']' || ch === ':' || ch === ',') return 1.0;
-  // digits and symbols
-  if (code >= 0x21 && code <= 0x2f) return 1.5;
-  if (code >= 0x30 && code <= 0x39) return 2.0;
-  // uppercase (often JSON keys)
-  if (code >= 0x41 && code <= 0x5a) return 3.5;
-  // lowercase (natural language in descriptions)
-  if (code >= 0x61 && code <= 0x7a) return 4.0;
-  // everything else (unicode, emojis, etc.)
-  return 2.5;
-}
-
-// ---------------------------------------------------------------------------
 // ToolIndex
 // ---------------------------------------------------------------------------
 
@@ -567,51 +532,6 @@ export class ToolIndex {
       count += list.length;
     }
     return count;
-  }
-
-  // -----------------------------------------------------------------------
-  // Static Helpers
-  // -----------------------------------------------------------------------
-
-  /**
-   * Estimate token count of a tool's full schema (name + description + inputSchema).
-   *
-   * Uses character-class weighted counting calibrated against cl100k_base.
-   * Accuracy is typically within ±10% for JSON Schema payloads.
-   */
-  static estimateTokens(tool: Tool): number {
-    const parts: string[] = [tool.name];
-    if (tool.description) parts.push(tool.description);
-    if (tool.inputSchema) parts.push(ToolIndex.safeStringify(tool.inputSchema));
-
-    const text = parts.join(' ');
-    let weightedLen = 0;
-
-    for (let i = 0; i < text.length; i++) {
-      weightedLen += 1 / classifyChar(text[i]);
-    }
-
-    return Math.ceil(weightedLen / (1 / CALIBRATION_DIVISOR));
-  }
-
-  private static safeStringify(value: unknown): string {
-    const seen = new WeakSet<object>();
-    const json = JSON.stringify(value, (_key, nestedValue) => {
-      if (typeof nestedValue === 'bigint') {
-        return nestedValue.toString();
-      }
-
-      if (nestedValue && typeof nestedValue === 'object') {
-        if (seen.has(nestedValue)) {
-          return '[Circular]';
-        }
-        seen.add(nestedValue);
-      }
-
-      return nestedValue;
-    });
-
-    return json ?? '';
   }
 
   // -----------------------------------------------------------------------

--- a/src/shared/tool-index.ts
+++ b/src/shared/tool-index.ts
@@ -179,10 +179,11 @@ export class ToolIndex {
         sessionId: tool.sessionId,
       });
 
-      const text = this.buildSearchableText(tool).toLowerCase();
+      const rawText = this.buildSearchableText(tool);
+      const text = rawText.toLowerCase();
       this.searchTexts.set(docKey, text);
 
-      const tokens = this.tokenize(text);
+      const tokens = this.tokenize(rawText);
       const tf = new Map<string, number>();
       const uniqueTokens = new Set<string>();
 
@@ -665,6 +666,7 @@ export class ToolIndex {
       .replace(/([a-z])([A-Z])/g, '$1 $2')
       // Split snake_case / kebab-case
       .replace(/[_-]/g, ' ')
+      .toLowerCase()
       // Remove non-alphanumeric (except spaces)
       .replace(/[^a-z0-9\s]/g, '')
       // Split on whitespace

--- a/src/shared/tool-router.ts
+++ b/src/shared/tool-router.ts
@@ -290,25 +290,6 @@ export class ToolRouter {
     return [...this.activeGroups];
   }
 
-  // -----------------------------------------------------------------------
-  // Stats & Introspection
-  // -----------------------------------------------------------------------
-
-  /** Estimate token cost of the currently filtered tool set. */
-  async getFilteredTokenCost(): Promise<number> {
-    const tools = await this.getFilteredTools();
-    let total = 0;
-    for (const tool of tools) {
-      total += ToolIndex.estimateTokens(tool);
-    }
-    return total;
-  }
-
-  /** Get compression stats showing savings from current strategy. */
-  getCompressionStats() {
-    return SchemaCompressor.estimateSavings(this.allTools);
-  }
-
   /** Number of total indexed tools. */
   get totalToolCount(): number {
     return this.allTools.length;

--- a/src/shared/tool-router.ts
+++ b/src/shared/tool-router.ts
@@ -294,11 +294,6 @@ export class ToolRouter {
   // Stats & Introspection
   // -----------------------------------------------------------------------
 
-  /** Total token cost of all tools if loaded without filtering. */
-  getTotalTokenCost(): number {
-    return this.index.getTotalTokenCost();
-  }
-
   /** Estimate token cost of the currently filtered tool set. */
   async getFilteredTokenCost(): Promise<number> {
     const tools = await this.getFilteredTools();

--- a/tests/meta-tools.test.ts
+++ b/tests/meta-tools.test.ts
@@ -222,6 +222,7 @@ test.describe('executeMetaTool', () => {
 
         expect(result?.isError).toBe(false);
         expect((result?.content[0] as any).text).toContain('web_search');
+        expect((result?.content[0] as any).text).not.toContain('Estimated tokens');
     });
 
     test('should resolve select queries using serverName fragments', async () => {

--- a/tests/meta-tools.test.ts
+++ b/tests/meta-tools.test.ts
@@ -222,7 +222,6 @@ test.describe('executeMetaTool', () => {
 
         expect(result?.isError).toBe(false);
         expect((result?.content[0] as any).text).toContain('web_search');
-        expect((result?.content[0] as any).text).not.toContain('Estimated tokens');
     });
 
     test('should resolve select queries using serverName fragments', async () => {

--- a/tests/tool-index.perf.test.ts
+++ b/tests/tool-index.perf.test.ts
@@ -83,10 +83,6 @@ async function measureIndexPerformance(
     }
     const regexMs = performance.now() - regexStart;
 
-    const totalTokenStart = performance.now();
-    const totalTokenCost = index.getTotalTokenCost();
-    const totalTokenMs = performance.now() - totalTokenStart;
-
     const sampleResults = await index.search('github repository', 10);
 
     return {
@@ -95,8 +91,6 @@ async function measureIndexPerformance(
         buildMs: Number(buildMs.toFixed(2)),
         avgSearchMs: Number((searchMs / 100).toFixed(4)),
         avgRegexMs: Number((regexMs / 100).toFixed(4)),
-        totalTokenLookupMs: Number(totalTokenMs.toFixed(4)),
-        totalTokenCost,
         sampleResultCount: sampleResults.length,
         topResult: sampleResults[0],
     };
@@ -107,19 +101,16 @@ function assertWithinBudget(
         buildMs: number;
         avgSearchMs: number;
         avgRegexMs: number;
-        totalTokenLookupMs: number;
     },
     budget: {
         buildMs: number;
         avgSearchMs: number;
         avgRegexMs: number;
-        totalTokenLookupMs: number;
     }
 ) {
     expect(result.buildMs).toBeLessThan(budget.buildMs);
     expect(result.avgSearchMs).toBeLessThan(budget.avgSearchMs);
     expect(result.avgRegexMs).toBeLessThan(budget.avgRegexMs);
-    expect(result.totalTokenLookupMs).toBeLessThan(budget.totalTokenLookupMs);
 }
 
 test.describe('ToolIndex performance', () => {
@@ -133,12 +124,10 @@ test.describe('ToolIndex performance', () => {
         );
 
         expect(result.sampleResultCount).toBeGreaterThan(0);
-        expect(result.totalTokenCost).toBeGreaterThan(0);
         assertWithinBudget(result, {
             buildMs: 1000,
             avgSearchMs: 5,
             avgRegexMs: 3,
-            totalTokenLookupMs: 1,
         });
     });
 
@@ -157,12 +146,10 @@ test.describe('ToolIndex performance', () => {
         );
 
         expect(result.sampleResultCount).toBeGreaterThan(0);
-        expect(result.totalTokenCost).toBeGreaterThan(0);
         assertWithinBudget(result, {
             buildMs: 3000,
             avgSearchMs: 5,
             avgRegexMs: 3,
-            totalTokenLookupMs: 1,
         });
     });
 
@@ -184,12 +171,10 @@ test.describe('ToolIndex performance', () => {
         );
 
         expect(result.sampleResultCount).toBeGreaterThan(0);
-        expect(result.totalTokenCost).toBeGreaterThan(0);
         assertWithinBudget(result, {
             buildMs: 1000,
             avgSearchMs: 5,
             avgRegexMs: 3,
-            totalTokenLookupMs: 1,
         });
     });
 });

--- a/tests/tool-index.test.ts
+++ b/tests/tool-index.test.ts
@@ -62,10 +62,6 @@ test.describe('ToolIndex', () => {
         expect(slackResults[0].serverName).toBe('Slack');
         expect(slackResults[0].serverId).toBe('slack-server');
         expect(index.getTool('search')).toHaveLength(2);
-        expect(githubResults[0].estimatedTokens).toBeGreaterThan(0);
-        expect(index.getTotalTokenCost()).toBe(
-            githubResults[0].estimatedTokens + slackResults[0].estimatedTokens
-        );
     });
 
     test('should prefer exact namespace matches before fuzzy server names', async () => {
@@ -233,5 +229,37 @@ test.describe('ToolIndex', () => {
 
         expect(results).toHaveLength(1);
         expect(results[0].name).toBe('create_invoice');
+    });
+
+    test('should build an index for cyclic JSON schemas', async () => {
+        const index = new ToolIndex();
+        const inputSchema: Record<string, unknown> = {
+            type: 'object',
+            properties: {
+                query: {
+                    type: 'string',
+                    description: 'Search query text',
+                },
+            },
+        };
+        inputSchema.self = inputSchema;
+
+        const tools: IndexedTool[] = [
+            {
+                name: 'cyclic_search',
+                description: 'Search with a cyclic schema',
+                inputSchema,
+                serverName: 'Search',
+                sessionId: 'search-session',
+                serverId: 'search-server',
+            },
+        ];
+
+        await expect(index.buildIndex(tools)).resolves.toBeUndefined();
+
+        const results = await index.search('query text', 5);
+
+        expect(results).toHaveLength(1);
+        expect(results[0].name).toBe('cyclic_search');
     });
 });

--- a/tests/tool-index.test.ts
+++ b/tests/tool-index.test.ts
@@ -156,4 +156,82 @@ test.describe('ToolIndex', () => {
         expect(embeddingQueryText).toBe('slack send');
         expect(results[0].serverId).toBe('slack-server');
     });
+
+    test('should search nested argument descriptions in JSON schemas', async () => {
+        const index = new ToolIndex();
+        const tools: IndexedTool[] = [
+            {
+                name: 'create_report',
+                description: 'Create a report',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        options: {
+                            type: 'object',
+                            properties: {
+                                schedule: {
+                                    type: 'object',
+                                    properties: {
+                                        timezone: {
+                                            type: 'string',
+                                            description: 'IANA timezone for delivery windows',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+                serverName: 'Reports',
+                sessionId: 'reports-session',
+                serverId: 'reports-server',
+            },
+        ];
+
+        await index.buildIndex(tools);
+
+        const results = await index.search('IANA timezone delivery', 5);
+
+        expect(results).toHaveLength(1);
+        expect(results[0].name).toBe('create_report');
+    });
+
+    test('should regex search nested argument names in JSON schemas', async () => {
+        const index = new ToolIndex();
+        const tools: IndexedTool[] = [
+            {
+                name: 'create_invoice',
+                description: 'Create an invoice',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        customer: {
+                            type: 'object',
+                            properties: {
+                                billingAddress: {
+                                    type: 'object',
+                                    properties: {
+                                        postalCode: {
+                                            type: 'string',
+                                            description: 'Postal code for tax calculation',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+                serverName: 'Billing',
+                sessionId: 'billing-session',
+                serverId: 'billing-server',
+            },
+        ];
+
+        await index.buildIndex(tools);
+
+        const results = index.searchRegex('postalcode', 5);
+
+        expect(results).toHaveLength(1);
+        expect(results[0].name).toBe('create_invoice');
+    });
 });

--- a/tests/tool-index.test.ts
+++ b/tests/tool-index.test.ts
@@ -231,6 +231,47 @@ test.describe('ToolIndex', () => {
         expect(results[0].name).toBe('create_invoice');
     });
 
+    test('should keyword search split words from nested camelCase argument names', async () => {
+        const index = new ToolIndex();
+        const tools: IndexedTool[] = [
+            {
+                name: 'create_invoice',
+                description: 'Create an invoice',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        customer: {
+                            type: 'object',
+                            properties: {
+                                billingAddress: {
+                                    type: 'object',
+                                    properties: {
+                                        postalCode: {
+                                            type: 'string',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+                serverName: 'Invoices',
+                sessionId: 'invoice-session',
+                serverId: 'invoice-server',
+            },
+        ];
+
+        await index.buildIndex(tools);
+
+        const addressResults = await index.search('address', 5);
+        const postalResults = await index.search('postal code', 5);
+
+        expect(addressResults).toHaveLength(1);
+        expect(addressResults[0].name).toBe('create_invoice');
+        expect(postalResults).toHaveLength(1);
+        expect(postalResults[0].name).toBe('create_invoice');
+    });
+
     test('should build an index for cyclic JSON schemas', async () => {
         const index = new ToolIndex();
         const inputSchema: Record<string, unknown> = {


### PR DESCRIPTION
## Summary
- Extend ToolIndex schema search text extraction to recursively include nested JSON Schema metadata, including nested argument names/descriptions and cycle-safe traversal.
- Remove estimated token-cost metadata from tool summaries and meta-tool responses so search/routing output focuses on matched tools.
- Remove runtime token-estimation and compression-stats APIs from `ToolIndex`, `ToolRouter`, and `SchemaCompressor`; update docs and tests for the simplified surface.

## Why
Tool search should cover the full argument catalog, including nested JSON Schema argument names and descriptions, matching the behavior described in the external tool-search reference linked from #101.

The follow-up cleanup removes approximate token-cost reporting from summaries and runtime APIs. That keeps the router/search API focused on tool discovery and avoids exposing heuristic cost values that are no longer part of the intended public surface.

Closes #101

## Verification
- `npx playwright test tests/tool-index.test.ts tests/meta-tools.test.ts` passed: 18/18.
- `npm run type-check` remains blocked by existing unrelated syntax errors in `examples/next/app/oauth/callback/page.tsx`.