### PR TITLE
fix(react): resolve OAuth popup race condition and state tracking issues

### DIFF
--- a/examples/next/app/oauth/callback-popup/page.tsx
+++ b/examples/next/app/oauth/callback-popup/page.tsx
@@ -3,39 +3,35 @@
 import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { Loader2, CheckCircle2, XCircle } from "lucide-react";
-import { useMcp } from "@mcp-ts/sdk/client/react";
 
 const AUTH_CODE_MESSAGE = "MCP_AUTH_CODE";
 const AUTH_RESULT_MESSAGE = "MCP_AUTH_RESULT";
+const AUTH_CHANNEL_NAME = "mcp-auth-channel";
+
+function createAuthBroadcastChannel(): BroadcastChannel | null {
+  if (typeof BroadcastChannel === "undefined") {
+    return null;
+  }
+
+  try {
+    return new BroadcastChannel(AUTH_CHANNEL_NAME);
+  } catch {
+    return null;
+  }
+}
 
 function PopupCallbackContent() {
   const searchParams = useSearchParams();
   const code = searchParams.get("code");
   const sessionId = searchParams.get("state");
 
-  const { connections, finishAuth } = useMcp({
-    url: "/api/mcp",
-    identity: process.env.NEXT_PUBLIC_MCP_IDENTITY!,
-    autoConnect: true,
-  });
-
   const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
   const [errorMessage, setErrorMessage] = useState("");
 
   const resolvedSessionId = sessionId || searchParams.get("sessionId");
 
-  // 1. Success Monitor: If the main window succeeds, this popup should just close.
   useEffect(() => {
-    if (!resolvedSessionId) return;
-    const conn = connections.find(c => c.sessionId === resolvedSessionId);
-    if (conn?.state === 'CONNECTED' || conn?.state === 'READY') {
-      setStatus("success");
-      window.setTimeout(() => window.close(), 1200);
-    }
-  }, [connections, resolvedSessionId]);
-
-  useEffect(() => {
-    if (!code || !resolvedSessionId || status !== "loading") {
+    if (!code || !resolvedSessionId) {
       if (!code || !resolvedSessionId) {
         setStatus("error");
         setErrorMessage("Missing required OAuth parameters.");
@@ -60,51 +56,36 @@ function PopupCallbackContent() {
       }
     };
 
-    const channel = new BroadcastChannel("mcp-auth-channel");
-    channel.addEventListener("message", handleResult);
+    const channel = createAuthBroadcastChannel();
+    channel?.addEventListener("message", handleResult);
     window.addEventListener("message", handleResult);
 
     const payload = { type: AUTH_CODE_MESSAGE, code, sessionId: resolvedSessionId, state: resolvedSessionId };
 
-    // Send via all available paths
     if (window.opener) {
       try {
         window.opener.postMessage(payload, window.location.origin);
-      } catch (err) {
-        console.warn('[PopupCallback] postMessage failed:', err);
+      } catch {
+        setStatus("error");
+        setErrorMessage("Could not communicate with main window.");
       }
     }
-    channel.postMessage(payload);
 
-    // Fallback if the main window is gone or unresponsive
-    const fallbackTimeout = window.setTimeout(() => {
-      if (!closed && status === "loading") {
-        console.log('[PopupCallback] No response from main window, attempting direct fallback...');
-        void completeAuthInPopup();
+    channel?.postMessage(payload);
+
+    const timeout = window.setTimeout(() => {
+      if (!closed) {
+        setStatus("error");
+        setErrorMessage("Could not confirm authorization. Please return to the main window and try again.");
       }
     }, 30000);
 
-    async function completeAuthInPopup() {
-      if (closed) return;
-      try {
-        await finishAuth(resolvedSessionId as string, code as string);
-        setStatus("success");
-        closed = true;
-        window.setTimeout(() => window.close(), 1200);
-      } catch (error) {
-        if (closed) return;
-        setStatus("error");
-        setErrorMessage(error instanceof Error ? error.message : "Failed to complete authorization.");
-      }
-    }
-
     return () => {
-      window.clearTimeout(fallbackTimeout);
+      window.clearTimeout(timeout);
       window.removeEventListener("message", handleResult);
-      channel.close();
+      channel?.close();
     };
-  }, [code, resolvedSessionId, finishAuth]);
-
+  }, [code, resolvedSessionId]);
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-gray-50/50 text-gray-900 font-sans p-4">

--- a/examples/next/app/oauth/callback-popup/page.tsx
+++ b/examples/next/app/oauth/callback-popup/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { Loader2, CheckCircle2, XCircle } from "lucide-react";
+import { useMcp } from "@mcp-ts/sdk/client/react";
 
 const AUTH_CODE_MESSAGE = "MCP_AUTH_CODE";
 const AUTH_RESULT_MESSAGE = "MCP_AUTH_RESULT";
@@ -12,70 +13,98 @@ function PopupCallbackContent() {
   const code = searchParams.get("code");
   const sessionId = searchParams.get("state");
 
+  const { connections, finishAuth } = useMcp({
+    url: "/api/mcp",
+    identity: process.env.NEXT_PUBLIC_MCP_IDENTITY!,
+    autoConnect: true,
+  });
+
   const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
   const [errorMessage, setErrorMessage] = useState("");
 
-  const openerMissing = typeof window !== "undefined" ? !window.opener : false;
-  const missingCode = !code;
-  const missingSessionId = !sessionId;
-  const blockingError = openerMissing
-    ? "No opener window found. This window should be opened from the app."
-    : missingCode
-    ? "No authorization code received."
-    : missingSessionId
-    ? "No OAuth state received."
-    : null;
+  const resolvedSessionId = sessionId || searchParams.get("sessionId");
+
+  // 1. Success Monitor: If the main window succeeds, this popup should just close.
+  useEffect(() => {
+    if (!resolvedSessionId) return;
+    const conn = connections.find(c => c.sessionId === resolvedSessionId);
+    if (conn?.state === 'CONNECTED' || conn?.state === 'READY') {
+      setStatus("success");
+      window.setTimeout(() => window.close(), 1200);
+    }
+  }, [connections, resolvedSessionId]);
 
   useEffect(() => {
-    if (blockingError) {
-      setStatus("error");
-      setErrorMessage(blockingError);
+    if (!code || !resolvedSessionId || status !== "loading") {
+      if (!code || !resolvedSessionId) {
+        setStatus("error");
+        setErrorMessage("Missing required OAuth parameters.");
+      }
       return;
     }
 
     let closed = false;
 
     const handleResult = (event: MessageEvent) => {
-      if (event.origin !== window.location.origin) return;
+      if (event.origin && event.origin !== window.location.origin) return;
       if (event.data?.type !== AUTH_RESULT_MESSAGE) return;
-      if (event.data.sessionId !== sessionId) return;
+      if (event.data.sessionId !== resolvedSessionId) return;
 
       if (event.data.success) {
         setStatus("success");
-        window.removeEventListener("message", handleResult);
         closed = true;
         window.setTimeout(() => window.close(), 1200);
-        return;
+      } else if (!closed) {
+        setStatus("error");
+        setErrorMessage(event.data.error || "Authentication failed");
       }
-
-      setStatus("error");
-      setErrorMessage(
-        typeof event.data.error === "string" && event.data.error.length > 0
-          ? event.data.error
-          : "Failed to complete authorization."
-      );
     };
 
+    const channel = new BroadcastChannel("mcp-auth-channel");
+    channel.addEventListener("message", handleResult);
     window.addEventListener("message", handleResult);
 
-    try {
-      window.opener.postMessage(
-        { type: AUTH_CODE_MESSAGE, code, sessionId },
-        window.location.origin
-      );
-    } catch {
-      window.setTimeout(() => {
+    const payload = { type: AUTH_CODE_MESSAGE, code, sessionId: resolvedSessionId, state: resolvedSessionId };
+
+    // Send via all available paths
+    if (window.opener) {
+      try {
+        window.opener.postMessage(payload, window.location.origin);
+      } catch (err) {
+        console.warn('[PopupCallback] postMessage failed:', err);
+      }
+    }
+    channel.postMessage(payload);
+
+    // Fallback if the main window is gone or unresponsive
+    const fallbackTimeout = window.setTimeout(() => {
+      if (!closed && status === "loading") {
+        console.log('[PopupCallback] No response from main window, attempting direct fallback...');
+        void completeAuthInPopup();
+      }
+    }, 30000);
+
+    async function completeAuthInPopup() {
+      if (closed) return;
+      try {
+        await finishAuth(resolvedSessionId as string, code as string);
+        setStatus("success");
+        closed = true;
+        window.setTimeout(() => window.close(), 1200);
+      } catch (error) {
+        if (closed) return;
         setStatus("error");
-        setErrorMessage("Could not communicate with main window. Please close this window and try again.");
-      }, 0);
+        setErrorMessage(error instanceof Error ? error.message : "Failed to complete authorization.");
+      }
     }
 
     return () => {
-      if (!closed) {
-        window.removeEventListener("message", handleResult);
-      }
+      window.clearTimeout(fallbackTimeout);
+      window.removeEventListener("message", handleResult);
+      channel.close();
     };
-  }, [blockingError, code, sessionId]);
+  }, [code, resolvedSessionId, finishAuth]);
+
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-gray-50/50 text-gray-900 font-sans p-4">

--- a/examples/next/app/oauth/callback/page.tsx
+++ b/examples/next/app/oauth/callback/page.tsx
@@ -16,30 +16,43 @@ function OAuthCallbackContent() {
   const { finishAuth } = useMcp({
     url: "/api/mcp",
     identity: process.env.NEXT_PUBLIC_MCP_IDENTITY!,
-    authToken: "demo-auth-token",
     autoConnect: true,
     autoInitialize: false,
+  });
+
+  useEffect(() => {
+    if (processedRef.current) {
+      return;
+    }
+    processedRef.current = true;
+
     const code = searchParams.get("code");
     const state = searchParams.get("state");
     const errorParam = searchParams.get("error");
 
     if (errorParam) {
-      setStatus("error");
-      setError(`OAuth error: ${errorParam}`);
+      queueMicrotask(() => {
+        setStatus("error");
+        setError(`OAuth error: ${errorParam}`);
+      });
       return;
     }
 
     if (!code) {
-      setStatus("error");
-      setError("No authorization code received");
+      queueMicrotask(() => {
+        setStatus("error");
+        setError("No authorization code received");
+      });
       return;
     }
 
     const sessionId = state || "";
 
     if (!sessionId) {
-      setStatus("error");
-      setError("Invalid state parameter");
+      queueMicrotask(() => {
+        setStatus("error");
+        setError("Invalid state parameter");
+      });
       return;
     }
 

--- a/src/client/react/oauth-popup.tsx
+++ b/src/client/react/oauth-popup.tsx
@@ -69,7 +69,12 @@ function postPopupResult(
     ...result,
   };
 
-  popupWindow?.postMessage(payload, window.location.origin);
+  try {
+    popupWindow?.postMessage(payload, window.location.origin);
+  } catch {
+    // COOP can leave a WindowProxy reference that is no longer usable.
+    // The BroadcastChannel path below is the reliable fallback.
+  }
 
   const channel = createAuthBroadcastChannel();
   if (channel) {
@@ -291,16 +296,13 @@ export function McpOAuthCallbackContent({
   const [phase, setPhase] = useState<'loading' | 'success' | 'error'>(debugPhase || 'loading');
   const [errorMessage, setErrorMessage] = useState('');
 
-  const openerMissing = typeof window !== 'undefined' ? !window.opener : false;
   const missingCode = !code;
   const missingSessionId = !sessionId;
-  const blockingError = openerMissing
-    ? 'Error: No opener window found. This window should be opened from the app.'
-    : missingCode
-      ? 'Error: No authorization code received.'
-      : missingSessionId
-        ? 'Error: No OAuth state received.'
-        : null;
+  const blockingError = missingCode
+    ? 'Error: No authorization code received.'
+    : missingSessionId
+      ? 'Error: No OAuth state received.'
+      : null;
 
   useEffect(() => {
     if (debugPhase) {

--- a/src/client/react/oauth-popup.tsx
+++ b/src/client/react/oauth-popup.tsx
@@ -42,6 +42,19 @@ export interface McpOAuthCallbackContentProps {
 
 const AUTH_CODE_MESSAGE = 'MCP_AUTH_CODE';
 const AUTH_RESULT_MESSAGE = 'MCP_AUTH_RESULT';
+const AUTH_CHANNEL_NAME = 'mcp-auth-channel';
+
+function createAuthBroadcastChannel(): BroadcastChannel | null {
+  if (typeof BroadcastChannel === 'undefined') {
+    return null;
+  }
+
+  try {
+    return new BroadcastChannel(AUTH_CHANNEL_NAME);
+  } catch {
+    return null;
+  }
+}
 
 function postPopupResult(
   popupWindow: WindowProxy | null,
@@ -56,17 +69,12 @@ function postPopupResult(
     ...result,
   };
 
-  // 1. Direct postMessage to the specific window if known
   popupWindow?.postMessage(payload, window.location.origin);
 
-  // 2. Broadcast to all listening windows (e.g. if opener reference was lost)
-  try {
-    const channel = new BroadcastChannel('mcp-auth-channel');
+  const channel = createAuthBroadcastChannel();
+  if (channel) {
     channel.postMessage(payload);
     channel.close();
-  } catch (err) {
-    // BroadcastChannel might not be supported in very old environments, but that's okay as postMessage is the primary path
-    console.warn('[useMcpOAuthPopup] Failed to broadcast result:', err);
   }
 }
 
@@ -135,26 +143,21 @@ export function createOAuthPopupRedirectHandler(
  *
  * If you are not using a popup flow, you do not need this hook.
  */
-const processedCodesGlobal = new Set<string>();
-
 export function useMcpOAuthPopup<TConnection extends OAuthPopupConnectionLike>(
   connections: TConnection[],
   finishAuth: (sessionId: string, code: string) => Promise<unknown>
 ): void {
   const pendingPopupsRef = useRef<Map<string, WindowProxy>>(new Map());
-
+  const processingCodesRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     const handleMessage = async (event: MessageEvent) => {
-      console.log('[useMcpOAuthPopup] Message received:', event.data);
-      // 1. Verify origin for security (ignore for BroadcastChannel messages which don't have origin or have same origin)
       if (event.origin && event.origin !== window.location.origin) {
-        console.warn('[useMcpOAuthPopup] Origin mismatch:', event.origin, 'expected:', window.location.origin);
         return;
       }
 
-
-      if (event.data?.type !== AUTH_CODE_MESSAGE || !event.data.code) {
+      const code = typeof event.data?.code === 'string' ? event.data.code : '';
+      if (event.data?.type !== AUTH_CODE_MESSAGE || !code) {
         return;
       }
 
@@ -163,29 +166,9 @@ export function useMcpOAuthPopup<TConnection extends OAuthPopupConnectionLike>(
         : null;
       const targetSessionId = typeof event.data.sessionId === 'string' ? event.data.sessionId : '';
 
-      // Capture the popup window reference if we have it, so we can notify it later
-      // even if this specific message is a duplicate code signal.
       if (popupWindow && targetSessionId) {
         pendingPopupsRef.current.set(targetSessionId, popupWindow);
       }
-
-      // Deduplicate: Don't process the same code twice
-      if (processedCodesGlobal.has(event.data.code)) {
-        console.log('[useMcpOAuthPopup] Code already processed (global), ignoring:', event.data.code);
-        
-        // If the session is already authenticated or ready, notify the popup immediately
-        // (This handles cases where the popup sends multiple signals or a late signal)
-        const existingConn = connections.find(c => c.sessionId === targetSessionId);
-        if (existingConn?.state === 'AUTHENTICATED' || existingConn?.state === 'READY') {
-          postPopupResult(popupWindow, {
-            sessionId: targetSessionId,
-            success: true,
-          });
-          pendingPopupsRef.current.delete(targetSessionId);
-        }
-        return;
-      }
-      processedCodesGlobal.add(event.data.code);
 
       if (!targetSessionId) {
         if (popupWindow) {
@@ -209,9 +192,16 @@ export function useMcpOAuthPopup<TConnection extends OAuthPopupConnectionLike>(
         return;
       }
 
+      const codeKey = `${targetSession.sessionId}:${code}`;
+      if (processingCodesRef.current.has(codeKey)) {
+        return;
+      }
+      processingCodesRef.current.add(codeKey);
+
       try {
-        await finishAuth(targetSession.sessionId, event.data.code);
+        await finishAuth(targetSession.sessionId, code);
       } catch (error) {
+        processingCodesRef.current.delete(codeKey);
         pendingPopupsRef.current.delete(targetSession.sessionId);
         if (popupWindow) {
           postPopupResult(popupWindow, {
@@ -223,8 +213,7 @@ export function useMcpOAuthPopup<TConnection extends OAuthPopupConnectionLike>(
       }
     };
 
-    // Listen on both postMessage and BroadcastChannel
-    const channel = new BroadcastChannel('mcp-auth-channel');
+    const channel = createAuthBroadcastChannel();
     const handleChannelMessage = (event: MessageEvent) => {
       if (event.data?.type === AUTH_CODE_MESSAGE) {
         void handleMessage(event);
@@ -232,14 +221,13 @@ export function useMcpOAuthPopup<TConnection extends OAuthPopupConnectionLike>(
     };
 
     window.addEventListener('message', handleMessage);
-    channel.addEventListener('message', handleChannelMessage);
+    channel?.addEventListener('message', handleChannelMessage);
     
     return () => {
       window.removeEventListener('message', handleMessage);
-      channel.removeEventListener('message', handleChannelMessage);
-      channel.close();
+      channel?.removeEventListener('message', handleChannelMessage);
+      channel?.close();
     };
-
   }, [connections, finishAuth]);
 
   useEffect(() => {
@@ -251,6 +239,11 @@ export function useMcpOAuthPopup<TConnection extends OAuthPopupConnectionLike>(
           sessionId: connection.sessionId,
           success: true,
         });
+        for (const codeKey of processingCodesRef.current) {
+          if (codeKey.startsWith(`${connection.sessionId}:`)) {
+            processingCodesRef.current.delete(codeKey);
+          }
+        }
         pendingPopupsRef.current.delete(connection.sessionId);
         continue;
       }
@@ -261,6 +254,11 @@ export function useMcpOAuthPopup<TConnection extends OAuthPopupConnectionLike>(
           success: false,
           error: connection.error || 'Failed to complete authorization',
         });
+        for (const codeKey of processingCodesRef.current) {
+          if (codeKey.startsWith(`${connection.sessionId}:`)) {
+            processingCodesRef.current.delete(codeKey);
+          }
+        }
         pendingPopupsRef.current.delete(connection.sessionId);
       }
     }
@@ -317,7 +315,8 @@ export function McpOAuthCallbackContent({
       return;
     }
 
-    const channel = new BroadcastChannel('mcp-auth-channel');
+    let closed = false;
+    const channel = createAuthBroadcastChannel();
     const handleResult = (event: MessageEvent) => {
       if (event.origin && event.origin !== window.location.origin) {
         return;
@@ -334,7 +333,7 @@ export function McpOAuthCallbackContent({
       if (event.data.success) {
         setPhase('success');
         window.removeEventListener('message', handleResult);
-        channel.close();
+        channel?.close();
         closed = true;
         window.setTimeout(() => window.close(), 1200);
         return;
@@ -349,33 +348,29 @@ export function McpOAuthCallbackContent({
     };
 
     window.addEventListener('message', handleResult);
-    channel.addEventListener('message', handleResult);
+    channel?.addEventListener('message', handleResult);
 
     const payload = { type: AUTH_CODE_MESSAGE, code, sessionId };
 
-    // 1. Try postMessage to opener
     if (window.opener) {
       try {
         window.opener.postMessage(payload, window.location.origin);
-      } catch (error) {
-        console.warn('Failed to postMessage to opener:', error);
+      } catch {
+        setPhase('error');
+        setErrorMessage('Error: Could not communicate with main window.');
       }
     }
 
-    // 2. Also try BroadcastChannel
-    try {
+    if (channel) {
       channel.postMessage(payload);
-    } catch (error) {
-      console.warn('Failed to post to BroadcastChannel:', error);
     }
 
     return () => {
       if (!closed) {
         window.removeEventListener('message', handleResult);
-        channel.close();
+        channel?.close();
       }
     };
-
   }, [blockingError, code, sessionId, debugPhase]);
 
   const loadingBubbles = (

--- a/src/client/react/oauth-popup.tsx
+++ b/src/client/react/oauth-popup.tsx
@@ -51,13 +51,23 @@ function postPopupResult(
     error?: string;
   }
 ): void {
-  popupWindow?.postMessage(
-    {
-      type: AUTH_RESULT_MESSAGE,
-      ...result,
-    },
-    window.location.origin
-  );
+  const payload = {
+    type: AUTH_RESULT_MESSAGE,
+    ...result,
+  };
+
+  // 1. Direct postMessage to the specific window if known
+  popupWindow?.postMessage(payload, window.location.origin);
+
+  // 2. Broadcast to all listening windows (e.g. if opener reference was lost)
+  try {
+    const channel = new BroadcastChannel('mcp-auth-channel');
+    channel.postMessage(payload);
+    channel.close();
+  } catch (err) {
+    // BroadcastChannel might not be supported in very old environments, but that's okay as postMessage is the primary path
+    console.warn('[useMcpOAuthPopup] Failed to broadcast result:', err);
+  }
 }
 
 /**
@@ -125,17 +135,24 @@ export function createOAuthPopupRedirectHandler(
  *
  * If you are not using a popup flow, you do not need this hook.
  */
+const processedCodesGlobal = new Set<string>();
+
 export function useMcpOAuthPopup<TConnection extends OAuthPopupConnectionLike>(
   connections: TConnection[],
   finishAuth: (sessionId: string, code: string) => Promise<unknown>
 ): void {
   const pendingPopupsRef = useRef<Map<string, WindowProxy>>(new Map());
 
+
   useEffect(() => {
     const handleMessage = async (event: MessageEvent) => {
-      if (event.origin !== window.location.origin) {
+      console.log('[useMcpOAuthPopup] Message received:', event.data);
+      // 1. Verify origin for security (ignore for BroadcastChannel messages which don't have origin or have same origin)
+      if (event.origin && event.origin !== window.location.origin) {
+        console.warn('[useMcpOAuthPopup] Origin mismatch:', event.origin, 'expected:', window.location.origin);
         return;
       }
+
 
       if (event.data?.type !== AUTH_CODE_MESSAGE || !event.data.code) {
         return;
@@ -146,52 +163,90 @@ export function useMcpOAuthPopup<TConnection extends OAuthPopupConnectionLike>(
         : null;
       const targetSessionId = typeof event.data.sessionId === 'string' ? event.data.sessionId : '';
 
+      // Capture the popup window reference if we have it, so we can notify it later
+      // even if this specific message is a duplicate code signal.
+      if (popupWindow && targetSessionId) {
+        pendingPopupsRef.current.set(targetSessionId, popupWindow);
+      }
+
+      // Deduplicate: Don't process the same code twice
+      if (processedCodesGlobal.has(event.data.code)) {
+        console.log('[useMcpOAuthPopup] Code already processed (global), ignoring:', event.data.code);
+        
+        // If the session is already authenticated or ready, notify the popup immediately
+        // (This handles cases where the popup sends multiple signals or a late signal)
+        const existingConn = connections.find(c => c.sessionId === targetSessionId);
+        if (existingConn?.state === 'AUTHENTICATED' || existingConn?.state === 'READY') {
+          postPopupResult(popupWindow, {
+            sessionId: targetSessionId,
+            success: true,
+          });
+          pendingPopupsRef.current.delete(targetSessionId);
+        }
+        return;
+      }
+      processedCodesGlobal.add(event.data.code);
+
       if (!targetSessionId) {
-        postPopupResult(popupWindow, {
-          success: false,
-          error: 'Missing OAuth session identifier',
-        });
+        if (popupWindow) {
+          postPopupResult(popupWindow, {
+            success: false,
+            error: 'Missing OAuth session identifier',
+          });
+        }
         return;
       }
 
       const targetSession = connections.find((connection) => connection.sessionId === targetSessionId);
       if (!targetSession) {
-        postPopupResult(popupWindow, {
-          sessionId: targetSessionId,
-          success: false,
-          error: 'OAuth session not found in the current client state',
-        });
+        if (popupWindow) {
+          postPopupResult(popupWindow, {
+            sessionId: targetSessionId,
+            success: false,
+            error: 'OAuth session not found in the current client state',
+          });
+        }
         return;
-      }
-
-      if (popupWindow) {
-        pendingPopupsRef.current.set(targetSession.sessionId, popupWindow);
       }
 
       try {
         await finishAuth(targetSession.sessionId, event.data.code);
       } catch (error) {
         pendingPopupsRef.current.delete(targetSession.sessionId);
-        postPopupResult(popupWindow, {
-          sessionId: targetSession.sessionId,
-          success: false,
-          error: error instanceof Error ? error.message : 'Failed to finish auth',
-        });
+        if (popupWindow) {
+          postPopupResult(popupWindow, {
+            sessionId: targetSession.sessionId,
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to finish auth',
+          });
+        }
+      }
+    };
+
+    // Listen on both postMessage and BroadcastChannel
+    const channel = new BroadcastChannel('mcp-auth-channel');
+    const handleChannelMessage = (event: MessageEvent) => {
+      if (event.data?.type === AUTH_CODE_MESSAGE) {
+        void handleMessage(event);
       }
     };
 
     window.addEventListener('message', handleMessage);
-    return () => window.removeEventListener('message', handleMessage);
+    channel.addEventListener('message', handleChannelMessage);
+    
+    return () => {
+      window.removeEventListener('message', handleMessage);
+      channel.removeEventListener('message', handleChannelMessage);
+      channel.close();
+    };
+
   }, [connections, finishAuth]);
 
   useEffect(() => {
     for (const connection of connections) {
-      const popupWindow = pendingPopupsRef.current.get(connection.sessionId);
-      if (!popupWindow) {
-        continue;
-      }
+      const popupWindow = pendingPopupsRef.current.get(connection.sessionId) || null;
 
-      if (connection.state === 'AUTHENTICATED') {
+      if (connection.state === 'AUTHENTICATED' || connection.state === 'READY' || connection.state === 'CONNECTED') {
         postPopupResult(popupWindow, {
           sessionId: connection.sessionId,
           success: true,
@@ -262,10 +317,9 @@ export function McpOAuthCallbackContent({
       return;
     }
 
-    let closed = false;
-
+    const channel = new BroadcastChannel('mcp-auth-channel');
     const handleResult = (event: MessageEvent) => {
-      if (event.origin !== window.location.origin) {
+      if (event.origin && event.origin !== window.location.origin) {
         return;
       }
 
@@ -280,6 +334,7 @@ export function McpOAuthCallbackContent({
       if (event.data.success) {
         setPhase('success');
         window.removeEventListener('message', handleResult);
+        channel.close();
         closed = true;
         window.setTimeout(() => window.close(), 1200);
         return;
@@ -294,25 +349,33 @@ export function McpOAuthCallbackContent({
     };
 
     window.addEventListener('message', handleResult);
+    channel.addEventListener('message', handleResult);
 
+    const payload = { type: AUTH_CODE_MESSAGE, code, sessionId };
+
+    // 1. Try postMessage to opener
+    if (window.opener) {
+      try {
+        window.opener.postMessage(payload, window.location.origin);
+      } catch (error) {
+        console.warn('Failed to postMessage to opener:', error);
+      }
+    }
+
+    // 2. Also try BroadcastChannel
     try {
-      window.opener.postMessage(
-        { type: AUTH_CODE_MESSAGE, code, sessionId },
-        window.location.origin
-      );
+      channel.postMessage(payload);
     } catch (error) {
-      console.error('Failed to communicate with opener:', error);
-      window.setTimeout(() => {
-        setPhase('error');
-        setErrorMessage('Error: Could not communicate with main window.');
-      }, 0);
+      console.warn('Failed to post to BroadcastChannel:', error);
     }
 
     return () => {
       if (!closed) {
         window.removeEventListener('message', handleResult);
+        channel.close();
       }
     };
+
   }, [blockingError, code, sessionId, debugPhase]);
 
   const loadingBubbles = (

--- a/tests/oauth-popup.test.ts
+++ b/tests/oauth-popup.test.ts
@@ -19,7 +19,7 @@ async function loadHarness(page: Page): Promise<void> {
     `
       import React, { useEffect, useState } from 'react';
       import { createRoot } from 'react-dom/client';
-      import { useMcpOAuthPopup } from ${JSON.stringify(popupSource)};
+      import { McpOAuthCallbackContent, useMcpOAuthPopup } from ${JSON.stringify(popupSource)};
 
       function Harness() {
         const [connections, setConnections] = useState(window.__initialConnections || []);
@@ -43,6 +43,11 @@ async function loadHarness(page: Page): Promise<void> {
       window.__renderOAuthHarness = (connections = []) => {
         window.__initialConnections = connections;
         createRoot(document.getElementById('root')).render(React.createElement(Harness));
+      };
+      window.__renderOAuthCallback = ({ code, sessionId }) => {
+        createRoot(document.getElementById('root')).render(
+          React.createElement(McpOAuthCallbackContent, { code, sessionId })
+        );
       };
     `
   );
@@ -168,9 +173,27 @@ async function captureAuthResults(page: Page): Promise<void> {
   );
 }
 
+async function captureAuthCodeMessages(page: Page): Promise<void> {
+  await page.evaluate(
+    ({ channelName }) => {
+      window.__authCodeMessages = [];
+
+      const channel = new BroadcastChannel(channelName);
+      channel.addEventListener('message', (event) => {
+        if (event.data?.type === 'MCP_AUTH_CODE') {
+          window.__authCodeMessages.push(event.data);
+        }
+      });
+      window.__authCodeChannel = channel;
+    },
+    { channelName: authChannelName }
+  );
+}
+
 test.describe('useMcpOAuthPopup', () => {
   test.afterEach(async ({ page }) => {
     await page.evaluate(() => {
+      window.__authCodeChannel?.close();
       window.__authResultChannel?.close();
     }).catch(() => undefined);
   });
@@ -289,13 +312,43 @@ test.describe('useMcpOAuthPopup', () => {
   });
 });
 
+test.describe('McpOAuthCallbackContent', () => {
+  test.afterEach(async ({ page }) => {
+    await page.evaluate(() => {
+      window.__authCodeChannel?.close();
+      window.__authResultChannel?.close();
+    }).catch(() => undefined);
+  });
+
+  test('broadcasts the auth code when COOP removes the opener reference', async ({ page }) => {
+    await loadHarness(page);
+    await captureAuthCodeMessages(page);
+
+    await page.evaluate(() => {
+      window.__renderOAuthCallback({ code: 'code-without-opener', sessionId: 'session-without-opener' });
+    });
+
+    await expect.poll(() => page.evaluate(() => window.__authCodeMessages.length)).toBe(1);
+    await expect(page.evaluate(() => window.__authCodeMessages)).resolves.toEqual([
+      {
+        type: 'MCP_AUTH_CODE',
+        code: 'code-without-opener',
+        sessionId: 'session-without-opener',
+      },
+    ]);
+  });
+});
+
 declare global {
   interface Window {
+    __authCodeChannel?: BroadcastChannel;
+    __authCodeMessages: Array<{ type: string; sessionId?: string; code?: string }>;
     __authResultChannel?: BroadcastChannel;
     __authResults: Array<{ type: string; sessionId?: string; success: boolean; error?: string }>;
     __finishAuthErrorMessage?: string;
     __finishAuthCalls: Array<{ sessionId: string; code: string }>;
     __initialConnections?: Array<{ sessionId: string; state: string }>;
+    __renderOAuthCallback: (props: { code?: string | null; sessionId?: string | null }) => void;
     __renderOAuthHarness: (connections?: Array<{ sessionId: string; state: string }>) => void;
     __setConnections: (connections: Array<{ sessionId: string; state: string }>) => void;
   }

--- a/tests/oauth-popup.test.ts
+++ b/tests/oauth-popup.test.ts
@@ -1,0 +1,302 @@
+import { expect, test, type Page } from '@playwright/test';
+import { build } from 'esbuild';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const authCodeMessage = 'MCP_AUTH_CODE';
+const authChannelName = 'mcp-auth-channel';
+
+async function loadHarness(page: Page): Promise<void> {
+  const fixtureDir = path.join(process.cwd(), 'test-results', 'oauth-popup-harness');
+  await mkdir(fixtureDir, { recursive: true });
+
+  const entryFile = path.join(fixtureDir, 'entry.tsx');
+  const bundleFile = path.join(fixtureDir, 'bundle.js');
+  const popupSource = path.resolve(process.cwd(), 'src/client/react/oauth-popup.tsx').replace(/\\/g, '/');
+
+  await writeFile(
+    entryFile,
+    `
+      import React, { useEffect, useState } from 'react';
+      import { createRoot } from 'react-dom/client';
+      import { useMcpOAuthPopup } from ${JSON.stringify(popupSource)};
+
+      function Harness() {
+        const [connections, setConnections] = useState(window.__initialConnections || []);
+
+        useEffect(() => {
+          window.__setConnections = setConnections;
+        }, []);
+
+        useMcpOAuthPopup(connections, async (sessionId, code) => {
+          window.__finishAuthCalls.push({ sessionId, code });
+          if (window.__finishAuthErrorMessage) {
+            throw new Error(window.__finishAuthErrorMessage);
+          }
+        });
+
+        return null;
+      }
+
+      window.__finishAuthCalls = [];
+      window.__finishAuthErrorMessage = undefined;
+      window.__renderOAuthHarness = (connections = []) => {
+        window.__initialConnections = connections;
+        createRoot(document.getElementById('root')).render(React.createElement(Harness));
+      };
+    `
+  );
+
+  await build({
+    entryPoints: [entryFile],
+    outfile: bundleFile,
+    bundle: true,
+    format: 'iife',
+    platform: 'browser',
+    jsx: 'automatic',
+  });
+
+  await page.route('http://oauth-popup.test/', async (route) => {
+    await route.fulfill({
+      contentType: 'text/html',
+      body: '<div id="root"></div>',
+    });
+  });
+  await page.goto('http://oauth-popup.test/');
+  await page.addScriptTag({ path: bundleFile });
+}
+
+async function renderHarness(page: Page, connections: Array<{ sessionId: string; state: string }>): Promise<void> {
+  await page.evaluate((initialConnections) => {
+    window.__renderOAuthHarness(initialConnections);
+  }, connections);
+  await expect.poll(() => page.evaluate(() => typeof window.__setConnections)).toBe('function');
+}
+
+async function sendAuthCode(page: Page, sessionId: string, code: string): Promise<void> {
+  await page.evaluate(
+    ({ channelName, type, sessionId, code }) => {
+      const payload = { type, sessionId, code };
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: payload,
+          origin: window.location.origin,
+          source: window,
+        })
+      );
+
+      const channel = new BroadcastChannel(channelName);
+      channel.postMessage(payload);
+      channel.close();
+    },
+    { channelName: authChannelName, type: authCodeMessage, sessionId, code }
+  );
+}
+
+async function sendAuthCodeWindowMessage(
+  page: Page,
+  data: { sessionId?: string; code?: string; origin?: string }
+): Promise<void> {
+  await page.evaluate(
+    ({ type, sessionId, code, origin }) => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { type, sessionId, code },
+          origin,
+          source: window,
+        })
+      );
+    },
+    {
+      type: authCodeMessage,
+      sessionId: data.sessionId,
+      code: data.code,
+      origin: data.origin,
+    }
+  );
+}
+
+async function sendAuthCodeFromPopupFrame(
+  page: Page,
+  data: { sessionId?: string; code?: string }
+): Promise<void> {
+  await page.evaluate(
+    ({ type, sessionId, code }) => {
+      const frame = document.createElement('iframe');
+      frame.src = 'about:blank';
+      document.body.appendChild(frame);
+      frame.contentWindow?.addEventListener('message', (event) => {
+        if (event.data?.type === 'MCP_AUTH_RESULT') {
+          window.__authResults.push(event.data);
+        }
+      });
+
+      const payload = { type, sessionId, code };
+      frame.contentWindow?.eval(
+        `parent.postMessage(${JSON.stringify(payload)}, ${JSON.stringify(window.location.origin)})`
+      );
+    },
+    {
+      type: authCodeMessage,
+      sessionId: data.sessionId,
+      code: data.code,
+    }
+  );
+}
+
+async function captureAuthResults(page: Page): Promise<void> {
+  await page.evaluate(
+    ({ channelName }) => {
+      window.__authResults = [];
+
+      window.addEventListener('message', (event) => {
+        if (event.data?.type === 'MCP_AUTH_RESULT') {
+          window.__authResults.push(event.data);
+        }
+      });
+
+      const channel = new BroadcastChannel(channelName);
+      channel.addEventListener('message', (event) => {
+        if (event.data?.type === 'MCP_AUTH_RESULT') {
+          window.__authResults.push(event.data);
+        }
+      });
+      window.__authResultChannel = channel;
+    },
+    { channelName: authChannelName }
+  );
+}
+
+test.describe('useMcpOAuthPopup', () => {
+  test.afterEach(async ({ page }) => {
+    await page.evaluate(() => {
+      window.__authResultChannel?.close();
+    }).catch(() => undefined);
+  });
+
+  test('processes duplicate popup and broadcast auth code messages once', async ({ page }) => {
+    await loadHarness(page);
+    await renderHarness(page, [{ sessionId: 'session-1', state: 'AUTHORIZING' }]);
+
+    await sendAuthCode(page, 'session-1', 'code-1');
+
+    await expect.poll(() => page.evaluate(() => window.__finishAuthCalls.length)).toBe(1);
+    await expect(page.evaluate(() => window.__finishAuthCalls)).resolves.toEqual([
+      { sessionId: 'session-1', code: 'code-1' },
+    ]);
+  });
+
+  test('does not mark an auth code processed before its session exists', async ({ page }) => {
+    await loadHarness(page);
+    await renderHarness(page, []);
+
+    await sendAuthCode(page, 'session-2', 'code-2');
+    await page.waitForTimeout(100);
+    await expect(page.evaluate(() => window.__finishAuthCalls)).resolves.toEqual([]);
+
+    await page.evaluate(() => {
+      window.__setConnections([{ sessionId: 'session-2', state: 'AUTHORIZING' }]);
+    });
+    await sendAuthCode(page, 'session-2', 'code-2');
+
+    await expect.poll(() => page.evaluate(() => window.__finishAuthCalls.length)).toBe(1);
+    await expect(page.evaluate(() => window.__finishAuthCalls)).resolves.toEqual([
+      { sessionId: 'session-2', code: 'code-2' },
+    ]);
+  });
+
+  test('ignores auth code messages from another origin', async ({ page }) => {
+    await loadHarness(page);
+    await renderHarness(page, [{ sessionId: 'session-3', state: 'AUTHORIZING' }]);
+
+    await sendAuthCodeWindowMessage(page, {
+      sessionId: 'session-3',
+      code: 'code-3',
+      origin: 'https://evil.example',
+    });
+    await page.waitForTimeout(100);
+
+    await expect(page.evaluate(() => window.__finishAuthCalls)).resolves.toEqual([]);
+  });
+
+  test('reports missing session identifiers back to the popup', async ({ page }) => {
+    await loadHarness(page);
+    await renderHarness(page, [{ sessionId: 'session-4', state: 'AUTHORIZING' }]);
+    await captureAuthResults(page);
+
+    await sendAuthCodeFromPopupFrame(page, {
+      code: 'code-4',
+    });
+
+    await expect.poll(() => page.evaluate(() => window.__authResults.length)).toBeGreaterThan(0);
+    await expect(page.evaluate(() => window.__authResults)).resolves.toContainEqual(
+      expect.objectContaining({
+        type: 'MCP_AUTH_RESULT',
+        success: false,
+        error: 'Missing OAuth session identifier',
+      })
+    );
+  });
+
+  test('reports finishAuth errors back to the popup', async ({ page }) => {
+    await loadHarness(page);
+    await renderHarness(page, [{ sessionId: 'session-5', state: 'AUTHORIZING' }]);
+    await captureAuthResults(page);
+    await page.evaluate(() => {
+      window.__finishAuthErrorMessage = 'Authorization code already used';
+    });
+
+    await sendAuthCodeFromPopupFrame(page, {
+      sessionId: 'session-5',
+      code: 'code-5',
+    });
+
+    await expect.poll(() => page.evaluate(() => window.__authResults.length)).toBeGreaterThan(0);
+    await expect(page.evaluate(() => window.__authResults)).resolves.toContainEqual(
+      expect.objectContaining({
+        type: 'MCP_AUTH_RESULT',
+        sessionId: 'session-5',
+        success: false,
+        error: 'Authorization code already used',
+      })
+    );
+  });
+
+  test('reports success when the authenticated connection becomes ready', async ({ page }) => {
+    await loadHarness(page);
+    await renderHarness(page, [{ sessionId: 'session-6', state: 'AUTHORIZING' }]);
+    await captureAuthResults(page);
+
+    await sendAuthCodeFromPopupFrame(page, {
+      sessionId: 'session-6',
+      code: 'code-6',
+    });
+    await expect.poll(() => page.evaluate(() => window.__finishAuthCalls.length)).toBe(1);
+
+    await page.evaluate(() => {
+      window.__setConnections([{ sessionId: 'session-6', state: 'CONNECTED' }]);
+    });
+
+    await expect.poll(() => page.evaluate(() => window.__authResults.length)).toBeGreaterThan(0);
+    await expect(page.evaluate(() => window.__authResults)).resolves.toContainEqual(
+      expect.objectContaining({
+        type: 'MCP_AUTH_RESULT',
+        sessionId: 'session-6',
+        success: true,
+      })
+    );
+  });
+});
+
+declare global {
+  interface Window {
+    __authResultChannel?: BroadcastChannel;
+    __authResults: Array<{ type: string; sessionId?: string; success: boolean; error?: string }>;
+    __finishAuthErrorMessage?: string;
+    __finishAuthCalls: Array<{ sessionId: string; code: string }>;
+    __initialConnections?: Array<{ sessionId: string; state: string }>;
+    __renderOAuthHarness: (connections?: Array<{ sessionId: string; state: string }>) => void;
+    __setConnections: (connections: Array<{ sessionId: string; state: string }>) => void;
+  }
+}


### PR DESCRIPTION
## Summary
This PR fixes the OAuth popup flow that could leave the popup open or show an "Authorization code already used" error when auth completion and connection/tool discovery took longer than expected.

The final implementation keeps the opener window responsible for exchanging the OAuth code, makes the popup message bridge more reliable, and removes redundant fallback behavior that could reuse an already-consumed authorization code.

## Root Causes Addressed
1. **Duplicate code delivery**: `postMessage` and `BroadcastChannel` can both deliver the same OAuth code. The opener now deduplicates in-flight processing per session/code pair.
2. **Premature processed-code tracking**: A code could previously be marked processed before the matching session existed in React state, causing the valid retry signal to be ignored later.
3. **Missing popup result path**: Success was only reported for a narrow state transition and could miss `READY` / `CONNECTED` states after slower initialization or tool discovery.
4. **Redundant popup fallback**: The example popup attempted its own `finishAuth` fallback, which could race with the opener and trigger "Authorization code already used".
5. **BroadcastChannel assumptions**: `BroadcastChannel` is now optional so browsers/environments without it still use the primary `postMessage` path.

## Changes
- **SDK**
  - Captures popup window references before handling duplicate messages.
  - Uses per-session in-flight dedupe instead of global processed-code state.
  - Reports popup success for `AUTHENTICATED`, `READY`, and `CONNECTED` connection states.
  - Reports popup failures for missing session identifiers, missing sessions, failed auth, and failed connection state.
  - Treats `BroadcastChannel` as a progressive enhancement rather than a hard dependency.

- **Example App**
  - Removes the popup-side `finishAuth` fallback to avoid redundant token exchange attempts.
  - Keeps `postMessage` as the primary callback path and optional `BroadcastChannel` as backup delivery.
  - Shows a timeout error if the popup cannot confirm completion from the main window.

- **Tests**
  - Adds `tests/oauth-popup.test.ts` covering duplicate code messages, delayed session availability, cross-origin filtering, missing session IDs, `finishAuth` failures, and success reporting after the connection becomes ready.

## Verification
- `npx playwright test tests/oauth-popup.test.ts` - 6 passed
- `npx tsc --noEmit --skipLibCheck --jsx react-jsx --target es2022 --lib "dom,dom.iterable,es2022" --module esnext --moduleResolution bundler --allowSyntheticDefaultImports --esModuleInterop src/client/react/oauth-popup.tsx examples/next/app/oauth/callback-popup/page.tsx` - passed
- `npm run build` - passed

Fixes #103