### PR TITLE
[codex] Clarify tool router server context in codemode

### DIFF
--- a/packages/code-mode/README.md
+++ b/packages/code-mode/README.md
@@ -9,7 +9,7 @@ Sandboxed execution engine for Model Context Protocol (MCP) tools.
 ## Features
 
 - **V8 Sandboxing**: Uses `isolated-vm` to isolate memory and execution.
-- **Namespace Bridging**: Exposes connected tool sources as callable JavaScript functions (e.g., `await github.list_pull_requests(...)`).
+- **Namespace Bridging**: Exposes connected tool servers as callable JavaScript functions (e.g., `await github.list_pull_requests(...)`).
 - **TypeScript Interfaces**: Generates TypeScript type definitions for registered tools.
 - **Adapters**: Built-in support for Vercel AI SDK and native MCP server tools.
 - **Optional Native Dependency**: `isolated-vm` is optional at install time so the package builds in any environment.
@@ -37,9 +37,10 @@ npm install @mcp-ts/codemode
 ```typescript
 import { createCodeModeRuntime } from "@mcp-ts/codemode";
 
-// Define a tool source
-const githubSource = {
-  id: "github",
+// Define a tool server
+const githubServer = {
+  serverId: "github",
+  serverName: "GitHub",
   async listTools() {
     return {
       tools: [
@@ -68,7 +69,7 @@ const githubSource = {
 
 // Create the runtime
 const runtime = await createCodeModeRuntime({
-  sources: [githubSource],
+  servers: [githubServer],
   limits: {
     timeoutMs: 5000,
     memoryLimitMb: 64,
@@ -103,7 +104,8 @@ console.log(result.value);
 Scripts running inside the sandbox have access to:
 
 - `input`: The serializable input payload passed from the host.
-- `callTool(sourceId, toolName, args)`: Directly invoke a tool.
+- `callTool(serverId, toolName, args)`: Directly invoke a tool and receive the normalized result.
+- `callToolRaw(serverId, toolName, args)`: Directly invoke a tool and receive the raw MCP envelope when available.
 - `searchTools(query, limit?)`: Search descriptions of registered tools.
 - `console`: Standard console logging (`log`, `info`, `warn`, `error`) redirected to host-managed logs.
 - **Hierarchical Namespaces**: E.g. `github.list_pull_requests(args)` generated dynamically from your registered sources.
@@ -141,7 +143,7 @@ Expose the `codemode` engine as an MCP server:
 import { createCodeModeMcpServer } from "@mcp-ts/codemode/server";
 
 const server = await createCodeModeMcpServer({
-  sources: [githubSource],
+  servers: [githubServer],
   limits: {
     timeoutMs: 10000,
     memoryLimitMb: 128

--- a/packages/code-mode/src/adapters/ai-sdk.ts
+++ b/packages/code-mode/src/adapters/ai-sdk.ts
@@ -24,7 +24,7 @@ export async function createCodemodeAITools(runtime: CodeModeRuntime): Promise<A
   return {
     codemode_search_tools: {
       description:
-        "Search connected tool sources by natural language description. Returns tool names, source IDs, and TypeScript interfaces. Use this first to discover what tools are available.",
+        "Search connected tool servers by natural language description. Returns tool names, server IDs, and TypeScript interfaces. Use this first to discover what tools are available.",
       inputSchema: jsonSchema!({
         type: "object",
         properties: {
@@ -47,20 +47,20 @@ export async function createCodemodeAITools(runtime: CodeModeRuntime): Promise<A
       },
     },
 
-    codemode_list_sources: {
-      description: "List all connected tool sources and indexed tool counts.",
+    codemode_list_servers: {
+      description: "List all connected tool servers and indexed tool counts.",
       inputSchema: jsonSchema!({
         type: "object",
         properties: {},
       }),
       execute: async () => {
-        return runtime.listSources();
+        return runtime.listServers();
       },
     },
 
     codemode_tools_info: {
       description:
-        "Get detailed TypeScript interface definitions for specific tools. Pass tool names as 'sourceId.toolName' format. Use after search to understand exact input/output contracts.",
+        "Get detailed TypeScript interface definitions for specific tools. Pass tool names as 'serverId.toolName' format. Use after search to understand exact input/output contracts.",
       inputSchema: jsonSchema!({
         type: "object",
         properties: {
@@ -68,7 +68,7 @@ export async function createCodemodeAITools(runtime: CodeModeRuntime): Promise<A
             type: "array",
             items: { type: "string" },
             description:
-              "Tool names to get interfaces for, in 'sourceId.toolName' format (e.g. ['github.get_issue', 'exa.web_search']).",
+              "Tool names to get interfaces for, in 'serverId.toolName' format (e.g. ['github.get_issue', 'exa.web_search']).",
           },
         },
         required: ["tool_names"],
@@ -84,7 +84,7 @@ export async function createCodemodeAITools(runtime: CodeModeRuntime): Promise<A
         "Execute TypeScript code with direct access to all registered tools as hierarchical functions (e.g., manual.tool()). " +
         "Tool calls are synchronous from the sandbox — no 'await' needed (but 'await' also works). " +
         "Use 'return' to provide the final value. Console output is captured. " +
-        "Also available: callTool(sourceId, toolName, args), searchTools(query), __interfaces, __getToolInterface(name).",
+        "Also available: callTool(serverId, toolName, args), callToolRaw(serverId, toolName, args), searchTools(query), __interfaces, __getToolInterface(name).",
       inputSchema: jsonSchema!({
         type: "object",
         properties: {
@@ -92,7 +92,7 @@ export async function createCodemodeAITools(runtime: CodeModeRuntime): Promise<A
             type: "string",
             description:
               "TypeScript code to execute with access to all registered tools. Your code runs as an async function body. " +
-              "Call tools directly: source.tool(args). Use return for the final value.",
+              "Call tools directly: server.tool(args). Use return for the final value.",
           },
           input: {
             description: "Optional serializable input exposed as 'input' in the sandbox.",
@@ -116,7 +116,7 @@ export async function createCodemodeAITools(runtime: CodeModeRuntime): Promise<A
           value: result.value,
           logs: result.logs,
           toolCalls: result.toolCalls.map((c) => ({
-            sourceId: c.sourceId,
+            serverId: c.serverId,
             toolName: c.toolName,
             ok: c.ok,
             durationMs: c.durationMs,

--- a/packages/code-mode/src/index.ts
+++ b/packages/code-mode/src/index.ts
@@ -1,8 +1,8 @@
 // Runtime
 export { createCodeModeRuntime, IsolatedVmCodeModeRuntime } from "./runtime/runtime.js";
 
-// Sources
-export { mcpSource, mcpSources } from "./sources/index.js";
+// Servers
+export { mcpServer, mcpServers, normalizeMcpToolResult } from "./sources/index.js";
 export type { McpLikeClient, McpLikeProvider } from "./sources/index.js";
 
 // AI SDK adapter
@@ -22,5 +22,5 @@ export type {
   ToolAnnotations,
   ToolDefinition,
   ToolSearchResult,
-  ToolSource,
+  ToolServer,
 } from "./types.js";

--- a/packages/code-mode/src/runtime/runtime.ts
+++ b/packages/code-mode/src/runtime/runtime.ts
@@ -7,14 +7,14 @@ import type {
   CodeModeToolCall,
   IndexedTool,
   ToolSearchResult,
-  ToolSource,
+  ToolServer,
 } from "../types.js";
 import { classifyError } from "./errors.js";
 import { estimateJsonBytes, resolveLimits } from "./limits.js";
 import {
-  indexSources,
-  listSourcesFromIndex,
-  normalizeSourceId,
+  indexServers,
+  listServersFromIndex,
+  normalizeServerId,
   resolveTool,
   searchToolIndex,
 } from "./tool-index.js";
@@ -27,22 +27,22 @@ import {
 } from "./sandbox-bridge.js";
 
 export class IsolatedVmCodeModeRuntime implements CodeModeRuntime {
-  private sources: Map<string, ToolSource>;
+  private servers: Map<string, ToolServer>;
   private indexedTools: IndexedTool[] = [];
   private initialized = false;
   private maxSearchResults: number;
 
   constructor(private options: CodeModeRuntimeOptions) {
     this.maxSearchResults = options.maxSearchResults ?? 10;
-    this.sources = new Map<string, ToolSource>();
-    for (const source of options.sources) {
-      this.sources.set(normalizeSourceId(source.id), source);
+    this.servers = new Map<string, ToolServer>();
+    for (const server of options.servers) {
+      this.servers.set(normalizeServerId(server.serverId), server);
     }
   }
 
   private async ensureInitialized(): Promise<void> {
     if (!this.initialized) {
-      this.indexedTools = await indexSources(this.options.sources);
+      this.indexedTools = await indexServers(this.options.servers);
       this.initialized = true;
     }
   }
@@ -52,8 +52,8 @@ export class IsolatedVmCodeModeRuntime implements CodeModeRuntime {
     return searchToolIndex(this.indexedTools, query, limit ?? this.maxSearchResults);
   }
 
-  listSources(): Array<{ sourceId: string; sourceName: string; toolCount: number }> {
-    return listSourcesFromIndex(this.indexedTools);
+  listServers(): Array<{ serverId: string; serverName: string; toolCount: number }> {
+    return listServersFromIndex(this.indexedTools);
   }
 
   getToolInterfaces(toolNames: string[]): string {
@@ -61,12 +61,12 @@ export class IsolatedVmCodeModeRuntime implements CodeModeRuntime {
     const notFound: string[] = [];
 
     for (const name of toolNames) {
-      // name can be "sourceId.toolName" or just "toolName"
+      // name can be "serverId.toolName" or just "toolName"
       let tool: IndexedTool | undefined;
       if (name.includes(".")) {
-        const [sourceId, ...rest] = name.split(".");
+        const [serverId, ...rest] = name.split(".");
         const toolName = rest.join(".");
-        tool = resolveTool(this.indexedTools, toolName, sourceId);
+        tool = resolveTool(this.indexedTools, toolName, serverId);
       } else {
         tool = resolveTool(this.indexedTools, name);
       }
@@ -114,7 +114,7 @@ export class IsolatedVmCodeModeRuntime implements CodeModeRuntime {
     // -----------------------------------------------------------------------
 
     const hostCallTool = async (
-      sourceId: string,
+      serverId: string,
       toolName: string,
       argsJson: string,
     ): Promise<string> => {
@@ -133,7 +133,7 @@ export class IsolatedVmCodeModeRuntime implements CodeModeRuntime {
       const callStartedAt = Date.now();
       const call: CodeModeToolCall = {
         id: `call_${totalToolCalls}`,
-        sourceId,
+        serverId,
         toolName,
         args: JSON.parse(argsJson),
         startedAt: callStartedAt,
@@ -143,17 +143,17 @@ export class IsolatedVmCodeModeRuntime implements CodeModeRuntime {
       toolCalls.push(call);
 
       try {
-        const tool = resolveTool(this.indexedTools, toolName, sourceId);
+        const tool = resolveTool(this.indexedTools, toolName, serverId);
         if (!tool) {
-          throw new Error(`Tool "${toolName}" was not found on source "${sourceId}".`);
+          throw new Error(`Tool "${toolName}" was not found on server "${serverId}".`);
         }
 
-        const source = this.sources.get(tool.sourceId);
-        if (!source) {
-          throw new Error(`Source "${tool.sourceId}" is no longer registered.`);
+        const server = this.servers.get(tool.serverId);
+        if (!server) {
+          throw new Error(`Server "${tool.serverId}" is no longer registered.`);
         }
 
-        const result = await source.callTool(toolName, JSON.parse(argsJson));
+        const result = await server.callTool(toolName, JSON.parse(argsJson));
         call.ok = true;
         return JSON.stringify({ success: true, result });
       } catch (error) {
@@ -171,12 +171,38 @@ export class IsolatedVmCodeModeRuntime implements CodeModeRuntime {
       return JSON.stringify(results);
     };
 
-    const hostGetToolSchema = async (sourceId: string, toolName: string): Promise<string> => {
-      const tool = resolveTool(this.indexedTools, toolName, sourceId);
+    const hostGetToolSchema = async (serverId: string, toolName: string): Promise<string> => {
+      const tool = resolveTool(this.indexedTools, toolName, serverId);
       if (!tool) {
-        return JSON.stringify({ error: `Tool "${toolName}" not found on source "${sourceId}".` });
+        return JSON.stringify({ error: `Tool "${toolName}" not found on server "${serverId}".` });
       }
       return JSON.stringify(tool);
+    };
+
+    const hostCallToolRaw = async (
+      serverId: string,
+      toolName: string,
+      argsJson: string,
+    ): Promise<string> => {
+      const tool = resolveTool(this.indexedTools, toolName, serverId);
+      if (!tool) {
+        return JSON.stringify({ success: false, error: `Tool "${toolName}" was not found on server "${serverId}".` });
+      }
+
+      const server = this.servers.get(tool.serverId);
+      if (!server) {
+        return JSON.stringify({ success: false, error: `Server "${tool.serverId}" is no longer registered.` });
+      }
+
+      try {
+        const result = server.callToolRaw
+          ? await server.callToolRaw(toolName, JSON.parse(argsJson))
+          : await server.callTool(toolName, JSON.parse(argsJson));
+        return JSON.stringify({ success: true, result });
+      } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        return JSON.stringify({ success: false, error: errorMsg });
+      }
     };
 
     const hostLog = (level: CodeModeLogEntry["level"], args: unknown[]) => {
@@ -216,6 +242,10 @@ export class IsolatedVmCodeModeRuntime implements CodeModeRuntime {
       const searchRef = new ivm.Reference(hostSearchTools);
       await jail.set("__searchToolsRef", searchRef);
 
+      // Raw tool call reference
+      const rawToolCallerRef = new ivm.Reference(hostCallToolRaw);
+      await jail.set("__callToolRawRef", rawToolCallerRef);
+
       // Get tool schema reference
       const schemaRef = new ivm.Reference(hostGetToolSchema);
       await jail.set("__getToolSchemaRef", schemaRef);
@@ -230,8 +260,8 @@ export class IsolatedVmCodeModeRuntime implements CodeModeRuntime {
       const bootstrapScript = await isolate.compileScript(bootstrapCode);
       await bootstrapScript.run(context);
 
-      // Namespace bridging: source.tool(args) functions
-      const namespaceBridgeCode = generateNamespaceBridgeCode(this.indexedTools, this.sources);
+      // Namespace bridging: server.tool(args) functions
+      const namespaceBridgeCode = generateNamespaceBridgeCode(this.indexedTools, this.servers);
       if (namespaceBridgeCode.trim()) {
         const namespaceScript = await isolate.compileScript(namespaceBridgeCode);
         await namespaceScript.run(context);

--- a/packages/code-mode/src/runtime/sandbox-bridge.ts
+++ b/packages/code-mode/src/runtime/sandbox-bridge.ts
@@ -1,5 +1,4 @@
-import type { IndexedTool, ToolSource } from "../types.js";
-import { normalizeSourceId } from "./tool-index.js";
+import type { IndexedTool, ToolServer } from "../types.js";
 
 // ---------------------------------------------------------------------------
 // Identifier helpers
@@ -14,13 +13,6 @@ export function sanitizeIdentifier(name: string): string {
     .replace(/^[0-9]/, "_$&");
 }
 
-// ---------------------------------------------------------------------------
-// TypeScript interface generation (ported from UTCP code_mode_utcp_client.ts)
-// ---------------------------------------------------------------------------
-
-/**
- * Converts a JSON Schema to a TypeScript type string.
- */
 function jsonSchemaToTsType(schema: Record<string, unknown> | undefined): string {
   if (!schema || typeof schema !== "object") return "any";
 
@@ -65,7 +57,8 @@ function jsonSchemaToTsType(schema: Record<string, unknown> | undefined): string
           .map((t) => {
             switch (t) {
               case "string": return "string";
-              case "number": case "integer": return "number";
+              case "number":
+              case "integer": return "number";
               case "boolean": return "boolean";
               case "null": return "null";
               case "object": return "object";
@@ -79,9 +72,6 @@ function jsonSchemaToTsType(schema: Record<string, unknown> | undefined): string
   }
 }
 
-/**
- * Generates the inner content of a TypeScript interface from a JSON Schema.
- */
 function jsonSchemaToObjectContent(schema: Record<string, unknown> | undefined): string {
   if (!schema || typeof schema !== "object" || schema.type !== "object") {
     return "    [key: string]: any;";
@@ -112,17 +102,17 @@ function escapeComment(text: string): string {
 
 /**
  * Generates a TypeScript interface definition for a single tool,
- * grouped under its source namespace.
+ * grouped under its server namespace.
  */
 export function toolToTypeScriptInterface(tool: IndexedTool): string {
-  const sanitizedSource = sanitizeIdentifier(tool.sourceId);
+  const sanitizedServer = sanitizeIdentifier(tool.serverId);
   const sanitizedTool = sanitizeIdentifier(tool.toolName);
-  const accessPattern = `${sanitizedSource}.${sanitizedTool}`;
+  const accessPattern = `${sanitizedServer}.${sanitizedTool}`;
 
   const inputContent = jsonSchemaToObjectContent(tool.inputSchema);
 
   return `
