### PR TITLE
feat(tool-router): support deferred tools for meta-tool-only exposure

### DIFF
--- a/packages/tool-router/README.md
+++ b/packages/tool-router/README.md
@@ -77,6 +77,31 @@ Use `pinnedTools` when a small number of tools should remain directly visible al
 
 The router owns canonical ids: server ids are normalized to lowercase slug-style ids before they appear in tool ids. For example, `u2tsgODpOrlF.toolname` is treated as `u2tsgodporlf.toolname`.
 
+### Deferred Tools
+
+Use `deferredTools` for tools that should stay out of the initial client-visible tool list while remaining indexed for `search_tools`, schema lookup, and `call_tool`.
+
+This is useful when you want an LLM to discover a tool only on demand instead of feeding it upfront. In practice:
+- `pinnedTools` are directly visible
+- `deferredTools` are meta-tool only
+- `excludeTools` are removed entirely
+
+Servers can also declare deferred-by-default tools with custom metadata:
+
+```typescript
+{
+  name: "workflow_list",
+  description: "List workflows",
+  _meta: {
+    toolRouter: {
+      deferred: true
+    }
+  }
+}
+```
+
+Router config still takes precedence, so you can pin a deferred-by-default tool when a specific client should see it directly.
+
 ### Excluded Tools
 
 Use `excludeTools` to omit tools from the router catalog entirely. Excluded tools are not indexed, not searchable, not pinnable, and not callable through router meta-tools.

