### PR TITLE
feat(tool-router): simplify meta-tools, add customizable names, and implement BM25 search

### DIFF
--- a/examples/next/app/agent/tool-router.ts
+++ b/examples/next/app/agent/tool-router.ts
@@ -1,0 +1,70 @@
+import { ToolLoopAgent, InferAgentUIMessage, stepCountIs } from "ai";
+import { createMCPClient, type MCPClient } from "@ai-sdk/mcp";
+import { createDeepSeek } from "@ai-sdk/deepseek";
+import { createToolRouter, createAISDKTools, asToolSource } from "@mcp-ts/tool-router";
+
+// ----------------------------------------------------------------------
+// 1. Agent Instructions
+// ----------------------------------------------------------------------
+const INSTRUCTIONS = `
+You are an expert assistant that helps users with tasks using the available MCP tools.
+
+Use this flow:
+1) list_sources
+2) search_tools
+3) get_tool_schema
+4) call_tool
+
+Always search tools first before calling them.
+`;
+
+const EXA_MCP_URL =
+  "https://mcp.exa.ai/mcp?tools=web_search_exa,deep_search_exa,get_code_context_exa,crawling_exa";
+const GREP_MCP_URL = "https://mcp.grep.app";
+
+const globalForMcp = globalThis as unknown as {
+  toolRouterToolsPromise?: Promise<Record<string, unknown>>;
+};
+
+async function getRouterTools(): Promise<Record<string, unknown>> {
+  if (!globalForMcp.toolRouterToolsPromise) {
+    globalForMcp.toolRouterToolsPromise = (async () => {
+      const [exaClient, grepClient] = await Promise.all([
+        createMCPClient({
+          transport: { type: "http", url: EXA_MCP_URL }
+        }),
+        createMCPClient({
+          transport: { type: "http", url: GREP_MCP_URL }
+        })
+      ]);
+
+      const router = await createToolRouter({
+        sources: [
+          asToolSource("exa", exaClient),
+          asToolSource("grep", grepClient)
+        ],
+        maxSearchResults: 8
+      });
+
+      return createAISDKTools(router) as Promise<Record<string, unknown>>;
+    })();
+  }
+
+  return globalForMcp.toolRouterToolsPromise;
+}
+
+export async function createMcpAgent(userId: string = process.env.NEXT_PUBLIC_MCP_USER_ID!) {
+  void userId;
+  const tools = await getRouterTools();
+
+  return new ToolLoopAgent({
+    model: createDeepSeek({ apiKey: process.env.DEEPSEEK_API_KEY })("deepseek-chat"),
+    instructions: INSTRUCTIONS,
+    tools: tools as any,
+    stopWhen: stepCountIs(20),
+  });
+}
+
+export type McpAgentUIMessage = InferAgentUIMessage<
+  Awaited<ReturnType<typeof createMcpAgent>>
+>;

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -10,8 +10,10 @@
   },
   "dependencies": {
     "@ai-sdk/deepseek": "^2.0.29",
+    "@ai-sdk/mcp": "^1.0.42",
     "@ai-sdk/react": "^3.0.170",
     "@mcp-ts/sdk": "file:../..",
+    "@mcp-ts/tool-router": "file:../../packages/tool-router",
     "@mcp-ts/codemode": "file:../../packages/codemode",
     "isolated-vm": "^6.1.2",
     "@radix-ui/react-slot": "^1.2.4",

--- a/packages/tool-router/README.md
+++ b/packages/tool-router/README.md
@@ -64,10 +64,10 @@ const github = createToolSource({
 
 The router exposes four meta-tools to LLMs:
 
-- `toolrouter_search_tools`: Search the tool index without fetching full schemas.
-- `toolrouter_list_sources`: List registered sources and tool counts.
-- `toolrouter_get_tool_schema`: Fetch the input schema for a specific tool.
-- `toolrouter_call_tool`: Invoke a tool on a registered source.
+- `search_tools`: Search the tool index without fetching full schemas.
+- `list_sources`: List registered sources and tool counts.
+- `get_tool_schema`: Fetch the input schema for a specific tool.
+- `call_tool`: Invoke a tool on a registered source.
 
 ---
 
@@ -77,7 +77,13 @@ The router exposes four meta-tools to LLMs:
 import { createToolRouter } from "@mcp-ts/tool-router";
 
 const router = await createToolRouter({
-  sources: [github, linear, slack]
+  sources: [github, linear, slack],
+  metaToolNames: {
+    searchTools: "find_tools",
+    listSources: "sources",
+    getToolSchema: "tool_schema",
+    callTool: "run_tool"
+  }
 });
 
 // Search tools
@@ -129,6 +135,57 @@ The model only sees the meta-tools rather than the entire tool catalog at start.
 
 ---
 
+## AI SDK Agent Example (Exa + grep)
+
+This mirrors the pattern used in `examples/next/app/agent/agent.ts`.
+
+```typescript
+import { ToolLoopAgent, stepCountIs } from "ai";
+import { createMCPClient } from "@ai-sdk/mcp";
+import { createDeepSeek } from "@ai-sdk/deepseek";
+import { createToolRouter, createAISDKTools, asToolSource } from "@mcp-ts/tool-router";
+
+const EXA_MCP_URL =
+  "https://mcp.exa.ai/mcp?tools=web_search_exa,deep_search_exa,get_code_context_exa,crawling_exa";
+const GREP_MCP_URL = "https://mcp.grep.app";
+
+const instructions = `
+You are an expert assistant that helps users with tasks using available MCP tools.
+Use this flow:
+1) list_sources
+2) search_tools
+3) get_tool_schema
+4) call_tool
+Always search first before calling.
+`;
+
+async function createAgent() {
+  const [exaClient, grepClient] = await Promise.all([
+    createMCPClient({ transport: { type: "http", url: EXA_MCP_URL } }),
+    createMCPClient({ transport: { type: "http", url: GREP_MCP_URL } })
+  ]);
+
+  const router = await createToolRouter({
+    sources: [
+      asToolSource("exa", exaClient),
+      asToolSource("grep", grepClient)
+    ],
+    maxSearchResults: 8
+  });
+
+  const tools = await createAISDKTools(router);
+
+  return new ToolLoopAgent({
+    model: createDeepSeek({ apiKey: process.env.DEEPSEEK_API_KEY })("deepseek-chat"),
+    instructions,
+    tools: tools as any,
+    stopWhen: stepCountIs(20)
+  });
+}
+```
+
+---
+
 ## MCP Client Adapters
 
 Wrap any compatible MCP client with `mcpSource`:
