### PR TITLE
fix: propagate serverUrl through ToolClient/ToolServer for codemode analytics

### DIFF
--- a/packages/code-mode/src/index.ts
+++ b/packages/code-mode/src/index.ts
@@ -3,8 +3,6 @@ export { createCodeModeRuntime, IsolatedVmCodeModeRuntime } from "./runtime/runt
 
 // Servers
 export { mcpServer, mcpServers, normalizeMcpToolResult } from "./sources/index.js";
-export type { McpLikeClient, McpLikeProvider } from "./sources/index.js";
-
 // AI SDK adapter
 export { createCodemodeAITools } from "./adapters/ai-sdk.js";
 
@@ -24,3 +22,4 @@ export type {
   ToolSearchResult,
   ToolServer,
 } from "./types.js";
+export type { ToolClient, ToolClientProvider } from "./sources/index.js";

--- a/packages/code-mode/src/sources/index.ts
+++ b/packages/code-mode/src/sources/index.ts
@@ -1,2 +1,2 @@
 export { mcpServer, mcpServers, normalizeMcpToolResult } from "./mcp.js";
-export type { McpLikeClient, McpLikeProvider } from "./mcp.js";
+export type { ToolClient, ToolClientProvider } from "./mcp.js";

--- a/packages/code-mode/src/sources/mcp.ts
+++ b/packages/code-mode/src/sources/mcp.ts
@@ -11,15 +11,16 @@ type McpCallToolEnvelope = {
   isError?: unknown;
 };
 
