### PR TITLE
refactor: MCPClient eager Client, ensureSession, test cases and logging

### DIFF
--- a/examples/next/app/agent/agent.ts
+++ b/examples/next/app/agent/agent.ts
@@ -1,5 +1,6 @@
 import { ToolLoopAgent, InferAgentUIMessage, stepCountIs } from "ai";
 import { MultiSessionClient } from "@mcp-ts/sdk/server";
+import type { McpObservabilityEvent } from "@mcp-ts/sdk/shared";
 import { AIAdapter } from "@mcp-ts/sdk/adapters/ai";
 import { createDeepSeek } from "@ai-sdk/deepseek";
 
@@ -27,7 +28,26 @@ function getMcpClient(userId: string): MultiSessionClient {
 
   let client = globalForMcp.mcpClientMap.get(userId);
   if (!client) {
-    client = new MultiSessionClient(userId);
+    client = new MultiSessionClient(userId, {
+      onSessionConnected: (_sessionId, mcpClient) => {
+        mcpClient.onObservabilityEvent((event: McpObservabilityEvent) => {
+          const prefix = `[MCP][${event.serverId ?? event.sessionId ?? '?'}]`;
+          switch (event.level) {
+            case 'error':
+              console.error(prefix, event.message, event.payload ?? '');
+              break;
+            case 'warn':
+              console.warn(prefix, event.message, event.payload ?? '');
+              break;
+            case 'debug':
+              console.debug(prefix, event.message, event.payload ?? '');
+              break;
+            default:
+              console.log(prefix, event.message, event.payload ?? '');
+          }
+        });
+      },
+    });
     globalForMcp.mcpClientMap.set(userId, client);
   }
 

--- a/src/server/handlers/sse-handler.ts
+++ b/src/server/handlers/sse-handler.ts
@@ -38,7 +38,7 @@ import { UnauthorizedError } from '../../shared/errors.js';
 import { isConnectionEvent, isRpcResponseEvent } from '../../shared/event-routing.js';
 import { parseOAuthState } from '../../shared/utils.js';
 import { MCPClient } from '../mcp/oauth-client.js';
-import { sessions } from '../storage/index.js';
+import { sessions, generateServerId } from '../storage/index.js';
 
 // ============================================
 // Types & Interfaces
@@ -256,7 +256,7 @@ export class SSEConnectionManager {
     // Tool name format: tool_<serverId>_<toolName> - with 12 char serverId leaves 46 chars for tool name
     const serverId = params.serverId && params.serverId.length <= 12
       ? params.serverId
-      : await sessions.generateSessionId();
+      : generateServerId();
 
     // Check for existing connections
     const existingSessions = await sessions.list(this.userId);

--- a/src/server/mcp/oauth-client.ts
+++ b/src/server/mcp/oauth-client.ts
@@ -686,27 +686,15 @@ export class MCPClient {
           authenticatedStateEmitted = true;
         }
 
-        this.emitProgress('Creating authenticated client...');
-
-        this.client = new Client(
-          {
-            name: MCP_CLIENT_NAME,
-            version: MCP_CLIENT_VERSION,
-          },
-          {
-            capabilities: {
-              extensions: {
-                'io.modelcontextprotocol/ui': {
-                  mimeTypes: ['text/html+mcp'],
-                },
-              },
-            } as McpAppClientCapabilities
-          }
-        );
-
         this.emitStateChange('CONNECTING');
 
-        /** We explicitly try to connect with the transport we just auth'd with first */
+        // The SDK Client may still have a transport attached from a prior
+        // connect() that failed with UnauthorizedError; close it first so
+        // we can negotiate a fresh session with the newly-exchanged tokens.
+        if (this.client.transport) {
+          try { await this.client.close(); } catch {}
+        }
+
         await this.client.connect(this.transport);
 
         /** Connection succeeded — lock in the transport type */
@@ -767,10 +755,6 @@ export class MCPClient {
    * @throws {Error} When client is not connected
    */
   async listTools(): Promise<ListToolsResult> {
-    if (!this.client) {
-      throw new Error('Not connected to server');
-    }
-
     this.emitStateChange('DISCOVERING');
 
     try {
@@ -814,9 +798,6 @@ export class MCPClient {
    * @throws {Error} When client is not connected
    */
   async callTool(toolName: string, toolArgs: Record<string, unknown>): Promise<CallToolResult> {
-    if (!this.client) {
-      throw new Error('Not connected to server');
-    }
 
     const request: CallToolRequest = {
       method: 'tools/call',
@@ -877,10 +858,6 @@ export class MCPClient {
    * @throws {Error} When client is not connected
    */
   async listPrompts(): Promise<ListPromptsResult> {
-    if (!this.client) {
-      throw new Error('Not connected to server');
-    }
-
     this.emitStateChange('DISCOVERING');
 
     try {
@@ -913,9 +890,6 @@ export class MCPClient {
    * @throws {Error} When client is not connected
    */
   async getPrompt(name: string, args?: Record<string, string>): Promise<GetPromptResult> {
-    if (!this.client) {
-      throw new Error('Not connected to server');
-    }
 
     const request: GetPromptRequest = {
       method: 'prompts/get',
@@ -936,10 +910,6 @@ export class MCPClient {
    * @throws {Error} When client is not connected
    */
   async listResources(): Promise<ListResourcesResult> {
-    if (!this.client) {
-      throw new Error('Not connected to server');
-    }
-
     this.emitStateChange('DISCOVERING');
 
     try {
@@ -971,9 +941,6 @@ export class MCPClient {
    * @throws {Error} When client is not connected
    */
   async readResource(uri: string): Promise<ReadResourceResult> {
-    if (!this.client) {
-      throw new Error('Not connected to server');
-    }
 
     const request: ReadResourceRequest = {
       method: 'resources/read',

--- a/src/server/mcp/oauth-client.ts
+++ b/src/server/mcp/oauth-client.ts
@@ -360,7 +360,15 @@ export class MCPClient {
     if (!existingSession && this.serverId && this.serverUrl && this.callbackUrl) {
       this.createdAt = Date.now();
       const updatedAt = this.createdAt;
-      console.log(`[MCPClient] Creating pending session ${this.sessionId} for connection setup`);
+      this._onObservabilityEvent.fire({
+        type: 'mcp:client:session_created',
+        level: 'info',
+        message: `Creating pending session ${this.sessionId} for connection setup`,
+        sessionId: this.sessionId,
+        serverId: this.serverId,
+        timestamp: Date.now(),
+        id: nanoid(),
+      });
       await sessions.create({
         sessionId: this.sessionId,
         userId: this.userId,
@@ -542,7 +550,15 @@ export class MCPClient {
 
       // Refresh session metadata on every successful connect so active sessions
       // record ongoing usage and don't look dormant to session cleanup jobs.
-      console.log(`[MCPClient] Saving active session ${this.sessionId} (connect success)`);
+      this._onObservabilityEvent.fire({
+        type: 'mcp:client:session_saved',
+        level: 'info',
+        message: `Saving active session ${this.sessionId} (connect success)`,
+        sessionId: this.sessionId,
+        serverId: this.serverId,
+        timestamp: Date.now(),
+        id: nanoid(),
+      });
       await this.saveSession('active');
     } catch (error) {
       /** Handle Authentication Errors */
@@ -580,7 +596,15 @@ export class MCPClient {
         }
 
         this.emitStateChange('AUTHENTICATING');
-        console.log(`[MCPClient] Saving pending OAuth session ${this.sessionId}`);
+        this._onObservabilityEvent.fire({
+          type: 'mcp:client:session_saved',
+          level: 'info',
+          message: `Saving pending OAuth session ${this.sessionId}`,
+          sessionId: this.sessionId,
+          serverId: this.serverId,
+          timestamp: Date.now(),
+          id: nanoid(),
+        });
         await this.saveSession('pending');
 
         if (this.serverId) {
@@ -701,7 +725,15 @@ export class MCPClient {
         this.transportType = currentType;
 
         this.emitStateChange('CONNECTED');
-        console.log(`[MCPClient] Saving active session ${this.sessionId} (OAuth complete)`);
+        this._onObservabilityEvent.fire({
+          type: 'mcp:client:session_saved',
+          level: 'info',
+          message: `Saving active session ${this.sessionId} (OAuth complete)`,
+          sessionId: this.sessionId,
+          serverId: this.serverId,
+          timestamp: Date.now(),
+          id: nanoid(),
+        });
         await this.saveSession('active');
 
         return; // Success, exit function
@@ -998,7 +1030,16 @@ export class MCPClient {
     try {
       await this.ensureSession();
     } catch (error) {
-      console.warn('[MCPClient] Initialization failed during clearSession:', error);
+      this._onObservabilityEvent.fire({
+        type: 'mcp:client:error',
+        level: 'warn',
+        message: 'Initialization failed during clearSession',
+        sessionId: this.sessionId,
+        serverId: this.serverId,
+        payload: { error: String(error) },
+        timestamp: Date.now(),
+        id: nanoid(),
+      });
     }
 
     if (this.oauthProvider) {

--- a/src/server/storage/index.ts
+++ b/src/server/storage/index.ts
@@ -9,7 +9,7 @@ import type { SessionStore, Session, SessionMutationEvent, SessionMutationListen
 
 // Re-export types
 export * from './types.js';
-export { generateSessionId } from '../../shared/utils.js';
+export { generateSessionId, generateServerId } from '../../shared/utils.js';
 export { RedisStorageBackend, MemoryStorageBackend, FileStorageBackend, SqliteStorage, SupabaseStorageBackend, NeonStorageBackend };
 
 export function createSupabaseStorageBackend(client: any): SupabaseStorageBackend {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1,17 +1,10 @@
-import { customAlphabet } from 'nanoid';
+import { customAlphabet, nanoid } from 'nanoid';
 
 const OAUTH_STATE_SEPARATOR = '.';
 
-/** first char: letters only (required by OpenAI) */
-const firstChar = customAlphabet(
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
-    1
-);
-
-/** remaining chars: alphanumeric */
-const rest = customAlphabet(
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789',
-    11
+const serverIdAlphabet = customAlphabet(
+    'abcdefghijklmnopqrstuvwxyz0123456789',
+    12
 );
 
 /**
@@ -32,11 +25,20 @@ export function sanitizeServerLabel(name: string): string {
 }
 
 /**
- * Generates a standard 12-character session ID compliant with external tool restrictions.
- * First character is always a letter.
+ * Generates a session ID with a human-readable prefix for easy identification.
+ * Format: sess_<21-char nanoid> (26 chars total).
+ * Not used in tool names, so length is not constrained.
  */
 export function generateSessionId(): string {
-    return firstChar() + rest();
+    return 'sess_' + nanoid(21);
+}
+
+/**
+ * Generates a short server ID suitable for use in tool names.
+ * 12-char alphanumeric string that keeps tool_<serverId>_<toolName> under 64 chars.
+ */
+export function generateServerId(): string {
+    return serverIdAlphabet();
 }
 
 export interface ParsedOAuthState {

--- a/tests/oauth-refresh-reauth.test.ts
+++ b/tests/oauth-refresh-reauth.test.ts
@@ -47,8 +47,7 @@ test.describe('MCPClient refresh-token reauthorization', () => {
 
     const events: any[] = [];
 
-    (MCPClient.prototype as any).initialize = async function () {
-      (this as any).client = {} as any;
+    (MCPClient.prototype as any).ensureSession = async function () {
       (this as any).oauthProvider = {
         authUrl: 'https://auth.example.com/authorize?state=session-2',
       };

--- a/tests/oauth-session-ttl.test.ts
+++ b/tests/oauth-session-ttl.test.ts
@@ -70,13 +70,13 @@ async function createPendingSession(client: MCPClient) {
 }
 
 test.describe('MCPClient session expiration lifecycle', () => {
-  const originalInitialize = (MCPClient.prototype as any).initialize;
+  const originalEnsureSession = (MCPClient.prototype as any).ensureSession;
   const originalTryConnect = (MCPClient.prototype as any).tryConnect;
   const originalGetTransport = (MCPClient.prototype as any).getTransport;
   const originalClientConnect = (Client.prototype as any).connect;
 
   test.afterEach(() => {
-    (MCPClient.prototype as any).initialize = originalInitialize;
+    (MCPClient.prototype as any).ensureSession = originalEnsureSession;
     (MCPClient.prototype as any).tryConnect = originalTryConnect;
     (MCPClient.prototype as any).getTransport = originalGetTransport;
     (Client.prototype as any).connect = originalClientConnect;
@@ -87,8 +87,7 @@ test.describe('MCPClient session expiration lifecycle', () => {
     const mockStorage = new TrackingMemoryStorage();
     _setStorageInstanceForTesting(mockStorage);
 
-    (MCPClient.prototype as any).initialize = async function () {
-      (this as any).client = {} as any;
+    (MCPClient.prototype as any).ensureSession = async function () {
       (this as any).oauthProvider = { authUrl: '' };
       await createPendingSession(this as MCPClient);
     };
@@ -119,8 +118,7 @@ test.describe('MCPClient session expiration lifecycle', () => {
     const mockStorage = new TrackingMemoryStorage();
     _setStorageInstanceForTesting(mockStorage);
 
-    (MCPClient.prototype as any).initialize = async function () {
-      (this as any).client = {} as any;
+    (MCPClient.prototype as any).ensureSession = async function () {
       (this as any).oauthProvider = { authUrl: 'https://auth.example.com' };
       await createPendingSession(this as MCPClient);
     };
@@ -151,7 +149,7 @@ test.describe('MCPClient session expiration lifecycle', () => {
     const mockStorage = new TrackingMemoryStorage();
     _setStorageInstanceForTesting(mockStorage);
 
-    (MCPClient.prototype as any).initialize = async function () {
+    (MCPClient.prototype as any).ensureSession = async function () {
       (this as any).oauthProvider = { authUrl: 'https://auth.example.com' };
       await createPendingSession(this as MCPClient);
     };
@@ -188,7 +186,7 @@ test.describe('MCPClient session expiration lifecycle', () => {
     const mockStorage = new TrackingMemoryStorage();
     _setStorageInstanceForTesting(mockStorage);
 
-    (MCPClient.prototype as any).initialize = async function () {
+    (MCPClient.prototype as any).ensureSession = async function () {
       (this as any).oauthProvider = { authUrl: 'https://auth.example.com' };
       await createPendingSession(this as MCPClient);
     };

--- a/tests/session-lifecycle.test.ts
+++ b/tests/session-lifecycle.test.ts
@@ -32,11 +32,10 @@ test.describe('Session Lifecycle Management', () => {
         });
 
         // Mock internal methods to simulate success
-        (client as any).initialize = async () => { 
+        (client as any).ensureSession = async () => { 
             (client as any).oauthProvider = { 
                 tokens: async () => ({ access_token: 'valid' })
             };
-            (client as any).client = { connect: async () => {} };
         };
         (client as any).tryConnect = async () => ({ transportType: 'sse' });
 
@@ -81,7 +80,7 @@ test.describe('Session Lifecycle Management', () => {
         });
 
         // Mock to throw generic error
-        (client as any).initialize = async function() {
+        (client as any).ensureSession = async function() {
             this.oauthProvider = { 
                 tokens: async () => ({ access_token: 'valid' })
             };
@@ -116,11 +115,10 @@ test.describe('Session Lifecycle Management', () => {
             status: 'active',
         });
 
-        (client as any).initialize = async function() {
+        (client as any).ensureSession = async function() {
             this.oauthProvider = {
                 tokens: async () => ({ access_token: 'valid' })
             };
-            this.client = { connect: async () => {} };
         };
         (client as any).tryConnect = async () => {
             throw new Error('ECONNREFUSED');
@@ -145,12 +143,11 @@ test.describe('Session Lifecycle Management', () => {
         });
 
         // Mock to throw Unauthorized without an auth URL
-        (client as any).initialize = async function() {
+        (client as any).ensureSession = async function() {
             this.oauthProvider = { 
                 tokens: async () => null, 
                 authUrl: '' 
             };
-            this.client = { connect: async () => {} };
         };
         (client as any).tryConnect = async () => {
             throw new SDKUnauthorizedError('Unauthorized');
@@ -171,12 +168,11 @@ test.describe('Session Lifecycle Management', () => {
         });
 
         // Mock to throw Unauthorized WITH an auth URL
-        (client as any).initialize = async function() {
+        (client as any).ensureSession = async function() {
             this.oauthProvider = { 
                 tokens: async () => null,
                 authUrl: 'http://auth.url'
             };
-            this.client = { connect: async () => {} };
         };
         (client as any).tryConnect = async () => {
             throw new SDKUnauthorizedError('Unauthorized');

--- a/tests/storage/supabase-backend.test.ts
+++ b/tests/storage/supabase-backend.test.ts
@@ -177,8 +177,8 @@ test.describe('SupabaseStorageBackend', () => {
             const id1 = storage.generateSessionId();
             const id2 = storage.generateSessionId();
             expect(id1).not.toBe(id2);
-            // 12-char pattern where first is letter
-            expect(id1).toMatch(/^[a-zA-Z][a-zA-Z0-9]{11}$/);
+            // 26-char pattern: sess_ + 21-char nanoid
+            expect(id1).toMatch(/^sess_[a-zA-Z0-9]{21}$/);
         });
     });
 


### PR DESCRIPTION
## Summary

Refactors `MCPClient` to eagerly create the SDK `Client` in the constructor, replaces `initialize()` with `ensureSession()` (which only handles session/OAuth setup, not Client creation), and adds `withRetry()` that catches `MCP_SESSION_EXPIRED`, reconnects, and retries.

## Changes

- **`oauth-client.ts`**: Client created eagerly in constructor (non-nullable); `initialize()` → `ensureSession()` (no Client creation); `connect()` closes stale transport without nulling client; `reconnect()` simplified to `ensureSession() + connect()`; `withRetry()` recovers from `MCP_SESSION_EXPIRED`; `disconnect()` no longer nulls client; 6 `console.log/warn` migrated to `_onObservabilityEvent.fire()`
- **`utils.ts`**: `generateSessionId()` → `sess_`+nanoid(21); added `generateServerId()` (12-char lowercase alphanumeric)
- **`sse-handler.ts`**: Uses `generateServerId()` for serverId fallback
- **`agent.ts`**: Subscribes to `onObservabilityEvent` for terminal logging
- **Tests**: Mock `initialize` → `ensureSession` in 3 test files; supabase ID format regex updated