@@ -149,6 +206,20 @@ If you have a client provider that manages multiple active clients:
 ```typescript
 const router = await createToolRouter({
   sources: mcpSources(multiSessionClient)
+});
+```
+
+Using Vercel AI SDK MCP clients (`@ai-sdk/mcp`):
+
+```typescript
+import { createMCPClient } from "@ai-sdk/mcp";
+import { createToolRouter, asToolSource } from "@mcp-ts/tool-router";
+
+const exa = await createMCPClient({ transport: { type: "http", url: "https://mcp.exa.ai/mcp" } });
+const grep = await createMCPClient({ transport: { type: "http", url: "https://mcp.grep.app" } });
+
+const router = await createToolRouter({
+  sources: [asToolSource("exa", exa), asToolSource("grep", grep)]
 });
 ```
 
@@ -181,6 +252,7 @@ Main exports:
 - `createToolRouter(options)`: Create and initialize a `ToolRouter`.
 - `createToolSource(source)`: Helper to type-check custom tool sources.
 - `createAISDKTools(router)`: Expose meta-tools as Vercel AI SDK tools.
+- `asToolSource(id, client, name?)`: Adapt a compatible MCP tool client (including `@ai-sdk/mcp`) to `ToolSource`.
 - `mcpSource(id, client, name?)`: Wrap an MCP-like client as a `ToolSource`.
 - `mcpSources(provider)`: Convert multiple client instances to `ToolSource[]`.
 