-namespace ${sanitizedSource} {
+namespace ${sanitizedServer} {
   interface ${sanitizedTool}Input {
 ${inputContent}
   }
@@ -130,67 +120,51 @@ ${inputContent}
 
 /**
  * ${escapeComment(tool.description || "No description")}
- * Source: ${tool.sourceId}
+ * Server: ${tool.serverId}
  * Access as: ${accessPattern}(args)
  */`;
 }
 
-/**
- * Generates all TypeScript interface definitions for a set of indexed tools.
- */
 export function generateAllInterfaces(tools: IndexedTool[]): string {
   const interfaces = tools.map((tool) => toolToTypeScriptInterface(tool));
   return `// Auto-generated TypeScript interfaces for available tools\n${interfaces.join("\n\n")}`;
 }
 
 /**
- * Generates a lookup map of tool name → TypeScript interface string.
- * Keys use the format "sourceId.toolName".
+ * Generates a lookup map of tool name -> TypeScript interface string.
+ * Keys use the format "serverId.toolName".
  */
 export function generateInterfaceMap(tools: IndexedTool[]): Record<string, string> {
   const map: Record<string, string> = {};
   for (const tool of tools) {
-    const key = `${tool.sourceId}.${tool.toolName}`;
+    const key = `${tool.serverId}.${tool.toolName}`;
     map[key] = toolToTypeScriptInterface(tool);
   }
   return map;
 }
 
-// ---------------------------------------------------------------------------
-// Namespace function code generation
-// ---------------------------------------------------------------------------
-
 /**
  * Generates JavaScript code to set up namespace functions in the sandbox.
- * Each source becomes a namespace object (e.g. `global.github = {}`) and
- * each tool becomes a synchronous function on that namespace
- * (e.g. `global.github.get_issue = function(args) { ... }`).
- *
- * Uses `applySyncPromise` so tool calls are synchronous from the sandbox's
- * perspective — no `await` needed (but `await` also works).
  */
 export function generateNamespaceBridgeCode(
   tools: IndexedTool[],
-  sources: Map<string, ToolSource>,
+  _servers: Map<string, ToolServer>,
 ): string {
   const parts: string[] = [];
   const namespaces = new Set<string>();
 
   for (const tool of tools) {
-    const sanitizedSource = sanitizeIdentifier(tool.sourceId);
+    const sanitizedServer = sanitizeIdentifier(tool.serverId);
     const sanitizedTool = sanitizeIdentifier(tool.toolName);
 
-    if (!namespaces.has(sanitizedSource)) {
-      namespaces.add(sanitizedSource);
-      parts.push(`globalThis.${sanitizedSource} = globalThis.${sanitizedSource} || {};`);
+    if (!namespaces.has(sanitizedServer)) {
+      namespaces.add(sanitizedServer);
+      parts.push(`globalThis.${sanitizedServer} = globalThis.${sanitizedServer} || {};`);
     }
 
-    // applySyncPromise blocks the isolate until the host-side async tool call completes.
-    // This makes `github.get_issue({...})` work without `await`.
-    // `await github.get_issue({...})` also works because awaiting a non-Promise is a no-op.
     parts.push(`
-      globalThis.${sanitizedSource}.${sanitizedTool} = function(args) {
-        var resultJson = __callToolRef.applySyncPromise(undefined, [${JSON.stringify(tool.sourceId)}, ${JSON.stringify(tool.toolName)}, JSON.stringify(args || {})]);
+      globalThis.${sanitizedServer}.${sanitizedTool} = function(args) {
+        var resultJson = __callToolRef.applySyncPromise(undefined, [${JSON.stringify(tool.serverId)}, ${JSON.stringify(tool.toolName)}, JSON.stringify(args || {})]);
         var parsed = JSON.parse(resultJson);
         if (!parsed.success) throw new Error(parsed.error);
         return parsed.result;
@@ -201,10 +175,6 @@ export function generateNamespaceBridgeCode(
   return parts.join("\n");
 }
 
-/**
- * Generates JavaScript code for console, searchTools, callTool, and
- * interface introspection helpers in the sandbox.
- */
 export function generateBootstrapCode(
   interfacesString: string,
   interfaceMapJson: string,
@@ -212,7 +182,6 @@ export function generateBootstrapCode(
   return `
     "use strict";
 
-    // Console bridge
     const __stringify = (a) => typeof a === "object" && a !== null ? JSON.stringify(a, null, 2) : String(a);
     globalThis.console = {
       log: (...args) => __logRef.applySync(undefined, args.map(__stringify)),
@@ -221,34 +190,36 @@ export function generateBootstrapCode(
       info: (...args) => __infoRef.applySync(undefined, args.map(__stringify)),
     };
 
-    // Low-level callTool escape hatch (requires await)
-    globalThis.callTool = function(sourceId, toolName, args) {
-      var resultJson = __callToolRef.applySyncPromise(undefined, [sourceId, toolName, JSON.stringify(args || {})]);
+    globalThis.callTool = function(serverId, toolName, args) {
+      var resultJson = __callToolRef.applySyncPromise(undefined, [serverId, toolName, JSON.stringify(args || {})]);
       var parsed = JSON.parse(resultJson);
       if (!parsed.success) throw new Error(parsed.error);
       return parsed.result;
     };
 
-    // searchTools (requires await)
+    globalThis.callToolRaw = function(serverId, toolName, args) {
+      var resultJson = __callToolRawRef.applySyncPromise(undefined, [serverId, toolName, JSON.stringify(args || {})]);
+      var parsed = JSON.parse(resultJson);
+      if (!parsed.success) throw new Error(parsed.error);
+      return parsed.result;
+    };
+
     globalThis.searchTools = function(query, limit) {
       var resultJson = __searchToolsRef.applySyncPromise(undefined, [query || "", limit || 10]);
       return JSON.parse(resultJson);
     };
 
-    // getToolSchema
-    globalThis.getToolSchema = function(sourceId, toolName) {
-      var resultJson = __getToolSchemaRef.applySyncPromise(undefined, [sourceId, toolName]);
+    globalThis.getToolSchema = function(serverId, toolName) {
+      var resultJson = __getToolSchemaRef.applySyncPromise(undefined, [serverId, toolName]);
       return JSON.parse(resultJson);
     };
 
-    // Interface introspection
     globalThis.__interfaces = ${JSON.stringify(interfacesString)};
     const __interfaceMap = ${interfaceMapJson};
     globalThis.__getToolInterface = function(toolName) {
       return __interfaceMap[toolName] || null;
     };
 
-    // Input passthrough
     globalThis.input = typeof __input !== "undefined" ? __input : undefined;
   `;
 }

--- a/packages/code-mode/src/runtime/tool-index.ts
+++ b/packages/code-mode/src/runtime/tool-index.ts
@@ -1,35 +1,35 @@
-import type { IndexedTool, ToolSearchResult, ToolSource } from "../types.js";
+import type { IndexedTool, ToolSearchResult, ToolServer } from "../types.js";
 
 /**
- * Normalizes a source ID to a safe, lowercase identifier.
+ * Normalizes a server ID to a safe, lowercase identifier.
  */
-export function normalizeSourceId(value: string): string {
+export function normalizeServerId(value: string): string {
   return value
     .toLowerCase()
     .replace(/[^a-z0-9_-]+/g, "_")
-    .replace(/^_+|_+$/g, "") || "source";
+    .replace(/^_+|_+$/g, "") || "server";
 }
 
 /**
- * Indexes all tools from the given sources.
- * Resolves tools from each source and flattens into a single list.
+ * Indexes all tools from the given servers.
+ * Resolves tools from each server and flattens into a single list.
  */
-export async function indexSources(sources: ToolSource[]): Promise<IndexedTool[]> {
+export async function indexServers(servers: ToolServer[]): Promise<IndexedTool[]> {
   const indexed: IndexedTool[] = [];
-  const seenSourceIds = new Set<string>();
+  const seenServerIds = new Set<string>();
 
-  for (const source of sources) {
-    const sourceId = normalizeSourceId(source.id);
-    if (seenSourceIds.has(sourceId)) {
-      throw new Error(`Duplicate tool source id "${sourceId}".`);
+  for (const server of servers) {
+    const serverId = normalizeServerId(server.serverId);
+    if (seenServerIds.has(serverId)) {
+      throw new Error(`Duplicate tool server id "${serverId}".`);
     }
-    seenSourceIds.add(sourceId);
+    seenServerIds.add(serverId);
 
-    const listed = await source.listTools();
+    const listed = await server.listTools();
     for (const tool of listed.tools) {
       indexed.push({
-        sourceId,
-        sourceName: source.name ?? sourceId,
+        serverId,
+        serverName: server.serverName ?? serverId,
         toolName: tool.name,
         description: tool.description ?? "",
         inputSchema: tool.inputSchema,
@@ -41,9 +41,6 @@ export async function indexSources(sources: ToolSource[]): Promise<IndexedTool[]
   return indexed;
 }
 
-/**
- * Scores a tool against a search query using word-match heuristics.
- */
 function scoreTool(tool: IndexedTool, query: string): number {
   const terms = query
     .toLowerCase()
@@ -54,32 +51,29 @@ function scoreTool(tool: IndexedTool, query: string): number {
   if (terms.length === 0) return 1;
 
   const name = tool.toolName.toLowerCase();
-  const source = `${tool.sourceId} ${tool.sourceName}`.toLowerCase();
+  const server = `${tool.serverId} ${tool.serverName}`.toLowerCase();
   const description = tool.description.toLowerCase();
   let score = 0;
 
   for (const term of terms) {
     if (name === term) score += 10;
     if (name.includes(term)) score += 6;
-    if (source.includes(term)) score += 4;
+    if (server.includes(term)) score += 4;
     if (description.includes(term)) score += 2;
   }
 
   return score;
 }
 
-/**
- * Searches the index by query with optional source filters.
- */
 export function searchToolIndex(
   index: IndexedTool[],
   query?: string,
   limit = 10,
-  sourceId?: string,
+  serverId?: string,
 ): ToolSearchResult[] {
   return index
     .filter((tool) => {
-      if (sourceId && tool.sourceId !== sourceId) return false;
+      if (serverId && tool.serverId !== serverId) return false;
       return true;
     })
     .map((tool) => ({ tool, score: scoreTool(tool, query ?? "") }))
@@ -87,8 +81,8 @@ export function searchToolIndex(
     .sort((a, b) => b.score - a.score || a.tool.toolName.localeCompare(b.tool.toolName))
     .slice(0, Math.min(limit, 100))
     .map(({ tool, score }) => ({
-      sourceId: tool.sourceId,
-      sourceName: tool.sourceName,
+      serverId: tool.serverId,
+      serverName: tool.serverName,
       toolName: tool.toolName,
       description: tool.description,
       annotations: tool.annotations,
@@ -97,23 +91,23 @@ export function searchToolIndex(
 }
 
 /**
- * Resolves a specific tool from the index by sourceId + toolName.
+ * Resolves a specific tool from the index by serverId + toolName.
  */
 export function resolveTool(
   index: IndexedTool[],
   toolName: string,
-  sourceId?: string,
+  serverId?: string,
 ): IndexedTool | undefined {
   const matches = index.filter((tool) => {
     if (tool.toolName !== toolName) return false;
-    if (sourceId && tool.sourceId !== normalizeSourceId(sourceId)) return false;
+    if (serverId && tool.serverId !== normalizeServerId(serverId)) return false;
     return true;
   });
 
   if (matches.length > 1) {
-    const sources = matches.map((t) => t.sourceId).join(", ");
+    const servers = matches.map((t) => t.serverId).join(", ");
     throw new Error(
-      `Tool "${toolName}" exists on multiple sources: ${sources}. Provide sourceId.`
+      `Tool "${toolName}" exists on multiple servers: ${servers}. Provide serverId.`
     );
   }
 
@@ -121,19 +115,19 @@ export function resolveTool(
 }
 
 /**
- * Lists connected sources with tool counts.
+ * Lists connected servers with tool counts.
  */
-export function listSourcesFromIndex(
+export function listServersFromIndex(
   index: IndexedTool[],
-): Array<{ sourceId: string; sourceName: string; toolCount: number }> {
-  const counts = new Map<string, { sourceId: string; sourceName: string; toolCount: number }>();
+): Array<{ serverId: string; serverName: string; toolCount: number }> {
+  const counts = new Map<string, { serverId: string; serverName: string; toolCount: number }>();
 
   for (const tool of index) {
     const current =
-      counts.get(tool.sourceId) ??
-      { sourceId: tool.sourceId, sourceName: tool.sourceName, toolCount: 0 };
+      counts.get(tool.serverId) ??
+      { serverId: tool.serverId, serverName: tool.serverName, toolCount: 0 };
     current.toolCount += 1;
-    counts.set(tool.sourceId, current);
+    counts.set(tool.serverId, current);
   }
 
   return [...counts.values()];

--- a/packages/code-mode/src/server/index.ts
+++ b/packages/code-mode/src/server/index.ts
@@ -19,7 +19,7 @@ export async function createCodeModeMcpServer(options: CodeModeMcpServerOptions)
     "codemode_search_tools",
     {
       description:
-        "Search connected tool sources by natural language description. Returns tool names, source IDs, and TypeScript interfaces.",
+        "Search connected tool servers by natural language description. Returns tool names, server IDs, and TypeScript interfaces.",
       inputSchema: {
         query: z.string().describe("Natural-language description of the task or tools you need."),
         limit: z.number().optional().describe("Maximum number of results (default: 10).")
@@ -34,13 +34,13 @@ export async function createCodeModeMcpServer(options: CodeModeMcpServerOptions)
   );
 
   server.registerTool(
-    "codemode_list_sources",
+    "codemode_list_servers",
     {
-      description: "List all connected tool sources and indexed tool counts.",
+      description: "List all connected tool servers and indexed tool counts.",
       inputSchema: {}
     },
     async () => {
-      const result = runtime.listSources();
+      const result = runtime.listServers();
       return {
         content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }]
       };
@@ -53,7 +53,7 @@ export async function createCodeModeMcpServer(options: CodeModeMcpServerOptions)
       description:
         "Get detailed TypeScript interface definitions for specific tools. Use after search to understand exact input contracts.",
       inputSchema: {
-        tool_names: z.array(z.string()).describe("Tool names in 'sourceId.toolName' format.")
+        tool_names: z.array(z.string()).describe("Tool names in 'serverId.toolName' format.")
       }
     },
     async ({ tool_names }) => {

--- a/packages/code-mode/src/sources/index.ts
+++ b/packages/code-mode/src/sources/index.ts
@@ -1,2 +1,2 @@
-export { mcpSource, mcpSources } from "./mcp.js";
+export { mcpServer, mcpServers, normalizeMcpToolResult } from "./mcp.js";
 export type { McpLikeClient, McpLikeProvider } from "./mcp.js";

--- a/packages/code-mode/src/sources/mcp.ts
+++ b/packages/code-mode/src/sources/mcp.ts
@@ -1,4 +1,15 @@
-import type { ToolSource, ToolDefinition } from "../types.js";
+import type { ToolServer, ToolDefinition } from "../types.js";
+
+type McpTextContent = {
+  type?: unknown;
+  text?: unknown;
+};
+
+type McpCallToolEnvelope = {
+  structuredContent?: unknown;
+  content?: unknown;
+  isError?: unknown;
+};
 
 export interface McpLikeClient {
   listTools(): Promise<{ tools: ToolDefinition[] }>;
@@ -11,25 +22,66 @@ export interface McpLikeProvider {
   getClients(): McpLikeClient[];
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function tryParseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+export function normalizeMcpToolResult(result: unknown): unknown {
+  if (!isRecord(result)) {
+    return result;
+  }
+
+  const envelope = result as McpCallToolEnvelope;
+  if (envelope.structuredContent !== undefined) {
+    return envelope.structuredContent;
+  }
+
+  const content = Array.isArray(envelope.content) ? envelope.content : null;
+  if (content?.length === 1) {
+    const item = content[0] as McpTextContent;
+    if (item?.type === "text" && typeof item.text === "string") {
+      return tryParseJson(item.text);
+    }
+  }
+
+  if (content) {
+    return {
+      content,
+      isError: Boolean(envelope.isError),
+    };
+  }
+
+  return result;
+}
+
 /**
- * Wraps a single MCP-like client as a ToolSource.
+ * Wraps a single MCP-like client as a ToolServer.
  */
-export function mcpSource(id: string, client: McpLikeClient, name?: string): ToolSource {
+export function mcpServer(serverId: string, client: McpLikeClient, serverName?: string): ToolServer {
   return {
-    id,
-    name: name ?? client.getServerName?.() ?? client.getServerId?.() ?? id,
+    serverId,
+    serverName: serverName ?? client.getServerName?.() ?? client.getServerId?.() ?? serverId,
     listTools: () => client.listTools(),
-    callTool: (toolName, args) => client.callTool(toolName, args),
+    callTool: async (toolName, args) => normalizeMcpToolResult(await client.callTool(toolName, args)),
+    callToolRaw: (toolName, args) => client.callTool(toolName, args),
   };
 }
 
 /**
- * Creates ToolSource[] from a provider that manages multiple MCP clients
+ * Creates ToolServer[] from a provider that manages multiple MCP clients
  * (e.g. MultiSessionClient).
  */
-export function mcpSources(provider: McpLikeProvider): ToolSource[] {
+export function mcpServers(provider: McpLikeProvider): ToolServer[] {
   return provider.getClients().map((client, index) =>
-    mcpSource(
+    mcpServer(
       client.getServerId?.() ?? `mcp_${index + 1}`,
       client,
       client.getServerName?.()

--- a/packages/code-mode/src/types.ts
+++ b/packages/code-mode/src/types.ts
@@ -17,16 +17,17 @@ export interface ToolDefinition {
   [key: string]: unknown;
 }
 
-export interface ToolSource {
-  id: string;
-  name?: string;
+export interface ToolServer {
+  serverId: string;
+  serverName?: string;
   listTools(): Promise<{ tools: ToolDefinition[] }>;
   callTool(name: string, args: Record<string, unknown>): Promise<unknown>;
+  callToolRaw?(name: string, args: Record<string, unknown>): Promise<unknown>;
 }
 
 export interface IndexedTool {
-  sourceId: string;
-  sourceName: string;
+  serverId: string;
+  serverName: string;
   toolName: string;
   description: string;
   inputSchema?: Record<string, unknown>;
@@ -34,8 +35,8 @@ export interface IndexedTool {
 }
 
 export interface ToolSearchResult {
-  sourceId: string;
-  sourceName: string;
+  serverId: string;
+  serverName: string;
   toolName: string;
   description: string;
   annotations?: ToolAnnotations;
@@ -56,7 +57,7 @@ export interface CodeModeLimits {
 }
 
 export interface CodeModeRuntimeOptions {
-  sources: ToolSource[];
+  servers: ToolServer[];
   limits?: CodeModeLimits;
   maxSearchResults?: number;
 }
@@ -72,7 +73,7 @@ export interface CodeModeLogEntry {
 
 export interface CodeModeToolCall {
   id: string;
-  sourceId: string;
+  serverId: string;
   toolName: string;
   args: unknown;
   startedAt: number;
@@ -102,6 +103,6 @@ export interface CodeModeResult {
 export interface CodeModeRuntime {
   run(code: string, input?: unknown, options?: CodeModeRunOptions): Promise<CodeModeResult>;
   searchTools(query: string, limit?: number): Promise<ToolSearchResult[]>;
-  listSources(): Array<{ sourceId: string; sourceName: string; toolCount: number }>;
+  listServers(): Array<{ serverId: string; serverName: string; toolCount: number }>;
   getToolInterfaces(toolNames: string[]): string;
 }

--- a/packages/code-mode/test/codemode.test.mjs
+++ b/packages/code-mode/test/codemode.test.mjs
@@ -7,7 +7,7 @@ const hasIsolatedVm = await import("isolated-vm").then(
 );
 
 /**
- * Creates a fake ToolSource for testing.
+ * Creates a fake ToolServer for testing.
  */
 function fakeSource(id = "github", tools = undefined) {
   const calls = [];
@@ -81,13 +81,82 @@ function fakeExaSource() {
   };
 }
 
+function fakeMcpEnvelopeSource(id = "docs") {
+  const calls = [];
+  return {
+    calls,
+    source: {
+      id,
+      name: id,
+      listTools: async () => ({
+        tools: [
+          {
+            name: "structured_search",
+            description: "Returns structuredContent",
+            inputSchema: { type: "object", properties: { query: { type: "string" } } }
+          },
+          {
+            name: "json_text_search",
+            description: "Returns JSON text content",
+            inputSchema: { type: "object", properties: { query: { type: "string" } } }
+          },
+          {
+            name: "plain_text_search",
+            description: "Returns plain text content",
+            inputSchema: { type: "object", properties: { query: { type: "string" } } }
+          },
+          {
+            name: "multipart_search",
+            description: "Returns multipart content",
+            inputSchema: { type: "object", properties: { query: { type: "string" } } }
+          }
+        ]
+      }),
+      callTool: async (name, args) => {
+        calls.push({ name, args });
+        if (name === "structured_search") {
+          return {
+            structuredContent: {
+              items: [{ title: "Structured result" }]
+            },
+            content: [{ type: "text", text: "{\"ignored\":true}" }],
+            isError: false
+          };
+        }
+        if (name === "json_text_search") {
+          return {
+            content: [{ type: "text", text: JSON.stringify({ items: [{ title: "JSON text result" }] }) }],
+            isError: false
+          };
+        }
+        if (name === "plain_text_search") {
+          return {
+            content: [{ type: "text", text: "plain text result" }],
+            isError: false
+          };
+        }
+        if (name === "multipart_search") {
+          return {
+            content: [
+              { type: "text", text: "first" },
+              { type: "text", text: "second" }
+            ],
+            isError: true
+          };
+        }
+        throw new Error(`Unknown tool ${name}`);
+      }
+    }
+  };
+}
+
 // -----------------------------------------------------------------------
-// Test 1: Namespace bridging — source.tool(args) works WITHOUT await
+// Test 1: Namespace bridging — server.tool(args) works WITHOUT await
 // -----------------------------------------------------------------------
 test("namespace bridging: github.get_issue(args) works without await", { skip: !hasIsolatedVm }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { calls, source } = fakeSource();
-  const runtime = await createCodeModeRuntime({ sources: [source] });
+  const runtime = await createCodeModeRuntime({ servers: [source] });
 
   const result = await runtime.run(`
     const issue = github.get_issue({ issue_number: 42 });
@@ -107,7 +176,7 @@ test("namespace bridging: github.get_issue(args) works without await", { skip: !
 test("namespace bridging: await github.get_issue(args) also works", { skip: !hasIsolatedVm }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { calls, source } = fakeSource();
-  const runtime = await createCodeModeRuntime({ sources: [source] });
+  const runtime = await createCodeModeRuntime({ servers: [source] });
 
   const result = await runtime.run(`
     const issue = await github.get_issue({ issue_number: 99 });
@@ -120,12 +189,12 @@ test("namespace bridging: await github.get_issue(args) also works", { skip: !has
 });
 
 // -----------------------------------------------------------------------
-// Test 3: Legacy callTool(sourceId, toolName, args) escape hatch
+// Test 3: callTool(serverId, toolName, args) escape hatch
 // -----------------------------------------------------------------------
 test("callTool() escape hatch works", { skip: !hasIsolatedVm }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { calls, source } = fakeSource();
-  const runtime = await createCodeModeRuntime({ sources: [source] });
+  const runtime = await createCodeModeRuntime({ servers: [source] });
 
   const result = await runtime.run(`
     const issue = callTool("github", "get_issue", { issue_number: 7 });
@@ -143,17 +212,17 @@ test("callTool() escape hatch works", { skip: !hasIsolatedVm }, async () => {
 test("searchTools() inside sandbox returns results", { skip: !hasIsolatedVm }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { source } = fakeSource();
-  const runtime = await createCodeModeRuntime({ sources: [source] });
+  const runtime = await createCodeModeRuntime({ servers: [source] });
 
   const result = await runtime.run(`
     const tools = searchTools("issue");
-    return tools.map(t => ({ sourceId: t.sourceId, toolName: t.toolName }));
+    return tools.map(t => ({ serverId: t.serverId, toolName: t.toolName }));
   `);
 
   assert.equal(result.error, undefined);
   assert.ok(Array.isArray(result.value));
   assert.ok(result.value.length > 0);
-  assert.equal(result.value[0].sourceId, "github");
+  assert.equal(result.value[0].serverId, "github");
 });
 
 // -----------------------------------------------------------------------
@@ -162,7 +231,7 @@ test("searchTools() inside sandbox returns results", { skip: !hasIsolatedVm }, a
 test("__interfaces contains TypeScript definitions", { skip: !hasIsolatedVm }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { source } = fakeSource();
-  const runtime = await createCodeModeRuntime({ sources: [source] });
+  const runtime = await createCodeModeRuntime({ servers: [source] });
 
   const result = await runtime.run(`
     return __interfaces;
@@ -181,7 +250,7 @@ test("__interfaces contains TypeScript definitions", { skip: !hasIsolatedVm }, a
 test("__getToolInterface() returns specific tool interface", { skip: !hasIsolatedVm }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { source } = fakeSource();
-  const runtime = await createCodeModeRuntime({ sources: [source] });
+  const runtime = await createCodeModeRuntime({ servers: [source] });
 
   const result = await runtime.run(`
     const iface = __getToolInterface("github.get_issue");
@@ -200,7 +269,7 @@ test("multi-source: github.get_issue() vs exa.web_search()", { skip: !hasIsolate
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const github = fakeSource();
   const exa = fakeExaSource();
-  const runtime = await createCodeModeRuntime({ sources: [github.source, exa.source] });
+  const runtime = await createCodeModeRuntime({ servers: [github.source, exa.source] });
 
   const result = await runtime.run(`
     const issue = github.get_issue({ issue_number: 1 });
@@ -221,7 +290,7 @@ test("multi-source: github.get_issue() vs exa.web_search()", { skip: !hasIsolate
 test("console output is captured", { skip: !hasIsolatedVm }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { source } = fakeSource();
-  const runtime = await createCodeModeRuntime({ sources: [source] });
+  const runtime = await createCodeModeRuntime({ servers: [source] });
 
   const result = await runtime.run(`
     console.log("hello");
@@ -244,7 +313,7 @@ test("console output is captured", { skip: !hasIsolatedVm }, async () => {
 test("tool calls are tracked in result", { skip: !hasIsolatedVm }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { source } = fakeSource();
-  const runtime = await createCodeModeRuntime({ sources: [source] });
+  const runtime = await createCodeModeRuntime({ servers: [source] });
 
   const result = await runtime.run(`
     github.get_issue({ issue_number: 1 });
@@ -266,7 +335,7 @@ test("tool calls are tracked in result", { skip: !hasIsolatedVm }, async () => {
 test("input is accessible in sandbox", { skip: !hasIsolatedVm }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { source } = fakeSource();
-  const runtime = await createCodeModeRuntime({ sources: [source] });
+  const runtime = await createCodeModeRuntime({ servers: [source] });
 
   const result = await runtime.run(`
     return { doubled: input.value * 2 };
@@ -277,20 +346,55 @@ test("input is accessible in sandbox", { skip: !hasIsolatedVm }, async () => {
 });
 
 // -----------------------------------------------------------------------
-// Test 11: Host-side searchTools and listSources
+// Test 11: Host-side searchTools and listServers
 // -----------------------------------------------------------------------
-test("runtime.searchTools() and runtime.listSources() work", { skip: !hasIsolatedVm }, async () => {
+test("runtime.searchTools() and runtime.listServers() work", { skip: !hasIsolatedVm }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const github = fakeSource();
   const exa = fakeExaSource();
-  const runtime = await createCodeModeRuntime({ sources: [github.source, exa.source] });
+  const runtime = await createCodeModeRuntime({ servers: [github.source, exa.source] });
 
   const searchResults = await runtime.searchTools("search web");
   assert.ok(searchResults.length > 0);
   assert.equal(searchResults[0].toolName, "web_search");
+  assert.equal(searchResults[0].serverId, "exa");
 
-  const sources = runtime.listSources();
-  assert.equal(sources.length, 2);
-  assert.ok(sources.some(s => s.sourceId === "github"));
-  assert.ok(sources.some(s => s.sourceId === "exa"));
+  const servers = runtime.listServers();
+  assert.equal(servers.length, 2);
+  assert.ok(servers.some(s => s.serverId === "github"));
+  assert.ok(servers.some(s => s.serverId === "exa"));
+});
+
+// -----------------------------------------------------------------------
+// Test 12: MCP-style tool responses are normalized for scripts
+// -----------------------------------------------------------------------
+test("MCP envelopes are normalized to script-friendly values", { skip: !hasIsolatedVm }, async () => {
+  const { createCodeModeRuntime } = await import("../dist/index.js");
+  const { source } = fakeMcpEnvelopeSource();
+  const runtime = await createCodeModeRuntime({ servers: [source] });
+
+  const result = await runtime.run(`
+    return {
+      structured: docs.structured_search({ query: "a" }),
+      jsonText: callTool("docs", "json_text_search", { query: "b" }),
+      plainText: docs.plain_text_search({ query: "c" }),
+      multipart: callTool("docs", "multipart_search", { query: "d" })
+    };
+  `);
+
+  assert.equal(result.error, undefined);
+  assert.deepEqual(result.value.structured, {
+    items: [{ title: "Structured result" }]
+  });
+  assert.deepEqual(result.value.jsonText, {
+    items: [{ title: "JSON text result" }]
+  });
+  assert.equal(result.value.plainText, "plain text result");
+  assert.deepEqual(result.value.multipart, {
+    content: [
+      { type: "text", text: "first" },
+      { type: "text", text: "second" }
+    ],
+    isError: true
+  });
 });

--- a/packages/tool-router/src/meta-handler.ts
+++ b/packages/tool-router/src/meta-handler.ts
@@ -136,7 +136,8 @@ function renderSearchResults(results: ToolSearchResult[], detail: ToolRouterDeta
         [
           `${index + 1}. ${tool.toolName}`,
           `Tool ID: ${tool.toolId}`,
-          `Server: ${tool.serverId}${tool.serverName && tool.serverName !== tool.serverId ? ` (${tool.serverName})` : ""}`,
+          `Server ID: ${tool.serverId}`,
+          `Server Name: ${tool.serverName}`,
           tool.description ? `Description: ${tool.description}` : null
         ]
           .filter(Boolean)
@@ -146,7 +147,10 @@ function renderSearchResults(results: ToolSearchResult[], detail: ToolRouterDeta
   }
 
   return results
-    .map((tool) => `- Tool ID: ${tool.toolId} - ${tool.description || "No description."}`)
+    .map(
+      (tool) =>
+        `- Tool ID: ${tool.toolId} | Server ID: ${tool.serverId} | Server Name: ${tool.serverName} - ${tool.description || "No description."}`
+    )
     .join("\n");
 }
 
@@ -161,7 +165,12 @@ function renderSchemaResults(results: ToolSchemaResult[], detail: ToolRouterDeta
 
   return results
     .map((tool) => {
-      const lines = [`### ${tool.toolName}`, `Tool ID: ${tool.toolId}`];
+      const lines = [
+        `### ${tool.toolName}`,
+        `Tool ID: ${tool.toolId}`,
+        `Server ID: ${tool.serverId}`,
+        `Server Name: ${tool.serverName}`
+      ];
       if (tool.description) {
         lines.push("", tool.description);
       }

--- a/packages/tool-router/test/toolrouter.test.mjs
+++ b/packages/tool-router/test/toolrouter.test.mjs
@@ -128,6 +128,8 @@ test("exposes meta tools for search, schema lookup, and proxy execution", async 
   });
   assert.equal(search.isError, false);
   assert.match(search.content[0].text, /list_pull_requests/);
+  assert.match(search.content[0].text, /Server ID: github/);
+  assert.match(search.content[0].text, /Server Name: github/);
   assert.deepEqual(search.structuredContent.results.map((tool) => tool.toolId), [
     "github.list_pull_requests"
   ]);
@@ -137,6 +139,8 @@ test("exposes meta tools for search, schema lookup, and proxy execution", async 
   });
   assert.equal(schema.isError, false);
   assert.match(schema.content[0].text, /Parameters/);
+  assert.match(schema.content[0].text, /Server ID: github/);
+  assert.match(schema.content[0].text, /Server Name: github/);
   assert.deepEqual(schema.structuredContent.results.map((tool) => tool.toolId), [
     "github.list_pull_requests"
   ]);
@@ -185,6 +189,8 @@ test("meta-tool execution is available as an isolated executor", async () => {
 
   assert.equal(result.isError, false);
   assert.match(result.content[0].text, /github\.get_issue/);
+  assert.match(result.content[0].text, /Server ID: github/);
+  assert.match(result.content[0].text, /Server Name: github/);
   assert.deepEqual(result.structuredContent.results.map((tool) => tool.toolId), [
     "github.get_issue"
   ]);
@@ -734,6 +740,8 @@ test("schema meta tool does not expose annotations", async () => {
   });
 
   assert.equal(schema.isError, false);
+  assert.match(schema.content[0].text, /Server ID: github/);
+  assert.match(schema.content[0].text, /Server Name: github/);
   assert.match(schema.content[0].text, /Parameters/);
   assert.match(schema.content[0].text, /Returns/);
   assert.match(schema.content[0].text, /deleted/);
@@ -746,6 +754,38 @@ test("schema meta tool does not expose annotations", async () => {
     },
     required: ["deleted"]
   });
+});
+
+test("search and schema meta tools include server id and server name in text responses", async () => {
+  const server = createToolServer({
+    id: "GitHub Server",
+    name: "GitHub Server",
+    listTools: async () => ({
+      tools: [
+        {
+          name: "get_issue",
+          description: "Get a GitHub issue",
+          inputSchema: { type: "object", properties: { issue_number: { type: "number" } } }
+        }
+      ]
+    }),
+    callTool: async (name, args) => ({ name, args })
+  });
+
+  const router = await createToolRouter({ servers: [server] });
+  const search = await router.executeMetaTool("search_tools", { query: "issue" });
+  const schema = await router.executeMetaTool("get_tool_schemas", {
+    toolIds: ["github_server.get_issue"]
+  });
+
+  assert.match(search.content[0].text, /Server ID: github_server/);
+  assert.match(search.content[0].text, /Server Name: GitHub Server/);
+  assert.match(schema.content[0].text, /Server ID: github_server/);
+  assert.match(schema.content[0].text, /Server Name: GitHub Server/);
+  assert.equal(search.structuredContent.results[0].serverId, "github_server");
+  assert.equal(search.structuredContent.results[0].serverName, "GitHub Server");
+  assert.equal(schema.structuredContent.results[0].serverId, "github_server");
+  assert.equal(schema.structuredContent.results[0].serverName, "GitHub Server");
 });
 
 test("search results expose canonical tool ids", async () => {


### PR DESCRIPTION
## Summary

This follow-up PR restores the `tool-router` and `code-mode` work that was not included in the already-merged PR #146.

## What changed

- normalizes MCP tool results in `code-mode` so script consumers prefer `structuredContent` when available and gracefully handle JSON text or multipart content
- updates `code-mode` terminology and runtime wiring from source-oriented behavior to server-oriented behavior
- keeps `tool-router` meta responses clearer about server identity in text output
- updates the related `code-mode` and `tool-router` tests to match the restored behavior

## Why

PR #146 merged only the example and shared meta-tool cleanup changes. The `packages/code-mode/*` and `packages/tool-router/*` changes from the earlier work were not part of that merged diff, so this PR carries just that missing follow-up.

## Validation

- `npm run build`
- `node --test packages/tool-router/test/toolrouter.test.mjs packages/code-mode/test/codemode.test.mjs`
  - passed with `32` passing and `12` skipped tests