--- a/packages/tool-router/src/router.ts
+++ b/packages/tool-router/src/router.ts
@@ -31,6 +31,7 @@ export class ToolRouter {
   private searchStrategy: import("./types.js").SearchStrategy;
   private policyEnforcer: PolicyEnforcer;
   private pinnedToolNames: Set<string>;
+  private deferredToolNames: Set<string>;
   private excludedToolPatterns: string[];
 
   constructor(private options: ToolRouterOptions) {
@@ -38,6 +39,7 @@ export class ToolRouter {
     this.searchStrategy = options.searchStrategy ?? new BM25SearchStrategy();
     this.policyEnforcer = new PolicyEnforcer(options.policy);
     this.pinnedToolNames = new Set((options.pinnedTools ?? []).map(normalizeToolReference));
+    this.deferredToolNames = new Set((options.deferredTools ?? []).map(normalizeToolReference));
     this.excludedToolPatterns = (options.excludeTools ?? []).map(normalizeToolReference);
     this.metaToolNames = {
       ...DEFAULT_TOOLROUTER_META_TOOL_NAMES,
@@ -310,10 +312,23 @@ export class ToolRouter {
       serverName: server.name ?? serverId,
       toolName: tool.name,
       description: tool.description ?? "",
+      deferred: this.isDeferredTool(serverId, tool),
       inputSchema: tool.inputSchema,
       outputSchema: tool.outputSchema,
       annotations: tool.annotations
     };
+  }
+
+  private isDeferredTool(serverId: string, tool: ToolDefinition): boolean {
+    const canonicalId = makeToolId(serverId, tool.name);
+    if (this.deferredToolNames.has(canonicalId) || this.deferredToolNames.has(tool.name)) {
+      return true;
+    }
+
+    const meta = (tool as ToolDefinition & {
+      _meta?: { toolRouter?: { deferred?: boolean } };
+    })._meta;
+    return meta?.toolRouter?.deferred === true;
   }
 }
 

--- a/packages/tool-router/src/types.ts
+++ b/packages/tool-router/src/types.ts
@@ -29,6 +29,7 @@ export interface IndexedTool {
   serverName: string;
   toolName: string;
   description: string;
+  deferred?: boolean;
   annotations?: ToolAnnotations;
   inputSchema?: unknown;
   outputSchema?: unknown;
@@ -81,6 +82,8 @@ export interface ToolRouterOptions {
   searchStrategy?: SearchStrategy;
   /** Canonical tool ids (serverId.toolName) or legacy tool names always visible alongside meta-tools. */
   pinnedTools?: string[];
+  /** Tools omitted from direct exposure but kept indexed for meta-tool search/schema/call flows. */
+  deferredTools?: string[];
   /** Canonical tool ids/patterns or legacy tool names/patterns to omit from the router catalog. */
   excludeTools?: string[];
   maxSearchResults?: number;

--- a/packages/tool-router/test/toolrouter.test.mjs
+++ b/packages/tool-router/test/toolrouter.test.mjs
@@ -543,6 +543,50 @@ test("pinned tools are excluded from search results", async () => {
   assert.equal(results.find((r) => r.toolName === "help"), undefined);
 });
 
+test("deferredTools stay searchable and callable but are omitted from visible tools", async () => {
+  const github = fakeServer("github", [
+    { name: "workflow_list", description: "List workflows" },
+    { name: "codemode_search_mcp_tools", description: "Search connected MCP tools" }
+  ]);
+
+  const router = await createToolRouter({
+    servers: [github.server],
+    pinnedTools: ["codemode_search_mcp_tools"],
+    deferredTools: ["workflow_list"]
+  });
+
+  const { pinned, metaTools } = router.getVisibleTools();
+  const results = await router.searchTools({ query: "workflow_list" });
+  const call = await router.callTool({ toolId: "github.workflow_list", args: {} });
+
+  assert.deepEqual(pinned.map((tool) => tool.toolName), ["codemode_search_mcp_tools"]);
+  assert.equal(metaTools.length, 4);
+  assert.equal(results.find((tool) => tool.toolId === "github.workflow_list")?.toolId, "github.workflow_list");
+  assert.deepEqual(call, { server: "github", name: "workflow_list", args: {} });
+});
+
+test("tool metadata can defer tools from visible tools without removing them from search", async () => {
+  const github = fakeServer("github", [
+    {
+      name: "workflow_run",
+      description: "Run a workflow",
+      _meta: { toolRouter: { deferred: true } }
+    },
+    { name: "codemode_run", description: "Run codemode" }
+  ]);
+
+  const router = await createToolRouter({
+    servers: [github.server],
+    pinnedTools: ["codemode_run"]
+  });
+
+  const { pinned } = router.getVisibleTools();
+  const results = await router.searchTools({ query: "workflow_run" });
+
+  assert.deepEqual(pinned.map((tool) => tool.toolName), ["codemode_run"]);
+  assert.equal(results.find((tool) => tool.toolId === "github.workflow_run")?.toolId, "github.workflow_run");
+});
+
 test("canonical pinned tool ids disambiguate duplicate tool names", async () => {
   const github = fakeServer("github", [
     { name: "status", description: "Get GitHub status" }

--- a/src/shared/tool-router.ts
+++ b/src/shared/tool-router.ts
@@ -106,6 +106,12 @@ export interface ToolRouterOptions {
   pinnedTools?: string[];
 
   /**
+   * Tool names to omit from direct exposure while keeping them indexed for
+   * search/schema lookup/calls through meta-tools.
+   */
+  deferredTools?: string[];
+
+  /**
    * Tool names or glob-style patterns to omit entirely from the router catalog.
    */
   excludeTools?: string[];
@@ -148,6 +154,7 @@ export class ToolRouter {
   private index: ToolIndex;
   private allTools: IndexedTool[] = [];
   private pinnedTools: IndexedTool[] = [];
+  private deferredTools: IndexedTool[] = [];
   private discoverableTools: IndexedTool[] = [];
   private groupsMap = new Map<string, ToolGroupInfo>();
   private strategy: ToolRouterStrategy;
@@ -156,6 +163,7 @@ export class ToolRouter {
   private activeGroups: Set<string>;
   private customGroups?: Record<string, string[]>;
   private pinnedToolNames: Set<string>;
+  private deferredToolNames: Set<string>;
   private excludeToolMatchers: RegExp[];
   private initialized = false;
 
@@ -169,6 +177,7 @@ export class ToolRouter {
     this.activeGroups = new Set(options.activeGroups ?? []);
     this.customGroups = options.groups;
     this.pinnedToolNames = new Set(options.pinnedTools ?? []);
+    this.deferredToolNames = new Set(options.deferredTools ?? []);
     this.excludeToolMatchers = (options.excludeTools ?? []).map((pattern) =>
       globToRegExp(pattern)
     );
@@ -203,9 +212,10 @@ export class ToolRouter {
 
       case 'all':
       default:
+        const directlyVisibleTools = this.getDirectlyVisibleTools();
         if (this.compactSchemas) {
           // Return tools with inputSchema stripped
-          return this.allTools.map((t) => {
+          return directlyVisibleTools.map((t) => {
             const compact = SchemaCompressor.toCompact(t);
             return {
               name: compact.name,
@@ -216,7 +226,7 @@ export class ToolRouter {
             };
           });
         }
-        return [...this.allTools];
+        return [...directlyVisibleTools];
     }
   }
 
@@ -374,6 +384,9 @@ export class ToolRouter {
     const fetchedTools = await this.fetchAllTools();
     this.allTools = fetchedTools.filter((tool) => !this.matchesExcludedTool(tool.name));
     this.pinnedTools = this.allTools.filter((tool) => this.matchesPinnedTool(tool.name));
+    this.deferredTools = this.allTools.filter(
+      (tool) => !this.matchesPinnedTool(tool.name) && this.matchesDeferredTool(tool)
+    );
     this.discoverableTools = this.allTools.filter((tool) => !this.matchesPinnedTool(tool.name));
     await this.index.buildIndex(this.discoverableTools);
     this.buildGroups();
@@ -469,7 +482,7 @@ export class ToolRouter {
       }
     }
 
-    const filtered = this.allTools.filter((t) => activeToolNames.has(t.name));
+    const filtered = this.getDirectlyVisibleTools().filter((t) => activeToolNames.has(t.name));
 
     if (this.compactSchemas) {
       return filtered.slice(0, this.maxTools).map((t) => {
@@ -502,8 +515,23 @@ export class ToolRouter {
     return this.pinnedToolNames.has(toolName);
   }
 
+  private matchesDeferredTool(tool: Tool): boolean {
+    if (this.deferredToolNames.has(tool.name)) {
+      return true;
+    }
+
+    const meta = (tool as Tool & {
+      _meta?: { toolRouter?: { deferred?: boolean } };
+    })._meta;
+    return meta?.toolRouter?.deferred === true;
+  }
+
   private matchesExcludedTool(toolName: string): boolean {
     return this.excludeToolMatchers.some((matcher) => matcher.test(toolName));
+  }
+
+  private getDirectlyVisibleTools(): IndexedTool[] {
+    return this.allTools.filter((tool) => !this.matchesDeferredTool(tool) || this.matchesPinnedTool(tool.name));
   }
 }
 

--- a/tests/meta-tools.test.ts
+++ b/tests/meta-tools.test.ts
@@ -516,4 +516,55 @@ test.describe('executeMetaTool', () => {
             expect(router.getToolSchema('web_search')).toBeUndefined();
         });
     });
+
+    test.describe('deferredTools', () => {
+        test('deferred tools are omitted from all-strategy direct exposure but remain searchable and callable', async () => {
+            const router = new ToolRouter([
+                createRouterClient('workflow-server', 'Workflow MCP', [
+                    { name: 'workflow_list', description: 'List workflows' },
+                    { name: 'codemode_search_mcp_tools', description: 'Search connected MCP tools' },
+                ]) as any,
+            ], {
+                strategy: 'all',
+                pinnedTools: ['codemode_search_mcp_tools'],
+                deferredTools: ['workflow_list'],
+            });
+
+            const filteredTools = await router.getFilteredTools();
+            expect(filteredTools.map((tool) => tool.name)).toContain('codemode_search_mcp_tools');
+            expect(filteredTools.map((tool) => tool.name)).not.toContain('workflow_list');
+
+            const searchResults = await router.searchTools('workflow', 10);
+            expect(searchResults.map((tool) => tool.name)).toContain('workflow_list');
+
+            const schema = router.getToolSchema('workflow_list');
+            expect(schema?.name).toBe('workflow_list');
+
+            const result = await router.callTool('workflow_list', {});
+            expect(result.content[0].text).toContain('Workflow MCP:workflow_list:{}');
+        });
+
+        test('tool metadata can mark deferred tools without excluding them from search', async () => {
+            const router = new ToolRouter([
+                createRouterClient('workflow-server', 'Workflow MCP', [
+                    {
+                        name: 'workflow_run',
+                        description: 'Run workflows',
+                        _meta: { toolRouter: { deferred: true } } as any,
+                    },
+                    { name: 'codemode_run', description: 'Run codemode' },
+                ]) as any,
+            ], {
+                strategy: 'all',
+                pinnedTools: ['codemode_run'],
+            });
+
+            const filteredTools = await router.getFilteredTools();
+            expect(filteredTools.map((tool) => tool.name)).toContain('codemode_run');
+            expect(filteredTools.map((tool) => tool.name)).not.toContain('workflow_run');
+
+            const searchResults = await router.searchTools('workflow', 10);
+            expect(searchResults.map((tool) => tool.name)).toContain('workflow_run');
+        });
+    });
 });


### PR DESCRIPTION
## What is the type of this PR?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Which area of the project does this PR affect?

- [ ] `server` (MCP client, handlers)
- [ ] `client` (React, Vue, SSE client)
- [ ] `adapters` (Vercel AI, LangChain, Mastra, AG-UI)
- [ ] `storage` (Redis, SQLite, File, Memory backends)
- [x] `docs` (Docusaurus documentation)
- [ ] `examples` (Example applications)
- [ ] `ci` (GitHub workflows)
- [x] Other (`tool-router` and shared meta-tool routing)

## Description of the change

This PR adds support for deferred tools in the tool router.

Deferred tools are kept in the router catalog for discovery and invocation, but are omitted from direct tool exposure. This allows an LLM to find them through meta-tools only when needed instead of receiving them up front.

Specifically, this change:
- adds `deferredTools` to router configuration
- supports deferred-by-default tools via `_meta.toolRouter.deferred`
- keeps deferred tools searchable and callable through search/schema/call flows
- excludes deferred tools from direct exposure unless they are explicitly pinned
- updates README documentation and tests for both the package router and shared router behavior

This branch also includes a merge from `main` so the PR stays current, but the feature work itself is the deferred-tools support above.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] Code follows TypeScript strict mode guidelines
- [x] Tests added/updated
- [x] Documentation updated (if user-facing change)
- [ ] Build succeeds (`npm run build`)
- [ ] Type check passes (`npm run type-check`)
- [ ] All tests pass (`npm test`)
- [x] Commit messages follow conventional format

## Related Issue

Closes #144 