### PR TITLE
fix: prune stale MCPClient refs in MultiSessionClient.connect()

### DIFF
--- a/src/server/mcp/multi-session-client.ts
+++ b/src/server/mcp/multi-session-client.ts
@@ -210,6 +210,15 @@ export class MultiSessionClient {
      */
     async connect(): Promise<void> {
         const sessions = await this.getActiveSessions();
+        const activeSessionIds = new Set(sessions.map(s => s.sessionId));
+
+        // Prune stale clients whose sessions no longer exist in storage.
+        // Otherwise a lingering MCPClient with a still-alive SDK Client
+        // transport triggers OAuth refreshes on listTools(), and the
+        // StorageOAuthClientProvider.state() -> patchCredentials() call
+        // fails with a FK violation because the session was deleted.
+        this.clients = this.clients.filter(c => activeSessionIds.has(c.getSessionId()));
+
         await this.connectInBatches(sessions);
     }
 

--- a/tests/multi-session-client.test.ts
+++ b/tests/multi-session-client.test.ts
@@ -186,7 +186,7 @@ test.describe('MultiSessionClient', () => {
         const client = multiClient.getClients()[0];
         expect(client.isConnected()).toBe(true);
 
-        multiClient.disconnect();
+        await multiClient.disconnect();
 
         expect(multiClient.getClients().length).toBe(0);
         expect(client.isConnected()).toBe(false); // Because mock disconnect sets it to false


### PR DESCRIPTION
## Problem

Stale `MCPClient` instances remain in `MultiSessionClient.clients` after their sessions are deleted from storage by the SSE handler's `clearSession()`. The SDK Client transport on the stale instance is still alive, so `isConnected()` returns `true`, causing `listTools()` calls that may trigger OAuth flows referencing the deleted session — leading to foreign key violations in `mcp_credentials`.

## Fix

`MultiSessionClient.connect()` now filters out clients whose `sessionId` doesn't appear in the active sessions list fetched from storage, preventing stale references from persisting across reconnect cycles.

Also fixed a pre-existing missing `await` in the test `"should properly disconnect and clear client cache"`.

Files changed:
- `src/server/mcp/multi-session-client.ts` — prune stale clients in `connect()`
- `tests/multi-session-client.test.ts` — add missing `await` on `disconnect()` call

---
Closes #166 