--- a/packages/tool-router/src/adapters/ai-sdk.ts
+++ b/packages/tool-router/src/adapters/ai-sdk.ts
@@ -1,5 +1,5 @@
 import type { ToolRouter } from "../router.js";
-import { isToolRouterMetaTool } from "../meta-tools.js";
+import type { ToolSource } from "../types.js";
 
 export type AISDKToolSet = Record<string, {
   description?: string;
@@ -7,6 +7,50 @@ export type AISDKToolSet = Record<string, {
   execute: (args: Record<string, unknown>) => Promise<unknown>;
   annotations?: any;
 }>;
+
+export interface MCPClient {
+  listTools(): Promise<{
+    tools: Array<{
+      name: string;
+      description?: string;
+      inputSchema?: unknown;
+      annotations?: Record<string, unknown>;
+      [key: string]: unknown;
+    }>;
+  }>;
+  tools(): Promise<Record<string, unknown>>;
+}
+
+export function asToolSource(id: string, client: MCPClient, name?: string): ToolSource {
+  let cachedToolsPromise: Promise<Record<string, unknown>> | null = null;
+
+  return {
+    id,
+    name: name ?? id,
+    listTools: async () => {
+      const result = await client.listTools();
+      return {
+        tools: result.tools.map((tool) => ({
+          name: tool.name,
+          description: typeof tool.description === "string" ? tool.description : undefined,
+          inputSchema: tool.inputSchema,
+          annotations: (tool.annotations ?? undefined) as Record<string, unknown> | undefined
+        }))
+      };
+    },
+    callTool: async (toolName, args) => {
+      if (!cachedToolsPromise) {
+        cachedToolsPromise = client.tools();
+      }
+      const toolSet = await cachedToolsPromise;
+      const tool = toolSet[toolName] as { execute?: (...args: unknown[]) => Promise<unknown> } | undefined;
+      if (!tool || typeof tool.execute !== "function") {
+        throw new Error(`Tool "${toolName}" not found on source "${id}".`);
+      }
+      return tool.execute(args);
+    }
+  };
+}
 
 export async function createAISDKTools(router: ToolRouter): Promise<AISDKToolSet> {
   let jsonSchema: ((schema: any) => unknown) | undefined;
@@ -23,12 +67,7 @@ export async function createAISDKTools(router: ToolRouter): Promise<AISDKToolSet
         description: tool.description,
         inputSchema: jsonSchema!(tool.inputSchema),
         annotations: tool.annotations,
-        execute: async (args: Record<string, unknown>) => {
-          if (!isToolRouterMetaTool(tool.name)) {
-            throw new Error(`Unknown toolrouter meta tool "${tool.name}".`);
-          }
-          return router.executeMetaTool(tool.name, args);
-        }
+        execute: async (args: Record<string, unknown>) => router.executeMetaTool(tool.name, args)
       }
     ])
   );

--- a/packages/tool-router/src/index.ts
+++ b/packages/tool-router/src/index.ts
@@ -1,14 +1,9 @@
 export { ToolRouter, createToolRouter } from "./router.js";
 export {
-  TOOLROUTER_CALL_TOOL,
-  TOOLROUTER_GET_TOOL_SCHEMA,
-  TOOLROUTER_LIST_SOURCES,
-  TOOLROUTER_META_TOOL_NAMES,
-  TOOLROUTER_SEARCH_TOOLS,
   createMetaTools,
-  isToolRouterMetaTool
+  DEFAULT_TOOLROUTER_META_TOOL_NAMES
 } from "./meta-tools.js";
