### PR TITLE
Add async tool schema resolution

### DIFF
--- a/src/shared/meta-tools.ts
+++ b/src/shared/meta-tools.ts
@@ -235,12 +235,23 @@ export async function executeMetaTool(
   router: ToolRouter,
   callToolFn?: CallToolFn
 ): Promise<CallToolResult | null> {
-  const resolveToolSchema = (
+  const resolveToolSchema = async (
     name: string,
     namespace?: string,
     options?: ToolLookupOptions
-  ): { tool?: IndexedTool; error?: CallToolResult } => {
+  ): Promise<{ tool?: IndexedTool; error?: CallToolResult }> => {
     try {
+      if (typeof (router as ToolRouter & { resolveToolSchema?: unknown }).resolveToolSchema === 'function') {
+        return {
+          tool: await (router as ToolRouter & {
+            resolveToolSchema: (
+              toolName: string,
+              namespace?: string,
+              options?: ToolLookupOptions
+            ) => Promise<IndexedTool | undefined>;
+          }).resolveToolSchema(name, namespace, options),
+        };
+      }
       return { tool: router.getToolSchema(name, namespace, options) };
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err);
@@ -307,8 +318,6 @@ export async function executeMetaTool(
       // Fast path: Check for select: prefix
       const selectMatch = query.match(/^select:(.+)$/i);
       if (selectMatch) {
-        await router.listTools({ serverId, serverName, limit: 1 });
-
         const requested = selectMatch[1]!
           .split(',')
           .map((s) => s.trim())
@@ -320,7 +329,7 @@ export async function executeMetaTool(
         const namespace = serverId ?? serverName;
 
         for (const requestedToolName of requested) {
-          const { tool, error } = resolveToolSchema(requestedToolName, namespace, {
+          const { tool, error } = await resolveToolSchema(requestedToolName, namespace, {
             allowServerNameFragment: Boolean(serverName && !serverId),
           });
           if (error) {
@@ -410,7 +419,7 @@ export async function executeMetaTool(
     case 'mcp_get_tool_schema': {
       const name = String(args.toolName ?? '');
       const namespace = String(args.serverId ?? '') || undefined;
-      const { tool, error } = resolveToolSchema(name, namespace);
+      const { tool, error } = await resolveToolSchema(name, namespace);
 
       if (error) {
         return error;
@@ -461,7 +470,7 @@ export async function executeMetaTool(
       }
 
       // Verify the tool exists in our index
-      const { tool, error } = resolveToolSchema(targetToolName, namespace);
+      const { tool, error } = await resolveToolSchema(targetToolName, namespace);
       if (error) {
         return error;
       }

--- a/src/shared/tool-router.ts
+++ b/src/shared/tool-router.ts
@@ -290,6 +290,19 @@ export class ToolRouter {
   }
 
   /**
+   * Resolve the full tool definition by name, ensuring the router index has
+   * been initialized first.
+   */
+  async resolveToolSchema(
+    toolName: string,
+    namespace?: string,
+    options: ToolLookupOptions = {}
+  ): Promise<IndexedTool | undefined> {
+    await this.ensureInitialized();
+    return this.getToolSchema(toolName, namespace, options);
+  }
+
+  /**
    * Get compact (schema-less) summaries for all tools.
    */
   getCompactTools(): CompactTool[] {

--- a/tests/meta-tools.test.ts
+++ b/tests/meta-tools.test.ts
@@ -462,6 +462,9 @@ test.describe('executeMetaTool', () => {
             const schema = router.getToolSchema('workflow_list');
             expect(schema?.name).toBe('workflow_list');
 
+            const resolvedSchema = await router.resolveToolSchema('workflow_list');
+            expect(resolvedSchema?.name).toBe('workflow_list');
+
             const result = await router.callTool('workflow_list', {});
             expect(result.content[0].text).toContain('Workflow MCP:workflow_list:{}');
         });
@@ -488,5 +491,21 @@ test.describe('executeMetaTool', () => {
             const searchResults = await router.searchTools('workflow', 10);
             expect(searchResults.map((tool) => tool.name)).toContain('workflow_run');
         });
+    });
+
+    test('resolveToolSchema initializes a fresh router before lookup', async () => {
+        const router = new ToolRouter([
+            createRouterClient('github-server', 'GitHub', [
+                { name: 'search_issues', description: 'Search issues' },
+            ]) as any,
+        ], {
+            strategy: 'search',
+        });
+
+        expect(router.getToolSchema('search_issues')).toBeUndefined();
+
+        const schema = await router.resolveToolSchema('search_issues', 'github-server');
+        expect(schema?.name).toBe('search_issues');
+        expect(schema?.serverId).toBe('github-server');
     });
 });


### PR DESCRIPTION
## What changed
Adds an async `resolveToolSchema()` API to `ToolRouter` that initializes the router index before performing schema lookup.

Updates the meta-tool execution path to prefer the new async resolver while keeping backward compatibility with lightweight router stubs that only implement `getToolSchema()`.

Adds regression coverage proving that a fresh router can resolve tool schemas correctly without requiring callers to manually warm the router first.

## Why
`getToolSchema()` is synchronous and assumes the router index is already initialized. Fresh routers could therefore return `undefined` for a valid tool schema until some other async call, like `listTools()` or `searchTools()`, had already initialized the router.

This was causing downstream callers to add manual warm-up workarounds. Moving the fix into `mcp-ts` makes schema lookup safe at the SDK layer.

## Impact
Callers can switch from ad hoc warm-up calls to `await router.resolveToolSchema(...)`, which is clearer, safer, and less error-prone.

## Validation
- `npm test -- tests/meta-tools.test.ts`
- `npm test -- tests/unit/workflow-tools-core.test.ts` in the downstream workflow engine workspace