-export interface McpLikeClient {
+export interface ToolClient {
   listTools(): Promise<{ tools: ToolDefinition[] }>;
   callTool(name: string, args: Record<string, unknown>): Promise<unknown>;
   getServerId?(): string | undefined;
   getServerName?(): string | undefined;
+  getServerUrl?(): string;
 }
 
-export interface McpLikeProvider {
-  getClients(): McpLikeClient[];
+export interface ToolClientProvider {
+  getClients(): ToolClient[];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -69,10 +70,11 @@ export function normalizeMcpToolResult(result: unknown): unknown {
 /**
  * Wraps a single MCP-like client as a ToolServer.
  */
-export function mcpServer(serverId: string, client: McpLikeClient, serverName?: string): ToolServer {
+export function mcpServer(serverId: string, client: ToolClient, serverName?: string): ToolServer {
   return {
     serverId,
     serverName: serverName ?? client.getServerName?.() ?? client.getServerId?.() ?? serverId,
+    serverUrl: client.getServerUrl?.(),
     listTools: () => client.listTools(),
     callTool: async (toolName, args) => normalizeMcpToolResult(await client.callTool(toolName, args)),
     callToolRaw: (toolName, args) => client.callTool(toolName, args),
@@ -83,12 +85,11 @@ export function mcpServer(serverId: string, client: McpLikeClient, serverName?: 
  * Creates ToolServer[] from a provider that manages multiple MCP clients
  * (e.g. MultiSessionClient).
  */
-export function mcpServers(provider: McpLikeProvider): ToolServer[] {
+export function mcpServers(provider: ToolClientProvider): ToolServer[] {
   return provider.getClients().map((client, index) =>
     mcpServer(
       client.getServerId?.() ?? `mcp_${index + 1}`,
-      client,
-      client.getServerName?.()
+      client
     )
   );
 }

--- a/packages/code-mode/src/types.ts
+++ b/packages/code-mode/src/types.ts
@@ -20,6 +20,7 @@ export interface ToolDefinition {
 export interface ToolServer {
   serverId: string;
   serverName?: string;
+  serverUrl?: string;
   listTools(): Promise<{ tools: ToolDefinition[] }>;
   callTool(name: string, args: Record<string, unknown>): Promise<unknown>;
   callToolRaw?(name: string, args: Record<string, unknown>): Promise<unknown>;

--- a/packages/code-mode/test/mcp-sources.test.mjs
+++ b/packages/code-mode/test/mcp-sources.test.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const { mcpServer, mcpServers } = await import("../dist/index.js");
+
+test("mcpServer: serverUrl is set when getServerUrl returns a URL", () => {
+  const server = mcpServer("test", {
+    listTools: async () => ({ tools: [] }),
+    callTool: async () => ({}),
+    getServerId: () => "test",
+    getServerName: () => "Test Server",
+    getServerUrl: () => "https://example.com/mcp",
+  });
+
+  assert.equal(server.serverUrl, "https://example.com/mcp");
+});
+
+test("mcpServer: serverUrl is undefined when client has no getServerUrl", () => {
+  const server = mcpServer("test", {
+    listTools: async () => ({ tools: [] }),
+    callTool: async () => ({}),
+    getServerId: () => "test",
+    getServerName: () => "Test Server",
+  });
+
+  assert.equal(server.serverUrl, undefined);
+});
+
+test("mcpServer: serverUrl is undefined when getServerUrl returns undefined", () => {
+  const server = mcpServer("test", {
+    listTools: async () => ({ tools: [] }),
+    callTool: async () => ({}),
+    getServerId: () => "test",
+    getServerName: () => "Test Server",
+    getServerUrl: () => undefined,
+  });
+
+  assert.equal(server.serverUrl, undefined);
+});
+
+test("mcpServer: serverUrl is set to empty string when getServerUrl returns empty string", () => {
+  const server = mcpServer("test", {
+    listTools: async () => ({ tools: [] }),
+    callTool: async () => ({}),
+    getServerId: () => "test",
+    getServerName: () => "Test Server",
+    getServerUrl: () => "",
+  });
+
+  assert.equal(server.serverUrl, "");
+});
+
+test("mcpServers: propagates serverUrl from multiple clients", () => {
+  const servers = mcpServers({
+    getClients: () => [
+      {
+        listTools: async () => ({ tools: [] }),
+        callTool: async () => ({}),
+        getServerId: () => "server_a",
+        getServerName: () => "Server A",
+        getServerUrl: () => "https://a.example.com/mcp",
+      },
+      {
+        listTools: async () => ({ tools: [] }),
+        callTool: async () => ({}),
+        getServerId: () => "server_b",
+        getServerName: () => "Server B",
+        getServerUrl: () => "https://b.example.com/mcp",
+      },
+      {
+        listTools: async () => ({ tools: [] }),
+        callTool: async () => ({}),
+        getServerId: () => "server_c",
+        getServerName: () => "Server C",
+      },
+    ],
+  });
+
+  assert.equal(servers.length, 3);
+  assert.equal(servers[0].serverUrl, "https://a.example.com/mcp");
+  assert.equal(servers[1].serverUrl, "https://b.example.com/mcp");
+  assert.equal(servers[2].serverUrl, undefined);
+});
+
+test("mcpServer: serverId and serverName are unaffected by serverUrl", () => {
+  const server = mcpServer("my_server", {
+    listTools: async () => ({ tools: [] }),
+    callTool: async () => ({}),
+    getServerId: () => "my_server",
+    getServerName: () => "My Server",
+    getServerUrl: () => "https://example.com/mcp",
+  });
+
+  assert.equal(server.serverId, "my_server");
+  assert.equal(server.serverName, "My Server");
+  assert.equal(server.serverUrl, "https://example.com/mcp");
+});
+
+test("mcpServer: callTool and listTools still work with serverUrl set", async () => {
+  const server = mcpServer("test", {
+    listTools: async () => ({
+      tools: [{ name: "my_tool", description: "A test tool" }],
+    }),
+    callTool: async (name, args) => ({ result: "ok", name, args }),
+    getServerId: () => "test",
+    getServerUrl: () => "https://example.com/mcp",
+  });
+
+  const tools = await server.listTools();
+  assert.equal(tools.tools.length, 1);
+  assert.equal(tools.tools[0].name, "my_tool");
+
+  const result = await server.callTool("my_tool", { foo: "bar" });
+  assert.deepEqual(result, { result: "ok", name: "my_tool", args: { foo: "bar" } });
+});


### PR DESCRIPTION
## Summary

Fixes `serverUrl` being `undefined` in analytics events for `codemode_run` downstream MCP tool calls by propagating the server URL through the `ToolClient` → `ToolServer` chain.

## Changes

- Added `getServerUrl?(): string` to the `ToolClient` interface
- Added `serverUrl?: string` to the `ToolServer` type
- `mcpServer()` now passes `client.getServerUrl?.()` as `ToolServer.serverUrl`
- Renamed `McpLikeClient` → `ToolClient`, `McpLikeProvider` → `ToolClientProvider`
- Added unit tests for `mcpServer()` serverUrl propagation
- Fixed return type of `getServerUrl?()` to `string`
- Removed redundant `serverName` pass-through from `mcpServers()`

Closes #161