-export { createAISDKTools } from "./adapters/ai-sdk.js";
+export { createAISDKTools, asToolSource } from "./adapters/ai-sdk.js";
 export { mcpSource, mcpSources } from "./adapters/mcp.js";
 export type {
   IndexedTool,
@@ -17,13 +12,16 @@ export type {
   ToolDefinition,
   ToolRouterCallResult,
   ToolRouterMetaTool,
+  ToolRouterMetaToolNames,
   ToolRouterOptions,
   ToolRouterPolicy,
+  ToolSchemaResult,
   ToolSchemaRequest,
   ToolSearchRequest,
   ToolSearchResult,
   ToolSource
 } from "./types.js";
+export type { MCPClient } from "./adapters/ai-sdk.js";
 
 export function createToolSource(source: import("./types.js").ToolSource): import("./types.js").ToolSource {
   return source;

--- a/packages/tool-router/src/meta-tools.ts
+++ b/packages/tool-router/src/meta-tools.ts
@@ -1,25 +1,16 @@
-import type { ToolRouterMetaTool } from "./types.js";
+import type { ToolRouterMetaTool, ToolRouterMetaToolNames } from "./types.js";
 
-export const TOOLROUTER_SEARCH_TOOLS = "toolrouter_search_tools";
-export const TOOLROUTER_LIST_SOURCES = "toolrouter_list_sources";
-export const TOOLROUTER_GET_TOOL_SCHEMA = "toolrouter_get_tool_schema";
-export const TOOLROUTER_CALL_TOOL = "toolrouter_call_tool";
+export const DEFAULT_TOOLROUTER_META_TOOL_NAMES: ToolRouterMetaToolNames = {
+  searchTools: "search_tools",
+  listSources: "list_sources",
+  getToolSchema: "get_tool_schema",
+  callTool: "call_tool"
+};
 
-export const TOOLROUTER_META_TOOL_NAMES = [
-  TOOLROUTER_SEARCH_TOOLS,
-  TOOLROUTER_LIST_SOURCES,
-  TOOLROUTER_GET_TOOL_SCHEMA,
-  TOOLROUTER_CALL_TOOL
-] as const;
-
-export function isToolRouterMetaTool(name: string): boolean {
-  return (TOOLROUTER_META_TOOL_NAMES as readonly string[]).includes(name);
-}
-
-export function createMetaTools(): ToolRouterMetaTool[] {
+export function createMetaTools(names: ToolRouterMetaToolNames = DEFAULT_TOOLROUTER_META_TOOL_NAMES): ToolRouterMetaTool[] {
   return [
     {
-      name: TOOLROUTER_SEARCH_TOOLS,
+      name: names.searchTools,
       description:
         "Search connected tool sources without loading every tool schema into context. Use this first to find candidate tools.",
       inputSchema: {
@@ -33,7 +24,7 @@ export function createMetaTools(): ToolRouterMetaTool[] {
       }
     },
     {
-      name: TOOLROUTER_LIST_SOURCES,
+      name: names.listSources,
       description: "List connected tool sources and indexed tool counts.",
       inputSchema: {
         type: "object",
@@ -43,7 +34,7 @@ export function createMetaTools(): ToolRouterMetaTool[] {
       }
     },
     {
-      name: TOOLROUTER_GET_TOOL_SCHEMA,
+      name: names.getToolSchema,
       description: "Get the full input schema for one discovered tool before calling it.",
       inputSchema: {
         type: "object",
@@ -56,7 +47,7 @@ export function createMetaTools(): ToolRouterMetaTool[] {
       }
     },
     {
-      name: TOOLROUTER_CALL_TOOL,
+      name: names.callTool,
       description: "Proxy execution to a discovered tool on the correct source.",
       inputSchema: {
         type: "object",

--- a/packages/tool-router/src/router.ts
+++ b/packages/tool-router/src/router.ts
@@ -1,26 +1,33 @@
-import { createMetaTools, TOOLROUTER_CALL_TOOL, TOOLROUTER_GET_TOOL_SCHEMA, TOOLROUTER_LIST_SOURCES, TOOLROUTER_SEARCH_TOOLS } from "./meta-tools.js";
+import { createMetaTools, DEFAULT_TOOLROUTER_META_TOOL_NAMES } from "./meta-tools.js";
 import type {
   IndexedTool,
   ToolCallRequest,
   ToolDefinition,
+  ToolRouterMetaToolNames,
   ToolRouterCallResult,
   ToolRouterMetaTool,
   ToolRouterOptions,
+  ToolSchemaResult,
   ToolSchemaRequest,
   ToolSearchRequest,
   ToolSearchResult,
   ToolSource
 } from "./types.js";
-import { assertToolAllowed, matchesSearchScope, normalizeSourceId, scoreTool } from "./utils.js";
+import { assertToolAllowed, bm25Scores, matchesSearchScope, normalizeSourceId } from "./utils.js";
 
 export class ToolRouter {
   private sources = new Map<string, ToolSource>();
   private indexedTools: IndexedTool[] = [];
   private initialized = false;
   private maxSearchResults: number;
+  private metaToolNames: ToolRouterMetaToolNames;
 
   constructor(private options: ToolRouterOptions) {
     this.maxSearchResults = options.maxSearchResults ?? 10;
+    this.metaToolNames = {
+      ...DEFAULT_TOOLROUTER_META_TOOL_NAMES,
+      ...(options.metaToolNames ?? {})
+    };
     for (const source of options.sources) {
       this.sources.set(source.id, source);
     }
@@ -54,7 +61,7 @@ export class ToolRouter {
   }
 
   getMetaTools(): ToolRouterMetaTool[] {
-    const tools = createMetaTools();
+    const tools = createMetaTools(this.metaToolNames);
     if (!this.options.excludeMetaTools?.length) {
       return tools;
     }
@@ -65,10 +72,11 @@ export class ToolRouter {
   async searchTools(request: ToolSearchRequest): Promise<ToolSearchResult[]> {
     await this.ensureInitialized();
     const limit = Math.min(request.limit ?? this.maxSearchResults, 100);
+    const candidates = this.indexedTools.filter((tool) => matchesSearchScope(tool, request));
+    const scores = bm25Scores(candidates, request.query ?? "");
 
-    return this.indexedTools
-      .filter((tool) => matchesSearchScope(tool, request))
-      .map((tool) => ({ tool, score: scoreTool(tool, request.query) }))
+    return candidates
+      .map((tool, index) => ({ tool, score: scores[index] ?? 0 }))
       .filter((entry) => !request.query || entry.score > 0)
       .sort((a, b) => b.score - a.score || a.tool.toolName.localeCompare(b.tool.toolName))
       .slice(0, limit)
@@ -77,7 +85,6 @@ export class ToolRouter {
         sourceName: tool.sourceName,
         toolName: tool.toolName,
         description: tool.description,
-        annotations: tool.annotations,
         score
       }));
   }
@@ -85,6 +92,14 @@ export class ToolRouter {
   listSources(query = ""): Array<{ sourceId: string; sourceName: string; toolCount: number }> {
     const lowered = query.toLowerCase();
     const counts = new Map<string, { sourceId: string; sourceName: string; toolCount: number }>();
+
+    for (const [sourceId, source] of this.sources.entries()) {
+      counts.set(sourceId, {
+        sourceId,
+        sourceName: source.name ?? sourceId,
+        toolCount: 0
+      });
+    }
 
     for (const tool of this.indexedTools) {
       const current =
@@ -102,12 +117,18 @@ export class ToolRouter {
     );
   }
 
-  getToolSchema(request: ToolSchemaRequest): IndexedTool {
+  getToolSchema(request: ToolSchemaRequest): ToolSchemaResult {
     const tool = this.resolveTool(request);
     if (!tool) {
       throw new Error(`Tool "${request.toolName}" was not found.`);
     }
-    return { ...tool };
+    return {
+      sourceId: tool.sourceId,
+      sourceName: tool.sourceName,
+      toolName: tool.toolName,
+      description: tool.description,
+      inputSchema: tool.inputSchema
+    };
   }
 
   async callTool(request: ToolCallRequest): Promise<unknown> {
@@ -130,7 +151,7 @@ export class ToolRouter {
   async executeMetaTool(name: string, args: Record<string, unknown>): Promise<ToolRouterCallResult> {
     try {
       switch (name) {
-        case TOOLROUTER_SEARCH_TOOLS: {
+        case this.metaToolNames.searchTools: {
           const results = await this.searchTools({
             query: stringArg(args.query),
             sourceId: stringArg(args.sourceId),
@@ -139,12 +160,12 @@ export class ToolRouter {
           });
           return this.success(formatJson(results), results);
         }
-        case TOOLROUTER_LIST_SOURCES: {
+        case this.metaToolNames.listSources: {
           await this.ensureInitialized();
           const result = this.listSources(stringArg(args.query) ?? "");
           return this.success(formatJson(result), result);
         }
-        case TOOLROUTER_GET_TOOL_SCHEMA: {
+        case this.metaToolNames.getToolSchema: {
           const schema = this.getToolSchema({
             sourceId: stringArg(args.sourceId),
             sourceName: stringArg(args.sourceName),
@@ -152,7 +173,7 @@ export class ToolRouter {
           });
           return this.success(formatJson(schema), schema);
         }
-        case TOOLROUTER_CALL_TOOL: {
+        case this.metaToolNames.callTool: {
           const result = await this.callTool({
             sourceId: stringArg(args.sourceId),
             sourceName: stringArg(args.sourceName),

--- a/packages/tool-router/src/types.ts
+++ b/packages/tool-router/src/types.ts
@@ -1,8 +1,10 @@
 export interface ToolAnnotations {
+  title?: string;
   readOnlyHint?: boolean;
   destructiveHint?: boolean;
   idempotentHint?: boolean;
   openWorldHint?: boolean;
+  [key: string]: unknown;
 }
 
 export interface ToolDefinition {
@@ -34,8 +36,15 @@ export interface ToolSearchResult {
   sourceName: string;
   toolName: string;
   description: string;
-  annotations?: ToolAnnotations;
   score: number;
+}
+
+export interface ToolSchemaResult {
+  sourceId: string;
+  sourceName: string;
+  toolName: string;
+  description: string;
+  inputSchema?: unknown;
 }
 
 export interface ToolRouterPolicy {
@@ -50,6 +59,12 @@ export interface ToolRouterOptions {
   policy?: ToolRouterPolicy;
   maxSearchResults?: number;
   excludeMetaTools?: string[];
+  metaToolNames?: Partial<{
+    searchTools: string;
+    listSources: string;
+    getToolSchema: string;
+    callTool: string;
+  }>;
 }
 
 export interface ToolSearchRequest {
@@ -74,6 +89,13 @@ export interface ToolRouterMetaTool {
   description: string;
   inputSchema: unknown;
   annotations?: ToolAnnotations;
+}
+
+export interface ToolRouterMetaToolNames {
+  searchTools: string;
+  listSources: string;
+  getToolSchema: string;
+  callTool: string;
 }
 
 export interface ToolRouterCallResult {

--- a/packages/tool-router/src/utils.ts
+++ b/packages/tool-router/src/utils.ts
@@ -27,28 +27,70 @@ export function matchesSearchScope(tool: IndexedTool, request: ToolSearchRequest
   return true;
 }
 
-export function scoreTool(tool: IndexedTool, query = ""): number {
-  const terms = query
-    .toLowerCase()
-    .split(/\s+/)
-    .map((term) => term.trim())
-    .filter(Boolean);
+function tokenize(value: string): string[] {
+  return value.toLowerCase().match(/[a-z0-9_]+/g) ?? [];
+}
 
-  if (terms.length === 0) return 1;
+function documentTokens(tool: IndexedTool): string[] {
+  const name = tokenize(tool.toolName);
+  const source = tokenize(`${tool.sourceId} ${tool.sourceName}`);
+  const description = tokenize(tool.description);
 
-  const name = tool.toolName.toLowerCase();
-  const source = `${tool.sourceId} ${tool.sourceName}`.toLowerCase();
-  const description = tool.description.toLowerCase();
-  let score = 0;
+  // Keep prior weighting intent: name > source > description.
+  return [
+    ...name,
+    ...name,
+    ...name,
+    ...source,
+    ...source,
+    ...description
+  ];
+}
 
-  for (const term of terms) {
-    if (name === term) score += 10;
-    if (name.includes(term)) score += 6;
-    if (source.includes(term)) score += 4;
-    if (description.includes(term)) score += 2;
+export function bm25Scores(tools: IndexedTool[], query = ""): number[] {
+  const queryTerms = tokenize(query);
+  if (queryTerms.length === 0) {
+    return tools.map(() => 1);
   }
 
-  return score;
+  const docs = tools.map(documentTokens);
+  const docLengths = docs.map((d) => d.length);
+  const totalLength = docLengths.reduce((sum, n) => sum + n, 0);
+  const avgDocLength = tools.length > 0 ? totalLength / tools.length : 1;
+
+  const df = new Map<string, number>();
+  for (const doc of docs) {
+    for (const term of new Set(doc)) {
+      df.set(term, (df.get(term) ?? 0) + 1);
+    }
+  }
+
+  const k1 = 1.2;
+  const b = 0.75;
+  const n = tools.length;
+
+  return docs.map((doc, index) => {
+    const tf = new Map<string, number>();
+    for (const term of doc) {
+      tf.set(term, (tf.get(term) ?? 0) + 1);
+    }
+
+    const dl = docLengths[index] || 1;
+    let score = 0;
+
+    for (const term of queryTerms) {
+      const termFreq = tf.get(term) ?? 0;
+      if (termFreq === 0) continue;
+
+      const termDf = df.get(term) ?? 0;
+      const idf = Math.log(1 + (n - termDf + 0.5) / (termDf + 0.5));
+      const numerator = termFreq * (k1 + 1);
+      const denominator = termFreq + k1 * (1 - b + b * (dl / avgDocLength));
+      score += idf * (numerator / denominator);
+    }
+
+    return score;
+  });
 }
 
 export async function assertToolAllowed(

--- a/packages/tool-router/test/toolrouter.test.mjs
+++ b/packages/tool-router/test/toolrouter.test.mjs
@@ -2,8 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   createToolRouter,
-  createToolSource,
-  isToolRouterMetaTool
+  createToolSource
 } from "../dist/index.js";
 
 function fakeSource(id, tools) {
@@ -91,27 +90,26 @@ test("exposes meta tools for search, schema lookup, and proxy execution", async 
   const names = metaTools.map((tool) => tool.name);
 
   assert.deepEqual(names, [
-    "toolrouter_search_tools",
-    "toolrouter_list_sources",
-    "toolrouter_get_tool_schema",
-    "toolrouter_call_tool"
+    "search_tools",
+    "list_sources",
+    "get_tool_schema",
+    "call_tool"
   ]);
-  assert.equal(names.every(isToolRouterMetaTool), true);
 
-  const search = await router.executeMetaTool("toolrouter_search_tools", {
+  const search = await router.executeMetaTool("search_tools", {
     query: "pull requests"
   });
   assert.equal(search.isError, false);
   assert.match(search.content[0].text, /list_pull_requests/);
 
-  const schema = await router.executeMetaTool("toolrouter_get_tool_schema", {
+  const schema = await router.executeMetaTool("get_tool_schema", {
     sourceId: "github",
     toolName: "list_pull_requests"
   });
   assert.equal(schema.isError, false);
   assert.match(schema.content[0].text, /inputSchema/);
 
-  const call = await router.executeMetaTool("toolrouter_call_tool", {
+  const call = await router.executeMetaTool("call_tool", {
     sourceId: "github",
     toolName: "list_pull_requests",
     args: { state: "open" }


### PR DESCRIPTION
## What is the type of this PR?

- [ ] Bugfix
- [x] Feature
- [x] Refactoring
- [ ] Documentation
- [ ] Other

## Which area of the project does this PR affect?

- [ ] `server` (MCP client, handlers)
- [ ] `client` (React, Vue, SSE client)
- [x] `adapters` (Vercel AI, LangChain, Mastra, AG-UI)
- [ ] `storage` (Redis, SQLite, File, Memory backends)
- [ ] `docs` (Docusaurus documentation)
- [x] `examples` (Example applications)
- [ ] `ci` (GitHub workflows)
- [x] Other (Standalone Tool Router Package)

## Description of the change

### Overview
This PR simplifies, standardizes, and enhances the `@mcp-ts/tool-router` package. Key improvements include removing the verbose `toolrouter_` prefix from the meta-tool names, adding support for fully customizable meta-tool naming mappings, integrating a robust BM25-based search scoring/ranking algorithm for tool searching, and providing an adapter to seamlessly bridge AI SDK MCP clients as tool sources. Additionally, a complete Next.js integration example using Exa and Grep MCP clients is included.

### Detailed Changes

#### 1. Simplified & Customizable Meta-Tools (`packages/tool-router`)
* **Simplified Default Names:** Removed the `toolrouter_` prefix from the default meta-tools. They are now cleaner:
  * `toolrouter_search_tools` → `search_tools`
  * `toolrouter_list_sources` → `list_sources`
  * `toolrouter_get_tool_schema` → `get_tool_schema`
  * `toolrouter_call_tool` → `call_tool`
* **Customizable Naming Mapping:** Added the `metaToolNames` option to `ToolRouterOptions` allowing clients to rename the meta-tools to any custom string (e.g. `find_tools`, `sources`, `tool_schema`, `run_tool`).
* **Cleaned Up Exports:** Cleaned up exports in indices and exported `DEFAULT_TOOLROUTER_META_TOOL_NAMES` and custom types.

#### 2. AI SDK Integration & Adapter (`packages/tool-router`)
* **`asToolSource` Helper:** Introduced a utility to convert any standard Vercel AI SDK `MCPClient` into a compatible `ToolSource` for the router.
* **Cached Tool Executions:** Handled caching of tool listing/execution on the bridged clients to prevent redundant fetching.

#### 3. BM25 Search Scoring & Ranking Algorithm (`packages/tool-router`)
* Replaced the simplistic term-matching heuristic `scoreTool` with a proper BM25 search index scoring mechanism (`bm25Scores`).
* Implemented text tokenization and IDF document frequency calculations. Weighted components prioritizing tool name (highest), source (middle), and description (lowest) for more relevant search results.

#### 4. Documentation & Examples
* **Updated README:** Reflected the cleaner meta-tool names and documented the custom renaming feature. Added a complete guide for setting up an AI SDK agent with Exa & grep clients.
* **Next.js Example App Integration:** Added `examples/next/app/agent/tool-router.ts` illustrating a complete agent workflow using `@ai-sdk/mcp` and `@mcp-ts/tool-router` under `ToolLoopAgent`.
* **Testing:** Updated `packages/tool-router/test/toolrouter.test.mjs` unit tests to reflect the new simplified meta-tool names and clean API interface.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] Code follows TypeScript strict mode guidelines
- [x] Tests added/updated
- [x] Documentation updated (if user-facing change)
- [x] Build succeeds (`npm run build`)
- [x] Type check passes (`npm run type-check`)
- [x] All tests pass (`npm test`)
- [x] Commit messages follow conventional format

## Related Issue

Closes #