### PR TITLE
[codex] add session mutation hooks

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -6,7 +6,7 @@
 /** Core MCP client and session management */
 export { MCPClient } from './mcp/oauth-client.js';
 export { UnauthorizedError } from '../shared/errors.js';
-export { sessions, type SessionStore } from './storage/index.js';
+export { sessions, onSessionMutation, type SessionStore } from './storage/index.js';
 export { StorageOAuthClientProvider } from './mcp/storage-oauth-provider.js';
 export { MultiSessionClient } from './mcp/multi-session-client.js';
 
@@ -43,6 +43,13 @@ export type {
   CallToolRequest,
   CallToolResponse,
 } from '../shared/types';
+
+export type {
+  Session,
+  SessionMutationEvent,
+  SessionMutationListener,
+  SessionMutationType,
+} from './storage/types.js';
 
 /** Re-export MCP SDK types for convenience */
 export type {

--- a/src/server/storage/index.ts
+++ b/src/server/storage/index.ts
@@ -5,7 +5,7 @@ import { FileStorageBackend } from './file-backend';
 import { SqliteStorage } from './sqlite-backend.js';
 import { SupabaseStorageBackend } from './supabase-backend.js';
 import { NeonStorageBackend, type NeonStorageOptions } from './neon-backend.js';
-import type { SessionStore } from './types.js';
+import type { SessionStore, Session, SessionMutationEvent, SessionMutationListener } from './types.js';
 
 // Re-export types
 export * from './types.js';
@@ -42,6 +42,65 @@ function warnIfNeonConnectionStringIsInsecure(connectionString: string): void {
 
 let storageInstance: SessionStore | null = null;
 let storagePromise: Promise<SessionStore> | null = null;
+const sessionMutationListeners = new Set<SessionMutationListener>();
+
+function emitSessionMutation(event: SessionMutationEvent): void {
+    for (const listener of sessionMutationListeners) {
+        try {
+            const result = listener(event);
+            if (result && typeof (result as Promise<void>).catch === 'function') {
+                void (result as Promise<void>).catch((error) => {
+                    console.error('[mcp-ts][Storage] Session mutation listener failed:', error);
+                });
+            }
+        } catch (error) {
+            console.error('[mcp-ts][Storage] Session mutation listener failed:', error);
+        }
+    }
+}
+
+function createSessionMutationEvent(prop: PropertyKey, args: any[]): SessionMutationEvent | null {
+    const timestamp = Date.now();
+
+    if (prop === 'create') {
+        const [session, ttl] = args as [Session, number | undefined];
+        if (!session?.userId || !session?.sessionId) return null;
+        return {
+            type: 'create',
+            userId: session.userId,
+            sessionId: session.sessionId,
+            session,
+            ttl,
+            timestamp,
+        };
+    }
+
+    if (prop === 'update') {
+        const [userId, sessionId, patch, ttl] = args as [string, string, Partial<Session>, number | undefined];
+        if (!userId || !sessionId) return null;
+        return {
+            type: 'update',
+            userId,
+            sessionId,
+            patch,
+            ttl,
+            timestamp,
+        };
+    }
+
+    if (prop === 'delete') {
+        const [userId, sessionId] = args as [string, string];
+        if (!userId || !sessionId) return null;
+        return {
+            type: 'delete',
+            userId,
+            sessionId,
+            timestamp,
+        };
+    }
+
+    return null;
+}
 
 async function initializeStorage<T extends SessionStore>(store: T): Promise<T> {
     if (typeof store.init === 'function') {
@@ -215,6 +274,17 @@ export function _setStorageInstanceForTesting(instance: SessionStore | null): vo
     }
 }
 
+export function onSessionMutation(listener: SessionMutationListener): () => void {
+    sessionMutationListeners.add(listener);
+    return () => {
+        sessionMutationListeners.delete(listener);
+    };
+}
+
+export function _resetSessionMutationListenersForTesting(): void {
+    sessionMutationListeners.clear();
+}
+
 /**
  * Global session store instance
  * Uses lazy initialization with a Proxy to handle async setup transparently
@@ -225,7 +295,12 @@ export const sessions: SessionStore = new Proxy({} as SessionStore, {
             const instance = await getStorage();
             const value = (instance as any)[prop];
             if (typeof value === 'function') {
-                return value.apply(instance, args);
+                const result = await value.apply(instance, args);
+                const event = createSessionMutationEvent(prop, args);
+                if (event) {
+                    emitSessionMutation(event);
+                }
+                return result;
             }
             return value;
         };

--- a/src/server/storage/types.ts
+++ b/src/server/storage/types.ts
@@ -29,6 +29,20 @@ export interface Session {
     clientId?: string;
 }
 
+export type SessionMutationType = 'create' | 'update' | 'delete';
+
+export interface SessionMutationEvent {
+    type: SessionMutationType;
+    userId: string;
+    sessionId: string;
+    timestamp: number;
+    session?: Session;
+    patch?: Partial<Session>;
+    ttl?: number;
+}
+
+export type SessionMutationListener = (event: SessionMutationEvent) => void | Promise<void>;
+
 export interface SetClientOptions {
     sessionId: string;
     serverId?: string; // Database server ID

--- a/tests/session-mutation-events.test.ts
+++ b/tests/session-mutation-events.test.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test';
+import {
+    sessions,
+    onSessionMutation,
+    _setStorageInstanceForTesting,
+    _resetSessionMutationListenersForTesting,
+    MemoryStorageBackend,
+} from '../src/server/storage';
+import { createMockSession } from './test-utils';
+
+test.describe('session mutation events', () => {
+    test.beforeEach(() => {
+        _setStorageInstanceForTesting(new MemoryStorageBackend());
+        _resetSessionMutationListenersForTesting();
+    });
+
+    test.afterEach(async () => {
+        try {
+            await sessions.disconnect();
+        } catch {
+            // No-op for tests.
+        }
+        _resetSessionMutationListenersForTesting();
+        _setStorageInstanceForTesting(null);
+    });
+
+    test('emits create, update, and delete events after successful mutations', async () => {
+        const session = createMockSession();
+        const events: Array<{ type: string; userId: string; sessionId: string; patch?: unknown }> = [];
+
+        const unsubscribe = onSessionMutation((event) => {
+            events.push({
+                type: event.type,
+                userId: event.userId,
+                sessionId: event.sessionId,
+                patch: event.patch,
+            });
+        });
+
+        await sessions.create(session, 60);
+        await sessions.update(session.userId, session.sessionId, { active: false }, 120);
+        await sessions.delete(session.userId, session.sessionId);
+        unsubscribe();
+
+        expect(events).toEqual([
+            {
+                type: 'create',
+                userId: session.userId,
+                sessionId: session.sessionId,
+                patch: undefined,
+            },
+            {
+                type: 'update',
+                userId: session.userId,
+                sessionId: session.sessionId,
+                patch: { active: false },
+            },
+            {
+                type: 'delete',
+                userId: session.userId,
+                sessionId: session.sessionId,
+                patch: undefined,
+            },
+        ]);
+    });
+
+    test('does not emit when the mutation fails', async () => {
+        const session = createMockSession();
+        const events: string[] = [];
+
+        onSessionMutation((event) => {
+            events.push(event.type);
+        });
+
+        await sessions.create(session);
+        await expect(sessions.create(session)).rejects.toThrow(/already exists/);
+        await expect(sessions.update('missing-user', 'missing-session', { active: true })).rejects.toThrow(/not found/);
+
+        expect(events).toEqual(['create']);
+    });
+
+    test('unsubscribe stops future delivery and listener errors do not break writes', async () => {
+        const session = createMockSession();
+        const events: string[] = [];
+
+        const unsubscribe = onSessionMutation((event) => {
+            events.push(`first:${event.type}`);
+        });
+
+        onSessionMutation(() => {
+            throw new Error('listener failed');
+        });
+
+        await sessions.create(session);
+        unsubscribe();
+        await sessions.update(session.userId, session.sessionId, { active: false });
+
+        expect(events).toEqual(['first:create']);
+        const stored = await sessions.get(session.userId, session.sessionId);
+        expect(stored?.active).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

This PR adds a generic in-process session mutation hook to the `@mcp-ts/sdk/server` surface.

## What changed

- added `SessionMutationType`, `SessionMutationEvent`, and `SessionMutationListener` types
- added `onSessionMutation(...)` on top of the global `sessions` proxy in storage
- emit normalized mutation events after successful `create`, `update`, and `delete` calls
- keep listener failures isolated so they do not break session writes
- export the new session mutation API and types from the server entrypoint
- added regression tests covering success-only emission, unsubscribe behavior, and listener isolation

## Why

This PR adds a generic in-process session mutation hook to the @mcp-ts/sdk/server surface. It provides a reusable primitive for reacting to session lifecycle changes in real time, enabling use cases like cache invalidation, observability, audit logging, metrics, and orchestration without coupling the SDK core to any one application’s behavior.

## Validation

- `npm test -- tests/session-mutation-events.test.ts`
- `npm run build`

## Notes

This API is intentionally generic. Cache invalidation is only one consumer of the new session mutation stream.