### PR TITLE
feat: add per-session MCP tool policy enforcement

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -89,6 +89,15 @@
                 ]
               },
               {
+                "group": "Tool Policy",
+                "icon": "shield",
+                "expanded": false,
+                "pages": [
+                  "tool-policy/overview",
+                  "tool-policy/configuration"
+                ]
+              },
+              {
                 "group": "Storage Backends",
                 "icon": "database",
                 "expanded": false,

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -65,7 +65,32 @@ interface Session {
   updatedAt?: number;
   expiresAt?: number | null;
   headers?: Record<string, string>;
+  toolPolicy?: ToolPolicy;
 }
+
+### Tool Policy Types
+
+```typescript
+import { createToolId, isToolAllowed, filterToolsByPolicy } from '@mcp-ts/sdk/server';
+
+interface ToolPolicy {
+  mode: 'all' | 'allowlist' | 'denylist';
+  toolIds: string[];
+  updatedAt: number;
+}
+```
+
+**Utility functions:**
+
+| Function | Description |
+|----------|-------------|
+| `createToolId(serverId, toolName)` | Creates composite `{serverId}::{toolName}` ID |
+| `normalizeToolPolicy(input, now?)` | Normalizes raw input into `ToolPolicy \| undefined` |
+| `normalizeToolPolicyForUpdate(input, now?)` | Like above but falls back to `{ mode: 'all', toolIds: [], updatedAt }` |
+| `isToolAllowed(policy, toolName, serverId?)` | Checks if a tool is permitted under the policy |
+| `assertToolAllowed(policy, toolName, serverId?)` | Throws if tool is not allowed |
+| `filterToolsByPolicy(tools, policy, serverId?)` | Filters tool array to only allowed tools |
+| `validateToolPolicyAgainstTools(policy, tools, serverId?)` | Validates all tool IDs correspond to actual tools |
 ```
 
 ## Error Handling

--- a/docs/storage-backends/neon.md
+++ b/docs/storage-backends/neon.md
@@ -90,6 +90,7 @@ CREATE TABLE IF NOT EXISTS public.mcp_sessions (
         CHECK (status IN ('pending', 'active')),
     headers JSONB,
     auth_url TEXT,
+    tool_policy JSONB,
     CONSTRAINT mcp_sessions_user_session_unique
         UNIQUE (user_id, session_id)
 );

--- a/docs/storage-backends/overview.md
+++ b/docs/storage-backends/overview.md
@@ -115,6 +115,7 @@ interface Session {
   updatedAt?: number;
   expiresAt?: number | null;
   headers?: Record<string, string>;
+  toolPolicy?: ToolPolicy;
 }
 ```
 

--- a/docs/storage-backends/supabase.md
+++ b/docs/storage-backends/supabase.md
@@ -92,6 +92,7 @@ CREATE TABLE IF NOT EXISTS public.mcp_sessions (
         CHECK (status IN ('pending', 'active')),
     headers JSONB,
     auth_url TEXT,
+    tool_policy JSONB,
     CONSTRAINT mcp_sessions_user_session_unique
         UNIQUE (user_id, session_id)
 );

--- a/docs/tool-policy/configuration.md
+++ b/docs/tool-policy/configuration.md
@@ -1,0 +1,97 @@
+---
+title: "Configuration"
+sidebarTitle: "Configuration"
+description: "Set up tool policy with SQL storage backends — the tool_policy column is optional and does not require a migration for basic usage."
+---
+
+## Optional Column
+
+The `tool_policy` column on `mcp_sessions` is **optional**. The SDK only writes it when you explicitly provide a `toolPolicy` on the session object. If you never set a policy, no migration is needed — the SDK works without the column.
+
+### Without the Column
+
+If you don't run the tool_policy migration:
+
+- `sessions.create()` omits `tool_policy` from the INSERT
+- `sessions.update()` omits `tool_policy` from the UPDATE unless you pass it
+- `sessions.get()` and `sessions.list()` return `toolPolicy: undefined`, which the SDK treats as `mode: 'all'`
+
+### With the Column
+
+Uncomment the `tool_policy` column in the install schema when you want to persist policies:
+
+**Neon** — `migrations/neon/20260513010000_install_mcp_sessions.sql`:
+```sql
+    auth_url TEXT,
+    -- tool_policy JSONB -- remove the comment to enable
+```
+
+**Supabase** — `migrations/supabase/20260330195700_install_mcp_sessions.sql`:
+```sql
+    auth_url TEXT,
+    -- tool_policy JSONB -- remove the comment to enable
+```
+
+Run `npx mcp-ts neon-init` or `npx mcp-ts supabase-init` (or apply the migration manually) after uncommenting.
+
+### Adding tool_policy to an existing database
+
+If you already have sessions and want to add tool policy support later, the same SQL works for both Neon and Supabase:
+
+```sql
+ALTER TABLE public.mcp_sessions
+ADD COLUMN IF NOT EXISTS tool_policy jsonb NOT NULL DEFAULT '{"mode":"all","toolIds":[]}'::jsonb;
+
+UPDATE public.mcp_sessions
+SET tool_policy = '{"mode":"all","toolIds":[]}'::jsonb
+WHERE tool_policy IS NULL;
+```
+
+This adds the column and backfills existing sessions with the unrestricted `all` policy.
+
+## Setting a Policy
+
+Pass `toolPolicy` when creating or updating a session:
+
+```typescript
+// Allowlist mode: only these two tools
+await sessions.create({
+  sessionId: 'sess-123',
+  userId: 'user-456',
+  serverUrl: 'https://mcp.example.com',
+  callbackUrl: 'https://app.com/callback',
+  transportType: 'streamable-http',
+  toolPolicy: {
+    mode: 'allowlist',
+    toolIds: ['server-a::get_weather', 'server-a::send_email'],
+  },
+});
+
+// Denylist mode: all tools except these
+await sessions.update('user-456', 'sess-123', {
+  toolPolicy: {
+    mode: 'denylist',
+    toolIds: ['server-a::dangerous_tool'],
+  },
+});
+
+// Reset to unrestricted
+await sessions.update('user-456', 'sess-123', {
+  toolPolicy: { mode: 'all', toolIds: [] },
+});
+```
+
+## Enforcing Policies at Runtime
+
+Use the `ToolPolicyGateway` — it wraps a client and enforces the session's policy before every tool call:
+
+```typescript
+import { ToolPolicyGateway } from '@mcp-ts/sdk/server';
+
+const gateway = new ToolPolicyGateway(client, toolPolicy);
+
+// Throws if the tool is not allowed by the policy
+const result = await gateway.callTool('get_weather', { city: 'Tokyo' });
+```
+
+The gateway also filters `listTools()` results to only return allowed tools.

--- a/docs/tool-policy/overview.md
+++ b/docs/tool-policy/overview.md
@@ -1,0 +1,46 @@
+---
+title: "Tool Policy Overview"
+sidebarTitle: "Overview"
+description: "Control which tools an MCP session can access using allowlist, denylist, or unrestricted modes."
+---
+
+Tool Policy lets you restrict which tools an MCP session can call. It is stored as an optional `toolPolicy` field on the `Session` object and persisted in SQL storage backends (Neon, Supabase) when provided.
+
+## How It Works
+
+Each session can carry a `toolPolicy` with one of three modes:
+
+| Mode | Behavior |
+|------|----------|
+| `all` | All tools are allowed (default when no policy is set) |
+| `allowlist` | Only the listed tool IDs are allowed |
+| `denylist` | All tools are allowed **except** the listed tool IDs |
+
+A tool ID is a composite string: `{serverId}::{toolName}` (e.g. `my-server::get_weather`).
+
+## When to Use
+
+- **Multi-tenant deployments** — restrict each session to a subset of tools
+- **Security boundaries** — prevent a session from calling privileged tools
+- **Gradual rollouts** — allowlist tools as they are vetted per session
+
+## Session Data Structure
+
+The `toolPolicy` field is optional on `Session`:
+
+```typescript
+interface Session {
+  sessionId: string;
+  userId: string;
+  // ... other fields
+  toolPolicy?: ToolPolicy;
+}
+
+interface ToolPolicy {
+  mode: 'all' | 'allowlist' | 'denylist';
+  toolIds: string[];
+  updatedAt: number;
+}
+```
+
+When no policy is provided (`undefined`), the SDK treats it as `all` — all tools are permitted.

--- a/migrations/neon/20260513010000_install_mcp_sessions.sql
+++ b/migrations/neon/20260513010000_install_mcp_sessions.sql
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS public.mcp_sessions (
         CHECK (status IN ('pending', 'active')),
     headers JSONB,
     auth_url TEXT,
+    -- tool_policy JSONB -- optional, see docs/tool-policy
     CONSTRAINT mcp_sessions_user_session_unique
         UNIQUE (user_id, session_id)
 );

--- a/migrations/neon/20260702010000_add_mcp_session_tool_policy.sql
+++ b/migrations/neon/20260702010000_add_mcp_session_tool_policy.sql
@@ -1,0 +1,7 @@
+ALTER TABLE public.mcp_sessions
+ADD COLUMN IF NOT EXISTS tool_policy jsonb NOT NULL DEFAULT '{"mode":"all","toolIds":[]}'::jsonb;
+
+UPDATE public.mcp_sessions
+SET tool_policy = '{"mode":"all","toolIds":[]}'::jsonb
+WHERE tool_policy IS NULL;
+

--- a/migrations/neon/20260702010000_add_mcp_session_tool_policy.sql
+++ b/migrations/neon/20260702010000_add_mcp_session_tool_policy.sql
@@ -1,7 +1,0 @@
-ALTER TABLE public.mcp_sessions
-ADD COLUMN IF NOT EXISTS tool_policy jsonb NOT NULL DEFAULT '{"mode":"all","toolIds":[]}'::jsonb;
-
-UPDATE public.mcp_sessions
-SET tool_policy = '{"mode":"all","toolIds":[]}'::jsonb
-WHERE tool_policy IS NULL;
-

--- a/migrations/supabase/20260330195700_install_mcp_sessions.sql
+++ b/migrations/supabase/20260330195700_install_mcp_sessions.sql
@@ -15,6 +15,7 @@ CREATE TABLE IF NOT EXISTS public.mcp_sessions (
         CHECK (status IN ('pending', 'active')),
     headers JSONB,
     auth_url TEXT,
+    -- tool_policy JSONB -- optional, see docs/tool-policy
     CONSTRAINT mcp_sessions_user_session_unique
         UNIQUE (user_id, session_id)
 );

--- a/migrations/supabase/20260702010000_add_mcp_session_tool_policy.sql
+++ b/migrations/supabase/20260702010000_add_mcp_session_tool_policy.sql
@@ -1,0 +1,7 @@
+ALTER TABLE public.mcp_sessions
+ADD COLUMN IF NOT EXISTS tool_policy jsonb NOT NULL DEFAULT '{"mode":"all","toolIds":[]}'::jsonb;
+
+UPDATE public.mcp_sessions
+SET tool_policy = '{"mode":"all","toolIds":[]}'::jsonb
+WHERE tool_policy IS NULL;
+

--- a/migrations/supabase/20260702010000_add_mcp_session_tool_policy.sql
+++ b/migrations/supabase/20260702010000_add_mcp_session_tool_policy.sql
@@ -1,7 +1,0 @@
-ALTER TABLE public.mcp_sessions
-ADD COLUMN IF NOT EXISTS tool_policy jsonb NOT NULL DEFAULT '{"mode":"all","toolIds":[]}'::jsonb;
-
-UPDATE public.mcp_sessions
-SET tool_policy = '{"mode":"all","toolIds":[]}'::jsonb
-WHERE tool_policy IS NULL;
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "@mcp-ts/sdk",
-  "version": "1.6.2",
+  "version": "2.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-ts/sdk",
-      "version": "1.6.2",
+      "version": "2.4.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.5.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "json-schema": "^0.4.0",
-        "json-schema-to-zod": "^2.7.0",
         "nanoid": "^5.1.6"
       },
       "bin": {
@@ -33,6 +32,7 @@
         "better-sqlite3": "^12.6.2",
         "ioredis": "^5.9.2",
         "ioredis-mock": "^8.13.1",
+        "json-schema-to-zod": "^2.7.0",
         "playwright": "^1.58.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -48,10 +48,12 @@
       "peerDependencies": {
         "@ag-ui/client": ">=0.0.40",
         "@langchain/core": "^1.1.39",
+        "@neondatabase/serverless": "^1.1.0",
         "@supabase/supabase-js": "^2.0.0",
         "ai": "^6.0.0",
         "better-sqlite3": "^12.0.0",
         "ioredis": "^5.0.0",
+        "json-schema-to-zod": "^2.7.0",
         "react": ">=18.0.0",
         "rxjs": ">=7.0.0",
         "zod": "^3.23.0"
@@ -61,6 +63,9 @@
           "optional": true
         },
         "@langchain/core": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
           "optional": true
         },
         "@supabase/supabase-js": {
@@ -73,6 +78,9 @@
           "optional": true
         },
         "ioredis": {
+          "optional": true
+        },
+        "json-schema-to-zod": {
           "optional": true
         },
         "react": {
@@ -2792,6 +2800,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/json-schema-to-zod/-/json-schema-to-zod-2.7.0.tgz",
       "integrity": "sha512-eW59l3NQ6sa3HcB+Ahf7pP6iGU7MY4we5JsPqXQ2ZcIPF8QxSg/lkY8lN0Js/AG0NjMbk+nZGUfHlceiHF+bwQ==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "json-schema-to-zod": "dist/cjs/cli.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-ts/sdk",
-  "version": "2.4.5",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-ts/sdk",
-      "version": "2.4.5",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-ts/sdk",
-  "version": "2.4.5",
+  "version": "2.5.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/code-mode/package.json
+++ b/packages/code-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-ts/codemode",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/code-mode/src/sources/mcp.ts
+++ b/packages/code-mode/src/sources/mcp.ts
@@ -16,7 +16,7 @@ export interface ToolClient {
   callTool(name: string, args: Record<string, unknown>): Promise<unknown>;
   getServerId?(): string | undefined;
   getServerName?(): string | undefined;
-  getServerUrl?(): string;
+  getServerUrl?(): string | undefined;
 }
 
 export interface ToolClientProvider {

--- a/packages/tool-router/package.json
+++ b/packages/tool-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-ts/tool-router",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/tool-router/src/adapters/mcp.ts
+++ b/packages/tool-router/src/adapters/mcp.ts
@@ -12,6 +12,7 @@ export interface ToolClient {
   tools?(): Promise<Record<string, unknown>>;
   getServerId?(): string | undefined;
   getServerName?(): string | undefined;
+  getServerUrl?(): string | undefined;
 }
 
 export interface ToolClientProvider {

--- a/src/adapters/agui-adapter.ts
+++ b/src/adapters/agui-adapter.ts
@@ -29,6 +29,7 @@
 import { MCPClient } from '../server/mcp/oauth-client.js';
 import { MultiSessionClient } from '../server/mcp/multi-session-client.js';
 import { ToolRouter } from '../shared/tool-router.js';
+import type { ToolClient } from '../shared/types.js';
 import { executeMetaTool, isMetaTool } from '../shared/meta-tools.js';
 
 /**
@@ -184,7 +185,7 @@ export class AguiAdapter {
         return typeof (this.client as any).getClients === 'function';
     }
 
-    private async transformTools(client: MCPClient): Promise<AguiTool[]> {
+    private async transformTools(client: ToolClient): Promise<AguiTool[]> {
         if (!client.isConnected()) return [];
 
         const result = await client.listTools();
@@ -214,7 +215,7 @@ export class AguiAdapter {
         });
     }
 
-    private async transformToolDefinitions(client: MCPClient): Promise<AguiToolDefinition[]> {
+    private async transformToolDefinitions(client: ToolClient): Promise<AguiToolDefinition[]> {
         if (!client.isConnected()) return [];
 
         const result = await client.listTools();
@@ -299,3 +300,6 @@ export class AguiAdapter {
         return `tool_${normalized}_${toolName}`;
     }
 }
+
+
+

--- a/src/adapters/ai-adapter.ts
+++ b/src/adapters/ai-adapter.ts
@@ -3,6 +3,7 @@ import { MultiSessionClient } from '../server/mcp/multi-session-client';
 import type { JSONSchema7 } from 'json-schema';
 import type { ToolSet } from 'ai';
 import { ToolRouter } from '../shared/tool-router.js';
+import type { ToolClient } from '../shared/types.js';
 import { executeMetaTool, isMetaTool } from '../shared/meta-tools.js';
 
 export interface AIAdapterOptions {
@@ -54,7 +55,7 @@ export class AIAdapter {
         }
     }
 
-    private async transformTools(client: MCPClient): Promise<ToolSet> {
+    private async transformTools(client: ToolClient): Promise<ToolSet> {
         // Safe check for isConnected method (duck typing for bundler compatibility)
         const isConnected = typeof client.isConnected === 'function'
             ? client.isConnected()
@@ -217,3 +218,4 @@ export class AIAdapter {
         return new AIAdapter(client, options).getTools();
     }
 }
+

--- a/src/adapters/langchain-adapter.ts
+++ b/src/adapters/langchain-adapter.ts
@@ -3,6 +3,7 @@ import { MultiSessionClient } from '../server/mcp/multi-session-client';
 import type { DynamicStructuredTool, StructuredTool } from '@langchain/core/tools';
 import type { z } from 'zod';
 import { ToolRouter } from '../shared/tool-router.js';
+import type { ToolClient } from '../shared/types.js';
 import { executeMetaTool, isMetaTool } from '../shared/meta-tools.js';
 
 export interface LangChainAdapterOptions {
@@ -58,7 +59,7 @@ export class LangChainAdapter {
         }
     }
 
-    private async transformTools(client: MCPClient): Promise<StructuredTool[]> {
+    private async transformTools(client: ToolClient): Promise<StructuredTool[]> {
         if (!client.isConnected()) {
             return [];
         }
@@ -66,7 +67,7 @@ export class LangChainAdapter {
         await this.ensureDependencies();
 
         const result = await client.listTools();
-        const prefix = this.options.prefix ?? client.getServerId()?.replace(/-/g, '').substring(0, 8) ?? 'mcp';
+        const prefix = this.options.prefix ?? client.getServerId?.()?.replace(/-/g, '').substring(0, 8) ?? 'mcp';
 
         return result.tools.map((tool) => {
             // In a real implementation, you would use a library like 'json-schema-to-zod'
@@ -127,7 +128,7 @@ export class LangChainAdapter {
                 try {
                     return await this.transformTools(client);
                 } catch (error) {
-                    console.error(`[LangChainAdapter] Failed to fetch tools from ${client.getServerId()}:`, error);
+                    console.error(`[LangChainAdapter] Failed to fetch tools from ${client.getServerId?.() ?? "unknown"}:`, error);
                     return [];
                 }
             })
@@ -203,3 +204,4 @@ export class LangChainAdapter {
         return new LangChainAdapter(client, options).getTools();
     }
 }
+

--- a/src/adapters/mastra-adapter.ts
+++ b/src/adapters/mastra-adapter.ts
@@ -1,5 +1,6 @@
 import { MCPClient } from '../server/mcp/oauth-client';
 import { MultiSessionClient } from '../server/mcp/multi-session-client';
+import type { ToolClient } from '../shared/types.js';
 import type { z } from 'zod';
 
 export interface MastraAdapterOptions {
@@ -51,7 +52,7 @@ export class MastraAdapter {
 
 
 
-    private async transformTools(client: MCPClient): Promise<Record<string, MastraTool>> {
+    private async transformTools(client: ToolClient): Promise<Record<string, MastraTool>> {
         if (!client.isConnected()) {
             return {};
         }
@@ -59,7 +60,7 @@ export class MastraAdapter {
         await this.ensureZod();
 
         const result = await client.listTools();
-        const prefix = this.options.prefix ?? client.getServerId()?.replace(/-/g, '').substring(0, 8) ?? 'mcp';
+        const prefix = this.options.prefix ?? client.getServerId?.()?.replace(/-/g, '').substring(0, 8) ?? 'mcp';
         const tools: Record<string, MastraTool> = {};
 
         for (const tool of result.tools) {
@@ -113,7 +114,7 @@ export class MastraAdapter {
                 try {
                     return await this.transformTools(client);
                 } catch (error) {
-                    console.error(`[MastraAdapter] Failed to fetch tools from ${client.getServerId()}:`, error);
+                    console.error(`[MastraAdapter] Failed to fetch tools from ${client.getServerId?.() ?? "unknown"}:`, error);
                     return {};
                 }
             })
@@ -128,3 +129,4 @@ export class MastraAdapter {
         return new MastraAdapter(client, options).getTools();
     }
 }
+

--- a/src/client/core/sse-client.ts
+++ b/src/client/core/sse-client.ts
@@ -25,8 +25,8 @@ import type {
   ListToolsRpcResult,
   ListPromptsResult,
   ListResourcesResult,
-  UpdateSessionToolPolicyResult,
-  GetSessionToolAccessResult,
+  SetToolPolicyResult,
+  GetToolPolicyResult,
   ToolPolicy,
 } from '../../shared/types.js';
 
@@ -102,15 +102,15 @@ export class SSEClient {
     return this.sendRequest<DisconnectResult>('disconnect', { sessionId });
   }
 
-  async updateSessionToolPolicy(
+  async setToolPolicy(
     sessionId: string,
     toolPolicy: Pick<ToolPolicy, 'mode'> & { toolIds?: string[] }
-  ): Promise<UpdateSessionToolPolicyResult> {
-    return this.sendRequest<UpdateSessionToolPolicyResult>('updateSessionToolPolicy', { sessionId, toolPolicy });
+  ): Promise<SetToolPolicyResult> {
+    return this.sendRequest<SetToolPolicyResult>('setToolPolicy', { sessionId, toolPolicy });
   }
 
-  async getSessionToolAccess(sessionId: string): Promise<GetSessionToolAccessResult> {
-    return this.sendRequest<GetSessionToolAccessResult>('getSessionToolAccess', { sessionId });
+  async getToolPolicy(sessionId: string): Promise<GetToolPolicyResult> {
+    return this.sendRequest<GetToolPolicyResult>('getToolPolicy', { sessionId });
   }
 
   async listTools(sessionId: string): Promise<ListToolsRpcResult> {

--- a/src/client/core/sse-client.ts
+++ b/src/client/core/sse-client.ts
@@ -25,6 +25,9 @@ import type {
   ListToolsRpcResult,
   ListPromptsResult,
   ListResourcesResult,
+  UpdateSessionToolPolicyResult,
+  GetSessionToolAccessResult,
+  ToolPolicy,
 } from '../../shared/types.js';
 
 export interface SSEClientOptions {
@@ -97,6 +100,17 @@ export class SSEClient {
 
   async disconnectFromServer(sessionId: string): Promise<DisconnectResult> {
     return this.sendRequest<DisconnectResult>('disconnect', { sessionId });
+  }
+
+  async updateSessionToolPolicy(
+    sessionId: string,
+    toolPolicy: Pick<ToolPolicy, 'mode'> & { toolIds?: string[] }
+  ): Promise<UpdateSessionToolPolicyResult> {
+    return this.sendRequest<UpdateSessionToolPolicyResult>('updateSessionToolPolicy', { sessionId, toolPolicy });
+  }
+
+  async getSessionToolAccess(sessionId: string): Promise<GetSessionToolAccessResult> {
+    return this.sendRequest<GetSessionToolAccessResult>('getSessionToolAccess', { sessionId });
   }
 
   async listTools(sessionId: string): Promise<ListToolsRpcResult> {
@@ -367,3 +381,6 @@ export class SSEClient {
     }
   }
 }
+
+
+

--- a/src/client/react/use-mcp.ts
+++ b/src/client/react/use-mcp.ts
@@ -18,6 +18,9 @@ import type {
   ListPromptsResult,
   ListResourcesResult,
   SessionInfo,
+  ToolPolicy,
+  UpdateSessionToolPolicyResult,
+  GetSessionToolAccessResult,
 } from '../../shared/types';
 
 export interface UseMcpOptions {
@@ -89,6 +92,7 @@ export interface McpConnection {
   error?: string;
   createdAt?: Date;
   updatedAt?: Date;
+  toolPolicy?: ToolPolicy;
 }
 
 export interface McpClient {
@@ -192,6 +196,19 @@ export interface McpClient {
    * List available tools for a session
    */
   listTools: (sessionId: string) => Promise<ListToolsRpcResult>;
+
+  /**
+   * Update per-session tool access policy
+   */
+  updateToolPolicy: (
+    sessionId: string,
+    toolPolicy: Pick<ToolPolicy, 'mode'> & { toolIds?: string[] }
+  ) => Promise<UpdateSessionToolPolicyResult>;
+
+  /**
+   * Get all tools and effective policy state for access management
+   */
+  getToolAccess: (sessionId: string) => Promise<GetSessionToolAccessResult>;
 
   /**
    * List available prompts for a session
@@ -428,6 +445,7 @@ export function useMcp(options: UseMcpOptions): McpClient {
             state: getInitialConnectionState(s.status),
             createdAt: new Date(s.createdAt),
             updatedAt: new Date(s.updatedAt ?? s.createdAt),
+            toolPolicy: s.toolPolicy,
             tools: [],
           }))
         );
@@ -608,6 +626,42 @@ export function useMcp(options: UseMcpOptions): McpClient {
   }, []);
 
   /**
+   * Update tool access policy for a session
+   */
+  const updateToolPolicy = useCallback(async (
+    sessionId: string,
+    toolPolicy: Pick<ToolPolicy, 'mode'> & { toolIds?: string[] }
+  ): Promise<UpdateSessionToolPolicyResult> => {
+    if (!clientRef.current) {
+      throw new Error('SSE client not initialized');
+    }
+
+    const result = await clientRef.current.updateSessionToolPolicy(sessionId, toolPolicy);
+    if (isMountedRef.current) {
+      setConnections((prev: McpConnection[]) => prev.map((connection) =>
+        connection.sessionId === sessionId
+          ? {
+              ...connection,
+              toolPolicy: result.toolPolicy,
+              tools: result.tools,
+              updatedAt: new Date(),
+            }
+          : connection
+      ));
+    }
+    return result;
+  }, []);
+  /**
+   * Get all tools with effective access state for a session
+   */
+  const getToolAccess = useCallback(async (sessionId: string): Promise<GetSessionToolAccessResult> => {
+    if (!clientRef.current) {
+      throw new Error('SSE client not initialized');
+    }
+
+    return await clientRef.current.getSessionToolAccess(sessionId);
+  }, []);
+  /**
    * List prompts
    */
   const listPrompts = useCallback(async (sessionId: string): Promise<ListPromptsResult> => {
@@ -700,6 +754,8 @@ export function useMcp(options: UseMcpOptions): McpClient {
       resumeAuth,
       callTool,
       listTools,
+      updateToolPolicy,
+      getToolAccess,
       listPrompts,
       getPrompt,
       listResources,
@@ -724,6 +780,8 @@ export function useMcp(options: UseMcpOptions): McpClient {
       resumeAuth,
       callTool,
       listTools,
+      updateToolPolicy,
+      getToolAccess,
       listPrompts,
       getPrompt,
       listResources,
@@ -732,3 +790,8 @@ export function useMcp(options: UseMcpOptions): McpClient {
     ]
   );
 }
+
+
+
+
+

--- a/src/client/react/use-mcp.ts
+++ b/src/client/react/use-mcp.ts
@@ -19,8 +19,8 @@ import type {
   ListResourcesResult,
   SessionInfo,
   ToolPolicy,
-  UpdateSessionToolPolicyResult,
-  GetSessionToolAccessResult,
+  SetToolPolicyResult,
+  GetToolPolicyResult,
 } from '../../shared/types';
 
 export interface UseMcpOptions {
@@ -203,12 +203,12 @@ export interface McpClient {
   updateToolPolicy: (
     sessionId: string,
     toolPolicy: Pick<ToolPolicy, 'mode'> & { toolIds?: string[] }
-  ) => Promise<UpdateSessionToolPolicyResult>;
+  ) => Promise<SetToolPolicyResult>;
 
   /**
    * Get all tools and effective policy state for access management
    */
-  getToolAccess: (sessionId: string) => Promise<GetSessionToolAccessResult>;
+  getToolAccess: (sessionId: string) => Promise<GetToolPolicyResult>;
 
   /**
    * List available prompts for a session
@@ -631,12 +631,12 @@ export function useMcp(options: UseMcpOptions): McpClient {
   const updateToolPolicy = useCallback(async (
     sessionId: string,
     toolPolicy: Pick<ToolPolicy, 'mode'> & { toolIds?: string[] }
-  ): Promise<UpdateSessionToolPolicyResult> => {
+  ): Promise<SetToolPolicyResult> => {
     if (!clientRef.current) {
       throw new Error('SSE client not initialized');
     }
 
-    const result = await clientRef.current.updateSessionToolPolicy(sessionId, toolPolicy);
+    const result = await clientRef.current.setToolPolicy(sessionId, toolPolicy);
     if (isMountedRef.current) {
       setConnections((prev: McpConnection[]) => prev.map((connection) =>
         connection.sessionId === sessionId
@@ -654,12 +654,12 @@ export function useMcp(options: UseMcpOptions): McpClient {
   /**
    * Get all tools with effective access state for a session
    */
-  const getToolAccess = useCallback(async (sessionId: string): Promise<GetSessionToolAccessResult> => {
+  const getToolAccess = useCallback(async (sessionId: string): Promise<GetToolPolicyResult> => {
     if (!clientRef.current) {
       throw new Error('SSE client not initialized');
     }
 
-    return await clientRef.current.getSessionToolAccess(sessionId);
+    return await clientRef.current.getToolPolicy(sessionId);
   }, []);
   /**
    * List prompts

--- a/src/server/handlers/sse-handler.ts
+++ b/src/server/handlers/sse-handler.ts
@@ -32,13 +32,19 @@ import type {
   ListPromptsResult,
   ListResourcesResult,
   CallToolResult,
+  UpdateSessionToolPolicyParams,
+  UpdateSessionToolPolicyResult,
+  GetSessionToolAccessParams,
+  GetSessionToolAccessResult,
 } from '../../shared/types.js';
 import { RpcErrorCodes } from '../../shared/errors.js';
 import { UnauthorizedError } from '../../shared/errors.js';
 import { isConnectionEvent, isRpcResponseEvent } from '../../shared/event-routing.js';
 import { parseOAuthState } from '../../shared/utils.js';
 import { MCPClient } from '../mcp/oauth-client.js';
-import { sessions, generateServerId } from '../storage/index.js';
+import { sessions, generateServerId, type Session } from '../storage/index.js';
+import { createToolId, isToolAllowed, normalizeToolPolicyForUpdate, validateToolPolicyAgainstTools } from '../storage/tool-policy.js';
+import { createToolPolicyGateway } from '../mcp/tool-policy-gateway.js';
 
 // ============================================
 // Types & Interfaces
@@ -149,7 +155,7 @@ export class SSEConnectionManager {
    */
   async handleRequest(request: McpRpcRequest): Promise<McpRpcResponse> {
     try {
-      let result: SessionListResult | ConnectResult | DisconnectResult | GetSessionResult | FinishAuthResult | ListToolsRpcResult | ListPromptsResult | ListResourcesResult | unknown;
+      let result: SessionListResult | ConnectResult | DisconnectResult | GetSessionResult | FinishAuthResult | ListToolsRpcResult | UpdateSessionToolPolicyResult | GetSessionToolAccessResult | ListPromptsResult | ListResourcesResult | unknown;
 
       switch (request.method) {
         case 'listSessions':
@@ -166,6 +172,14 @@ export class SSEConnectionManager {
 
         case 'listTools':
           result = await this.listTools(request.params as SessionParams);
+          break;
+
+        case 'updateSessionToolPolicy':
+          result = await this.updateSessionToolPolicy(request.params as UpdateSessionToolPolicyParams);
+          break;
+
+        case 'getSessionToolAccess':
+          result = await this.getSessionToolAccess(request.params as GetSessionToolAccessParams);
           break;
 
         case 'callTool':
@@ -241,6 +255,7 @@ export class SSEConnectionManager {
         createdAt: s.createdAt,
         updatedAt: s.updatedAt ?? s.createdAt,
         status: s.status ?? 'pending',
+        toolPolicy: s.toolPolicy,
       })),
     };
   }
@@ -315,8 +330,8 @@ export class SSEConnectionManager {
       // Attempt connection
       await client.connect();
 
-      // Fetch tools
-      await client.listTools();
+      // Fetch policy-filtered tools for agent-facing discovery
+      await this.listPolicyFilteredTools(sessionId);
 
       return {
         sessionId,
@@ -407,23 +422,109 @@ export class SSEConnectionManager {
     return client;
   }
 
+  private async listPolicyFilteredTools(sessionId: string): Promise<{ session: Session; result: ListToolsRpcResult }> {
+    const session = await sessions.get(this.userId, sessionId);
+    if (!session) {
+      throw new Error('Session not found');
+    }
+
+    const client = await this.getOrCreateClient(sessionId);
+    const gateway = createToolPolicyGateway(this.userId, sessionId, client);
+    const result = await gateway.listTools();
+
+    this.emitConnectionEvent({
+      type: 'tools_discovered',
+      sessionId,
+      serverId: session.serverId ?? 'unknown',
+      toolCount: result.tools.length,
+      tools: result.tools,
+      timestamp: Date.now(),
+    });
+
+    return { session, result };
+  }
   /**
    * List tools from a session
    */
   private async listTools(params: SessionParams): Promise<ListToolsRpcResult> {
     const { sessionId } = params;
-    const client = await this.getOrCreateClient(sessionId);
-    const result = await client.listTools();
+    const { result } = await this.listPolicyFilteredTools(sessionId);
     return { tools: result.tools };
   }
 
+  /**
+   * Get all raw tools with effective access state for management UI.
+   */
+  private async getSessionToolAccess(params: GetSessionToolAccessParams): Promise<GetSessionToolAccessResult> {
+    const { sessionId } = params;
+    const session = await sessions.get(this.userId, sessionId);
+    if (!session) {
+      throw new Error('Session not found');
+    }
+
+    const client = await this.getOrCreateClient(sessionId);
+    const allTools = await client.listTools({ emitDiscoveryEvent: false });
+    const toolPolicy = session.toolPolicy ?? {
+      mode: 'all' as const,
+      toolIds: [],
+      updatedAt: session.updatedAt ?? session.createdAt,
+    };
+    const serverId = session.serverId ?? 'unknown';
+    const tools = allTools.tools.map((tool) => ({
+      ...tool,
+      toolId: createToolId(serverId, tool.name),
+      allowed: isToolAllowed(toolPolicy, tool.name, session.serverId),
+    }));
+
+    return {
+      toolPolicy,
+      tools,
+      toolCount: tools.length,
+      allowedToolCount: tools.filter((tool) => tool.allowed).length,
+    };
+  }
+
+  /**
+   * Update per-session tool access policy.
+   */
+  private async updateSessionToolPolicy(params: UpdateSessionToolPolicyParams): Promise<UpdateSessionToolPolicyResult> {
+    const { sessionId } = params;
+    const session = await sessions.get(this.userId, sessionId);
+    if (!session) {
+      throw new Error('Session not found');
+    }
+
+    const client = await this.getOrCreateClient(sessionId);
+    const allTools = await client.listTools({ emitDiscoveryEvent: false });
+    const toolPolicy = normalizeToolPolicyForUpdate(params.toolPolicy);
+    validateToolPolicyAgainstTools(toolPolicy, allTools.tools, session.serverId);
+
+    await sessions.update(this.userId, sessionId, { toolPolicy });
+
+    const filteredTools = createToolPolicyGateway(this.userId, sessionId, client).filterTools({ ...session, toolPolicy }, allTools.tools);
+    this.emitConnectionEvent({
+      type: 'tools_discovered',
+      sessionId,
+      serverId: session.serverId ?? 'unknown',
+      toolCount: filteredTools.length,
+      tools: filteredTools,
+      timestamp: Date.now(),
+    });
+
+    return {
+      success: true,
+      toolPolicy,
+      tools: filteredTools,
+      toolCount: filteredTools.length,
+    };
+  }
   /**
    * Call a tool on the MCP server
    */
   private async callTool(params: CallToolParams): Promise<CallToolResult> {
     const { sessionId, toolName, toolArgs } = params;
     const client = await this.getOrCreateClient(sessionId);
-    const result = await client.callTool(toolName, toolArgs);
+    const result = await createToolPolicyGateway(this.userId, sessionId, client).callTool(toolName, toolArgs);
 
     // Inject sessionId into meta so client knows who handled it
     // This allows AppHost to auto-launch without scanning all sessions
@@ -485,7 +586,7 @@ export class SSEConnectionManager {
       await client.connect();
       this.clients.set(sessionId, client);
 
-      const tools = await client.listTools();
+      const { result: tools } = await this.listPolicyFilteredTools(sessionId);
 
       return { success: true, toolCount: tools.tools.length };
     } catch (error) {
@@ -541,7 +642,7 @@ export class SSEConnectionManager {
       await client.finishAuth(code, oauthState);
       this.clients.set(sessionId, client);
 
-      const tools = await client.listTools();
+      const { result: tools } = await this.listPolicyFilteredTools(sessionId);
 
       return { success: true, toolCount: tools.tools.length };
     } catch (error) {
@@ -687,3 +788,8 @@ function writeSSEEvent(res: { write: Function }, event: string, data: unknown): 
   res.write(`event: ${event}\n`);
   res.write(`data: ${JSON.stringify(data)}\n\n`);
 }
+
+
+
+
+

--- a/src/server/handlers/sse-handler.ts
+++ b/src/server/handlers/sse-handler.ts
@@ -32,10 +32,10 @@ import type {
   ListPromptsResult,
   ListResourcesResult,
   CallToolResult,
-  UpdateSessionToolPolicyParams,
-  UpdateSessionToolPolicyResult,
-  GetSessionToolAccessParams,
-  GetSessionToolAccessResult,
+  SetToolPolicyParams,
+  SetToolPolicyResult,
+  GetToolPolicyParams,
+  GetToolPolicyResult,
 } from '../../shared/types.js';
 import { RpcErrorCodes } from '../../shared/errors.js';
 import { UnauthorizedError } from '../../shared/errors.js';
@@ -155,7 +155,7 @@ export class SSEConnectionManager {
    */
   async handleRequest(request: McpRpcRequest): Promise<McpRpcResponse> {
     try {
-      let result: SessionListResult | ConnectResult | DisconnectResult | GetSessionResult | FinishAuthResult | ListToolsRpcResult | UpdateSessionToolPolicyResult | GetSessionToolAccessResult | ListPromptsResult | ListResourcesResult | unknown;
+      let result: SessionListResult | ConnectResult | DisconnectResult | GetSessionResult | FinishAuthResult | ListToolsRpcResult | SetToolPolicyResult | GetToolPolicyResult | ListPromptsResult | ListResourcesResult | unknown;
 
       switch (request.method) {
         case 'listSessions':
@@ -174,12 +174,12 @@ export class SSEConnectionManager {
           result = await this.listTools(request.params as SessionParams);
           break;
 
-        case 'updateSessionToolPolicy':
-          result = await this.updateSessionToolPolicy(request.params as UpdateSessionToolPolicyParams);
+        case 'setToolPolicy':
+          result = await this.setToolPolicy(request.params as SetToolPolicyParams);
           break;
 
-        case 'getSessionToolAccess':
-          result = await this.getSessionToolAccess(request.params as GetSessionToolAccessParams);
+        case 'getToolPolicy':
+          result = await this.getToolPolicy(request.params as GetToolPolicyParams);
           break;
 
         case 'callTool':
@@ -455,7 +455,7 @@ export class SSEConnectionManager {
   /**
    * Get all raw tools with effective access state for management UI.
    */
-  private async getSessionToolAccess(params: GetSessionToolAccessParams): Promise<GetSessionToolAccessResult> {
+  private async getToolPolicy(params: GetToolPolicyParams): Promise<GetToolPolicyResult> {
     const { sessionId } = params;
     const session = await sessions.get(this.userId, sessionId);
     if (!session) {
@@ -463,7 +463,7 @@ export class SSEConnectionManager {
     }
 
     const client = await this.getOrCreateClient(sessionId);
-    const allTools = await client.listTools({ emitDiscoveryEvent: false });
+    const allTools = await client.fetchTools();
     const toolPolicy = session.toolPolicy ?? {
       mode: 'all' as const,
       toolIds: [],
@@ -487,7 +487,7 @@ export class SSEConnectionManager {
   /**
    * Update per-session tool access policy.
    */
-  private async updateSessionToolPolicy(params: UpdateSessionToolPolicyParams): Promise<UpdateSessionToolPolicyResult> {
+  private async setToolPolicy(params: SetToolPolicyParams): Promise<SetToolPolicyResult> {
     const { sessionId } = params;
     const session = await sessions.get(this.userId, sessionId);
     if (!session) {
@@ -495,7 +495,7 @@ export class SSEConnectionManager {
     }
 
     const client = await this.getOrCreateClient(sessionId);
-    const allTools = await client.listTools({ emitDiscoveryEvent: false });
+    const allTools = await client.fetchTools();
     const toolPolicy = normalizeToolPolicyForUpdate(params.toolPolicy);
     validateToolPolicyAgainstTools(toolPolicy, allTools.tools, session.serverId);
 
@@ -788,6 +788,7 @@ function writeSSEEvent(res: { write: Function }, event: string, data: unknown): 
   res.write(`event: ${event}\n`);
   res.write(`data: ${JSON.stringify(data)}\n\n`);
 }
+
 
 
 

--- a/src/server/mcp/multi-session-client.ts
+++ b/src/server/mcp/multi-session-client.ts
@@ -1,6 +1,7 @@
 import { MCPClient } from './oauth-client.js';
 import { sessions, type Session } from '../storage/index.js';
-import type { ToolClientProvider } from '../../shared/types.js';
+import type { ToolClient, ToolClientProvider } from '../../shared/types.js';
+import { createToolPolicyGateway } from './tool-policy-gateway.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -148,8 +149,10 @@ export class MultiSessionClient implements ToolClientProvider {
      * Use this to enumerate available tools across all connected servers,
      * or to route a tool call to the right client by `serverId`.
      */
-    getClients(): MCPClient[] {
-        return this.clients;
+    getClients(): ToolClient[] {
+        return this.clients.map((client) =>
+            createToolPolicyGateway(this.userId, client.getSessionId(), client)
+        );
     }
 
     /**
@@ -321,3 +324,4 @@ export class MultiSessionClient implements ToolClientProvider {
         );
     }
 }
+

--- a/src/server/mcp/oauth-client.ts
+++ b/src/server/mcp/oauth-client.ts
@@ -786,7 +786,7 @@ export class MCPClient {
    * @returns List of tools with their schemas and descriptions
    * @throws {Error} When client is not connected
    */
-  async listTools(): Promise<ListToolsResult> {
+  async listTools(options: { emitDiscoveryEvent?: boolean } = {}): Promise<ListToolsResult> {
     this.emitStateChange('DISCOVERING');
 
     try {
@@ -799,7 +799,7 @@ export class MCPClient {
         this.client!.request(request, ListToolsResultSchema)
       );
 
-      if (this.serverId) {
+      if (options.emitDiscoveryEvent !== false && this.serverId) {
         this._onConnectionEvent.fire({
           type: 'tools_discovered',
           sessionId: this.sessionId,
@@ -830,7 +830,6 @@ export class MCPClient {
    * @throws {Error} When client is not connected
    */
   async callTool(toolName: string, toolArgs: Record<string, unknown>): Promise<CallToolResult> {
-
     const request: CallToolRequest = {
       method: 'tools/call',
       params: {
@@ -1173,3 +1172,12 @@ export class MCPClient {
   }
 
 }
+
+
+
+
+
+
+
+
+

--- a/src/server/mcp/oauth-client.ts
+++ b/src/server/mcp/oauth-client.ts
@@ -782,24 +782,32 @@ export class MCPClient {
   }
 
   /**
+   * Lists all available tools from the connected MCP server without emitting discovery events.
+   * Gateways use this to apply policy before publishing tools to agents or UI state.
+   */
+  async fetchTools(): Promise<ListToolsResult> {
+    const request: ListToolsRequest = {
+      method: 'tools/list',
+      params: {},
+    };
+
+    return await this.withRetry(() =>
+      this.client!.request(request, ListToolsResultSchema)
+    );
+  }
+
+  /**
    * Lists all available tools from the connected MCP server
    * @returns List of tools with their schemas and descriptions
    * @throws {Error} When client is not connected
    */
-  async listTools(options: { emitDiscoveryEvent?: boolean } = {}): Promise<ListToolsResult> {
+  async listTools(): Promise<ListToolsResult> {
     this.emitStateChange('DISCOVERING');
 
     try {
-      const request: ListToolsRequest = {
-        method: 'tools/list',
-        params: {},
-      };
+      const result = await this.fetchTools();
 
-      const result = await this.withRetry(() =>
-        this.client!.request(request, ListToolsResultSchema)
-      );
-
-      if (options.emitDiscoveryEvent !== false && this.serverId) {
+      if (this.serverId) {
         this._onConnectionEvent.fire({
           type: 'tools_discovered',
           sessionId: this.sessionId,
@@ -821,7 +829,6 @@ export class MCPClient {
       throw error;
     }
   }
-
   /**
    * Executes a tool on the connected MCP server
    * @param toolName - Name of the tool to execute

--- a/src/server/mcp/tool-policy-gateway.ts
+++ b/src/server/mcp/tool-policy-gateway.ts
@@ -1,0 +1,84 @@
+import type { Tool, ListToolsResult, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { ToolClient } from '../../shared/types.js';
+import { sessions } from '../storage/index.js';
+import type { Session } from '../storage/types.js';
+import { assertToolAllowed, filterToolsByPolicy } from '../storage/tool-policy.js';
+
+type RawToolClient = ToolClient & {
+    listTools(options?: { emitDiscoveryEvent?: boolean }): Promise<{ tools: Tool[] }>;
+    callTool(name: string, args: Record<string, unknown>): Promise<CallToolResult>;
+};
+
+export class ToolPolicyGateway implements ToolClient {
+    constructor(
+        private readonly userId: string,
+        private readonly sessionId: string,
+        private readonly client: RawToolClient
+    ) {}
+
+    isConnected(): boolean {
+        return this.client.isConnected();
+    }
+
+    getServerId(): string | undefined {
+        return this.client.getServerId?.();
+    }
+
+    getServerName(): string | undefined {
+        return this.client.getServerName?.();
+    }
+
+    getSessionId(): string {
+        return this.client.getSessionId?.() ?? this.sessionId;
+    }
+
+    async listTools(): Promise<ListToolsResult> {
+        const session = await this.getSession();
+        const result = await this.client.listTools({ emitDiscoveryEvent: false });
+        const tools = this.filterTools(session, result.tools);
+
+        return {
+            ...result,
+            tools,
+        } as ListToolsResult;
+    }
+
+    async listAllTools(): Promise<ListToolsResult> {
+        return await this.client.listTools({ emitDiscoveryEvent: false }) as ListToolsResult;
+    }
+
+    async callTool(name: string, args: Record<string, unknown>): Promise<CallToolResult> {
+        const session = await this.getSession();
+        this.assertAllowed(session, name);
+        return await this.client.callTool(name, args);
+    }
+
+    filterTools(session: Session, tools: Tool[]): Tool[] {
+        return filterToolsByPolicy(tools, session.toolPolicy, this.getPolicyServerId(session));
+    }
+
+    assertAllowed(session: Session, toolName: string): void {
+        assertToolAllowed(session.toolPolicy, toolName, this.getPolicyServerId(session));
+    }
+
+    private async getSession(): Promise<Session> {
+        const session = await sessions.get(this.userId, this.sessionId);
+        if (!session) {
+            throw new Error('Session not found');
+        }
+        return session;
+    }
+
+    private getPolicyServerId(session: Session): string | undefined {
+        return this.client.getServerId?.() ?? session.serverId;
+    }
+}
+
+export function createToolPolicyGateway(
+    userId: string,
+    sessionId: string,
+    client: RawToolClient
+): ToolPolicyGateway {
+    return new ToolPolicyGateway(userId, sessionId, client);
+}
+

--- a/src/server/mcp/tool-policy-gateway.ts
+++ b/src/server/mcp/tool-policy-gateway.ts
@@ -5,7 +5,8 @@ import type { Session } from '../storage/types.js';
 import { assertToolAllowed, filterToolsByPolicy } from '../storage/tool-policy.js';
 
 type RawToolClient = ToolClient & {
-    listTools(options?: { emitDiscoveryEvent?: boolean }): Promise<{ tools: Tool[] }>;
+    fetchTools(): Promise<{ tools: Tool[] }>;
+    listTools(): Promise<{ tools: Tool[] }>;
     callTool(name: string, args: Record<string, unknown>): Promise<CallToolResult>;
 };
 
@@ -34,7 +35,7 @@ export class ToolPolicyGateway implements ToolClient {
 
     async listTools(): Promise<ListToolsResult> {
         const session = await this.getSession();
-        const result = await this.client.listTools({ emitDiscoveryEvent: false });
+        const result = await this.client.fetchTools();
         const tools = this.filterTools(session, result.tools);
 
         return {
@@ -44,7 +45,7 @@ export class ToolPolicyGateway implements ToolClient {
     }
 
     async listAllTools(): Promise<ListToolsResult> {
-        return await this.client.listTools({ emitDiscoveryEvent: false }) as ListToolsResult;
+        return await this.client.fetchTools() as ListToolsResult;
     }
 
     async callTool(name: string, args: Record<string, unknown>): Promise<CallToolResult> {
@@ -81,4 +82,5 @@ export function createToolPolicyGateway(
 ): ToolPolicyGateway {
     return new ToolPolicyGateway(userId, sessionId, client);
 }
+
 

--- a/src/server/mcp/tool-policy-gateway.ts
+++ b/src/server/mcp/tool-policy-gateway.ts
@@ -29,6 +29,10 @@ export class ToolPolicyGateway implements ToolClient {
         return this.client.getServerName?.();
     }
 
+    getServerUrl(): string | undefined {
+        return this.client.getServerUrl?.();
+    }
+
     getSessionId(): string {
         return this.client.getSessionId?.() ?? this.sessionId;
     }

--- a/src/server/storage/neon-backend.ts
+++ b/src/server/storage/neon-backend.ts
@@ -4,6 +4,7 @@ import { DORMANT_SESSION_EXPIRATION_MS } from '../../shared/constants.js';
 import { generateSessionId } from '../../shared/utils.js';
 import { encryptObject, decryptObject } from './crypto.js';
 import { resolveSessionExpiresAt } from './session-lifecycle.js';
+import { normalizeToolPolicy } from './tool-policy.js';
 
 export interface NeonStorageOptions {
     schema?: string;
@@ -30,6 +31,7 @@ type NeonSessionRow = {
     headers?: unknown;
     auth_url?: string | null;
     status?: SessionStatus | null;
+    tool_policy?: unknown;
 };
 
 type NeonCredentialsRow = {
@@ -103,6 +105,7 @@ export class NeonStorageBackend implements SessionStore {
             headers: decryptObject(row.headers),
             authUrl: row.auth_url ?? undefined,
             status: row.status ?? 'pending',
+            toolPolicy: normalizeToolPolicy(row.tool_policy as Parameters<typeof normalizeToolPolicy>[0]),
         };
     }
 
@@ -135,7 +138,9 @@ export class NeonStorageBackend implements SessionStore {
         const status = session.status ?? 'pending';
         const createdAt = new Date(session.createdAt || Date.now()).toISOString();
         const updatedAt = new Date(session.updatedAt ?? session.createdAt ?? Date.now()).toISOString();
-        const expiresAt = resolveSessionExpiresAt(status, new Date(createdAt).getTime());
+        const createdAtMs = new Date(createdAt).getTime();
+        const expiresAt = resolveSessionExpiresAt(status, createdAtMs);
+        const toolPolicy = normalizeToolPolicy(session.toolPolicy, createdAtMs) ?? { mode: 'all' as const, toolIds: [], updatedAt: createdAtMs };
 
         try {
             await this.sql.query(
@@ -152,10 +157,11 @@ export class NeonStorageBackend implements SessionStore {
                     headers,
                     auth_url,
                     status,
-                    expires_at
+                    expires_at,
+                    tool_policy
                 ) VALUES (
                     $1, $2, $3, $4, $5, $6, $7, $8,
-                    $9, $10, $11, $12, $13
+                    $9, $10, $11, $12, $13, $14
                 )`,
                 [
                     sessionId,
@@ -171,6 +177,7 @@ export class NeonStorageBackend implements SessionStore {
                     session.authUrl ?? null,
                     status,
                     expiresAt === null ? null : new Date(expiresAt).toISOString(),
+                    toolPolicy,
                 ]
             );
         } catch (error: any) {
@@ -191,6 +198,8 @@ export class NeonStorageBackend implements SessionStore {
         const updatedSession = { ...currentSession, ...data };
         const status = updatedSession.status ?? 'pending';
         const expiresAt = resolveSessionExpiresAt(status);
+        const policyUpdatedAt = updatedSession.updatedAt ?? Date.now();
+        const toolPolicy = normalizeToolPolicy(updatedSession.toolPolicy, policyUpdatedAt) ?? { mode: 'all' as const, toolIds: [], updatedAt: policyUpdatedAt };
 
         const shouldUpdateSession = (
             'serverId' in data ||
@@ -200,7 +209,8 @@ export class NeonStorageBackend implements SessionStore {
             'callbackUrl' in data ||
             'status' in data ||
             'headers' in data ||
-            'authUrl' in data
+            'authUrl' in data ||
+            'toolPolicy' in data
         );
 
         if (shouldUpdateSession) {
@@ -216,8 +226,9 @@ export class NeonStorageBackend implements SessionStore {
                     headers = $7,
                     auth_url = $8,
                     expires_at = $9,
+                    tool_policy = $10,
                     updated_at = now()
-                 WHERE user_id = $10 AND session_id = $11
+                 WHERE user_id = $11 AND session_id = $12
                  RETURNING id`,
                 [
                     updatedSession.serverId,
@@ -229,6 +240,7 @@ export class NeonStorageBackend implements SessionStore {
                     encryptObject(updatedSession.headers),
                     updatedSession.authUrl ?? null,
                     expiresAt === null ? null : new Date(expiresAt).toISOString(),
+                    toolPolicy,
                     userId,
                     sessionId,
                 ]
@@ -412,3 +424,7 @@ export class NeonStorageBackend implements SessionStore {
         // Neon HTTP queries do not hold a persistent connection.
     }
 }
+
+
+
+

--- a/src/server/storage/neon-backend.ts
+++ b/src/server/storage/neon-backend.ts
@@ -140,45 +140,33 @@ export class NeonStorageBackend implements SessionStore {
         const updatedAt = new Date(session.updatedAt ?? session.createdAt ?? Date.now()).toISOString();
         const createdAtMs = new Date(createdAt).getTime();
         const expiresAt = resolveSessionExpiresAt(status, createdAtMs);
-        const toolPolicy = normalizeToolPolicy(session.toolPolicy, createdAtMs) ?? { mode: 'all' as const, toolIds: [], updatedAt: createdAtMs };
+        const toolPolicy = normalizeToolPolicy(session.toolPolicy, createdAtMs);
+
+        const columns: string[] = [
+            'session_id', 'user_id', 'server_id', 'server_name',
+            'server_url', 'transport_type', 'callback_url',
+            'created_at', 'updated_at', 'headers', 'auth_url',
+            'status', 'expires_at',
+        ];
+        const values: unknown[] = [
+            sessionId, userId, session.serverId, session.serverName,
+            session.serverUrl, session.transportType, session.callbackUrl,
+            createdAt, updatedAt, encryptObject(session.headers),
+            session.authUrl ?? null, status,
+            expiresAt === null ? null : new Date(expiresAt).toISOString(),
+        ];
+
+        if (toolPolicy) {
+            columns.push('tool_policy');
+            values.push(toolPolicy);
+        }
+
+        const placeholders = values.map((_, i) => `$${i + 1}`);
 
         try {
             await this.sql.query(
-                `INSERT INTO ${this.tableName} (
-                    session_id,
-                    user_id,
-                    server_id,
-                    server_name,
-                    server_url,
-                    transport_type,
-                    callback_url,
-                    created_at,
-                    updated_at,
-                    headers,
-                    auth_url,
-                    status,
-                    expires_at,
-                    tool_policy
-                ) VALUES (
-                    $1, $2, $3, $4, $5, $6, $7, $8,
-                    $9, $10, $11, $12, $13, $14
-                )`,
-                [
-                    sessionId,
-                    userId,
-                    session.serverId,
-                    session.serverName,
-                    session.serverUrl,
-                    session.transportType,
-                    session.callbackUrl,
-                    createdAt,
-                    updatedAt,
-                    encryptObject(session.headers),
-                    session.authUrl ?? null,
-                    status,
-                    expiresAt === null ? null : new Date(expiresAt).toISOString(),
-                    toolPolicy,
-                ]
+                `INSERT INTO ${this.tableName} (${columns.join(', ')}) VALUES (${placeholders.join(', ')})`,
+                values
             );
         } catch (error: any) {
             if (error.code === '23505') {
@@ -198,8 +186,6 @@ export class NeonStorageBackend implements SessionStore {
         const updatedSession = { ...currentSession, ...data };
         const status = updatedSession.status ?? 'pending';
         const expiresAt = resolveSessionExpiresAt(status);
-        const policyUpdatedAt = updatedSession.updatedAt ?? Date.now();
-        const toolPolicy = normalizeToolPolicy(updatedSession.toolPolicy, policyUpdatedAt) ?? { mode: 'all' as const, toolIds: [], updatedAt: policyUpdatedAt };
 
         const shouldUpdateSession = (
             'serverId' in data ||
@@ -214,36 +200,39 @@ export class NeonStorageBackend implements SessionStore {
         );
 
         if (shouldUpdateSession) {
+            const setClauses: string[] = [];
+            const values: unknown[] = [];
+            let paramIndex = 1;
+
+            const addSet = (column: string, value: unknown) => {
+                setClauses.push(`${column} = $${paramIndex++}`);
+                values.push(value);
+            };
+
+            addSet('server_id', updatedSession.serverId);
+            addSet('server_name', updatedSession.serverName);
+            addSet('server_url', updatedSession.serverUrl);
+            addSet('transport_type', updatedSession.transportType);
+            addSet('callback_url', updatedSession.callbackUrl);
+            addSet('status', status);
+            addSet('headers', encryptObject(updatedSession.headers));
+            addSet('auth_url', updatedSession.authUrl ?? null);
+            addSet('expires_at', expiresAt === null ? null : new Date(expiresAt).toISOString());
+
+            if ('toolPolicy' in data) {
+                const policyUpdatedAt = updatedSession.updatedAt ?? Date.now();
+                const toolPolicy = normalizeToolPolicy(updatedSession.toolPolicy, policyUpdatedAt) ?? { mode: 'all' as const, toolIds: [], updatedAt: policyUpdatedAt };
+                addSet('tool_policy', toolPolicy);
+            }
+
+            setClauses.push('updated_at = now()');
+
             const updatedRows = await this.sql.query(
                 `UPDATE ${this.tableName}
-                 SET
-                    server_id = $1,
-                    server_name = $2,
-                    server_url = $3,
-                    transport_type = $4,
-                    callback_url = $5,
-                    status = $6,
-                    headers = $7,
-                    auth_url = $8,
-                    expires_at = $9,
-                    tool_policy = $10,
-                    updated_at = now()
-                 WHERE user_id = $11 AND session_id = $12
+                 SET ${setClauses.join(', ')}
+                 WHERE user_id = $${paramIndex++} AND session_id = $${paramIndex++}
                  RETURNING id`,
-                [
-                    updatedSession.serverId,
-                    updatedSession.serverName,
-                    updatedSession.serverUrl,
-                    updatedSession.transportType,
-                    updatedSession.callbackUrl,
-                    status,
-                    encryptObject(updatedSession.headers),
-                    updatedSession.authUrl ?? null,
-                    expiresAt === null ? null : new Date(expiresAt).toISOString(),
-                    toolPolicy,
-                    userId,
-                    sessionId,
-                ]
+                [...values, userId, sessionId]
             ) as Array<{ id: string }>;
 
             if (updatedRows.length === 0) {

--- a/src/server/storage/session-lifecycle.ts
+++ b/src/server/storage/session-lifecycle.ts
@@ -4,6 +4,7 @@ import {
     STATE_EXPIRATION_MS,
 } from '../../shared/constants.js';
 import type { Session, SessionStatus } from './types.js';
+import { normalizeToolPolicy } from './tool-policy.js';
 
 export function resolveSessionExpiresAt(status: SessionStatus = 'pending', referenceTime = Date.now()): number | null {
     return status === 'active' ? null : referenceTime + STATE_EXPIRATION_MS;
@@ -26,6 +27,7 @@ export function normalizeNewSession(session: Session, now = Date.now()): Session
         createdAt,
         updatedAt,
         expiresAt: resolveSessionExpiresAt(status, status === 'active' ? updatedAt : createdAt),
+        toolPolicy: normalizeToolPolicy(session.toolPolicy, updatedAt),
     };
 }
 
@@ -46,6 +48,7 @@ export function mergeSessionUpdate(
         ...updated,
         status,
         expiresAt: resolveSessionExpiresAt(status, updatedAt),
+        toolPolicy: normalizeToolPolicy(updated.toolPolicy, updatedAt),
     };
 }
 
@@ -63,6 +66,7 @@ export function normalizeStoredSession(session: Session): Session {
         createdAt,
         updatedAt,
         expiresAt,
+        toolPolicy: normalizeToolPolicy(session.toolPolicy, updatedAt),
     };
 }
 
@@ -76,3 +80,4 @@ export function isSessionExpired(session: Session, now = Date.now()): boolean {
 
     return typeof hydrated.expiresAt === 'number' && hydrated.expiresAt < now;
 }
+

--- a/src/server/storage/supabase-backend.ts
+++ b/src/server/storage/supabase-backend.ts
@@ -87,24 +87,30 @@ export class SupabaseStorageBackend implements SessionStore {
         const updatedAt = new Date(session.updatedAt ?? session.createdAt ?? Date.now()).toISOString();
         const expiresAt = resolveSessionExpiresAt(status, new Date(createdAt).getTime());
 
+        const insertData: Record<string, unknown> = {
+            session_id: sessionId,
+            user_id: userId,
+            server_id: session.serverId,
+            server_name: session.serverName,
+            server_url: session.serverUrl,
+            transport_type: session.transportType,
+            callback_url: session.callbackUrl,
+            created_at: createdAt,
+            updated_at: updatedAt,
+            headers: encryptObject(session.headers),
+            auth_url: session.authUrl ?? null,
+            status,
+            expires_at: expiresAt === null ? null : new Date(expiresAt).toISOString(),
+        };
+
+        const toolPolicy = normalizeToolPolicy(session.toolPolicy);
+        if (toolPolicy) {
+            insertData.tool_policy = toolPolicy;
+        }
+
         const { error } = await this.supabase
             .from('mcp_sessions')
-            .insert({
-                session_id: sessionId,
-                user_id: userId,
-                server_id: session.serverId,
-                server_name: session.serverName,
-                server_url: session.serverUrl,
-                transport_type: session.transportType,
-                callback_url: session.callbackUrl,
-                created_at: createdAt,
-                updated_at: updatedAt,
-                headers: encryptObject(session.headers),
-                auth_url: session.authUrl ?? null,
-                status,
-                expires_at: expiresAt === null ? null : new Date(expiresAt).toISOString(),
-                tool_policy: normalizeToolPolicy(session.toolPolicy) ?? { mode: 'all', toolIds: [], updatedAt },
-            });
+            .insert(insertData);
 
         if (error) {
             if (error.code === '23505') {

--- a/src/server/storage/supabase-backend.ts
+++ b/src/server/storage/supabase-backend.ts
@@ -3,6 +3,7 @@ import type { SessionStore, Session, SessionCredentials } from './types.js';
 import { generateSessionId } from '../../shared/utils.js';
 import { encryptObject, decryptObject } from './crypto.js';
 import { resolveSessionExpiresAt } from './session-lifecycle.js';
+import { normalizeToolPolicy } from './tool-policy.js';
 import { DORMANT_SESSION_EXPIRATION_MS } from '../../shared/constants.js';
 
 export class SupabaseStorageBackend implements SessionStore {
@@ -51,6 +52,7 @@ export class SupabaseStorageBackend implements SessionStore {
             headers: decryptObject(row.headers),
             authUrl: row.auth_url,
             status: row.status ?? 'pending',
+            toolPolicy: normalizeToolPolicy(row.tool_policy),
         };
     }
 
@@ -101,6 +103,7 @@ export class SupabaseStorageBackend implements SessionStore {
                 auth_url: session.authUrl ?? null,
                 status,
                 expires_at: expiresAt === null ? null : new Date(expiresAt).toISOString(),
+                tool_policy: normalizeToolPolicy(session.toolPolicy) ?? { mode: 'all', toolIds: [], updatedAt },
             });
 
         if (error) {
@@ -130,6 +133,7 @@ export class SupabaseStorageBackend implements SessionStore {
         }
         if ('headers' in data) updateData.headers = encryptObject(data.headers);
         if ('authUrl' in data) updateData.auth_url = data.authUrl ?? null;
+        if ('toolPolicy' in data) updateData.tool_policy = normalizeToolPolicy(data.toolPolicy);
 
         const shouldUpdateSession = Object.keys(updateData).some((key) => key !== 'updated_at');
 
@@ -351,3 +355,5 @@ export class SupabaseStorageBackend implements SessionStore {
         // Supabase client handles its own connection pooling over HTTP.
     }
 }
+
+

--- a/src/server/storage/tool-policy.ts
+++ b/src/server/storage/tool-policy.ts
@@ -1,0 +1,89 @@
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { ToolPolicy } from './types.js';
+
+export type ToolPolicyInput = {
+    mode?: unknown;
+    toolIds?: unknown;
+    updatedAt?: unknown;
+} | null | undefined;
+
+export function createToolId(serverId: string, toolName: string): string {
+    return `${serverId}::${toolName}`;
+}
+
+function normalizeToolIds(input?: unknown): string[] {
+    if (!Array.isArray(input)) return [];
+
+    return Array.from(new Set(
+        input
+            .filter((id): id is string => typeof id === 'string')
+            .map((id) => id.trim())
+            .filter(Boolean)
+    ));
+}
+
+export function normalizeToolPolicy(input?: ToolPolicyInput, now = Date.now()): ToolPolicy | undefined {
+    if (!input || typeof input !== 'object') {
+        return undefined;
+    }
+
+    const mode = input.mode === 'allowlist' || input.mode === 'denylist'
+        ? input.mode
+        : 'all';
+    const updatedAt = typeof input.updatedAt === 'number' && Number.isFinite(input.updatedAt)
+        ? input.updatedAt
+        : now;
+
+    if (mode === 'all') {
+        return { mode: 'all', toolIds: [], updatedAt };
+    }
+
+    return { mode, toolIds: normalizeToolIds(input.toolIds), updatedAt };
+}
+
+export function normalizeToolPolicyForUpdate(input: ToolPolicyInput, now = Date.now()): ToolPolicy {
+    return normalizeToolPolicy(input, now) ?? { mode: 'all', toolIds: [], updatedAt: now };
+}
+
+export function isToolAllowed(policy: ToolPolicy | undefined, toolName: string, serverId?: string): boolean {
+    if (!policy || policy.mode === 'all') return true;
+    if (!serverId) return false;
+
+    const toolId = createToolId(serverId, toolName);
+    if (policy.mode === 'allowlist') {
+        return policy.toolIds.includes(toolId);
+    }
+
+    return !policy.toolIds.includes(toolId);
+}
+
+export function assertToolAllowed(policy: ToolPolicy | undefined, toolName: string, serverId?: string): void {
+    if (isToolAllowed(policy, toolName, serverId)) return;
+    throw new Error(`Tool "${toolName}" is not allowed for this MCP session`);
+}
+
+export function filterToolsByPolicy<T extends Pick<Tool, 'name'>>(
+    tools: T[],
+    policy: ToolPolicy | undefined,
+    serverId?: string
+): T[] {
+    if (!policy || policy.mode === 'all') return tools;
+    return tools.filter((tool) => isToolAllowed(policy, tool.name, serverId));
+}
+
+export function validateToolPolicyAgainstTools(
+    policy: ToolPolicy,
+    tools: Array<Pick<Tool, 'name'>>,
+    serverId?: string
+): void {
+    if (policy.mode === 'all') return;
+    if (!serverId) {
+        throw new Error('Cannot validate MCP tool policy without a serverId');
+    }
+
+    const availableIds = new Set(tools.map((tool) => createToolId(serverId, tool.name)));
+    const unknownIds = policy.toolIds.filter((id) => !availableIds.has(id));
+    if (unknownIds.length > 0) {
+        throw new Error(`Unknown tool id(s) for this MCP session: ${unknownIds.join(', ')}`);
+    }
+}

--- a/src/server/storage/types.ts
+++ b/src/server/storage/types.ts
@@ -14,6 +14,14 @@ export interface OAuthState {
 
 export type SessionStatus = 'pending' | 'active';
 
+export type ToolPolicyMode = 'all' | 'allowlist' | 'denylist';
+
+export interface ToolPolicy {
+    mode: ToolPolicyMode;
+    toolIds: string[];
+    updatedAt: number;
+}
+
 export interface Session {
     sessionId: string;
     serverId?: string; // Database server ID for mapping
@@ -37,6 +45,7 @@ export interface Session {
      * - active: restorable session after successful connection/auth completion
      */
     status?: SessionStatus;
+    toolPolicy?: ToolPolicy;
 }
 
 export interface SessionCredentials {
@@ -158,3 +167,5 @@ export interface SessionStore {
      */
     disconnect(): Promise<void>;
 }
+
+

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -169,6 +169,13 @@ export type ToolInfo = {
 // Transport type
 export type TransportType = 'sse' | 'streamable-http';
 export type SessionStatus = 'pending' | 'active';
+export type ToolPolicyMode = 'all' | 'allowlist' | 'denylist';
+
+export interface ToolPolicy {
+  mode: ToolPolicyMode;
+  toolIds: string[];
+  updatedAt: number;
+}
 
 // SSE/RPC types
 export type McpRpcMethod =
@@ -182,7 +189,9 @@ export type McpRpcMethod =
   | 'listPrompts'
   | 'getPrompt'
   | 'listResources'
-  | 'readResource';
+  | 'readResource'
+  | 'updateSessionToolPolicy'
+  | 'getSessionToolAccess';
 
 export interface McpRpcRequest {
   id: string;
@@ -239,6 +248,18 @@ export interface FinishAuthParams {
   code: string;
 }
 
+export interface UpdateSessionToolPolicyParams {
+  sessionId: string;
+  toolPolicy: {
+    mode: ToolPolicyMode;
+    toolIds?: string[];
+  };
+}
+
+export interface GetSessionToolAccessParams {
+  sessionId: string;
+}
+
 export type McpRpcParams =
   | ConnectParams
   | DisconnectParams
@@ -247,6 +268,8 @@ export type McpRpcParams =
   | GetPromptParams
   | ReadResourceParams
   | FinishAuthParams
+  | UpdateSessionToolPolicyParams
+  | GetSessionToolAccessParams
   | undefined;
 
 // RPC Result Types
@@ -263,6 +286,7 @@ export interface SessionInfo {
    * `pending` means auth is in progress and should be resumed explicitly by user action.
    */
   status: SessionStatus;
+  toolPolicy?: ToolPolicy;
 }
 
 export interface SessionListResult {
@@ -292,6 +316,25 @@ export interface ListToolsRpcResult {
   tools: Tool[];
 }
 
+export interface UpdateSessionToolPolicyResult {
+  success: boolean;
+  toolPolicy: ToolPolicy;
+  tools: Tool[];
+  toolCount: number;
+}
+
+export type ToolAccessInfo = Tool & {
+  toolId: string;
+  allowed: boolean;
+};
+
+export interface GetSessionToolAccessResult {
+  toolPolicy: ToolPolicy;
+  tools: ToolAccessInfo[];
+  toolCount: number;
+  allowedToolCount: number;
+}
+
 export interface ListPromptsResult {
   prompts: Array<{
     name: string;
@@ -314,3 +357,6 @@ export interface ListResourcesResult {
 }
 
 export type { CallToolResult };
+
+
+

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -21,6 +21,7 @@ export interface ToolClient {
   callTool(name: string, args: Record<string, unknown>): Promise<any>;
   getServerId?(): string | undefined;
   getServerName?(): string | undefined;
+  getServerUrl?(): string | undefined;
   getSessionId?(): string;
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -190,8 +190,8 @@ export type McpRpcMethod =
   | 'getPrompt'
   | 'listResources'
   | 'readResource'
-  | 'updateSessionToolPolicy'
-  | 'getSessionToolAccess';
+  | 'setToolPolicy'
+  | 'getToolPolicy';
 
 export interface McpRpcRequest {
   id: string;
@@ -248,7 +248,7 @@ export interface FinishAuthParams {
   code: string;
 }
 
-export interface UpdateSessionToolPolicyParams {
+export interface SetToolPolicyParams {
   sessionId: string;
   toolPolicy: {
     mode: ToolPolicyMode;
@@ -256,7 +256,7 @@ export interface UpdateSessionToolPolicyParams {
   };
 }
 
-export interface GetSessionToolAccessParams {
+export interface GetToolPolicyParams {
   sessionId: string;
 }
 
@@ -268,8 +268,8 @@ export type McpRpcParams =
   | GetPromptParams
   | ReadResourceParams
   | FinishAuthParams
-  | UpdateSessionToolPolicyParams
-  | GetSessionToolAccessParams
+  | SetToolPolicyParams
+  | GetToolPolicyParams
   | undefined;
 
 // RPC Result Types
@@ -316,7 +316,7 @@ export interface ListToolsRpcResult {
   tools: Tool[];
 }
 
-export interface UpdateSessionToolPolicyResult {
+export interface SetToolPolicyResult {
   success: boolean;
   toolPolicy: ToolPolicy;
   tools: Tool[];
@@ -328,7 +328,7 @@ export type ToolAccessInfo = Tool & {
   allowed: boolean;
 };
 
-export interface GetSessionToolAccessResult {
+export interface GetToolPolicyResult {
   toolPolicy: ToolPolicy;
   tools: ToolAccessInfo[];
   toolCount: number;

--- a/tests/mcp-tool-policy.test.ts
+++ b/tests/mcp-tool-policy.test.ts
@@ -25,6 +25,12 @@ function rawClient(overrides: Record<string, unknown> = {}) {
     getSessionId: () => 'policy-session',
     getServerId: () => 'github',
     getServerName: () => 'GitHub',
+    fetchTools: async () => ({
+      tools: [
+        { name: 'get_issue', description: 'Read issue' },
+        { name: 'create_issue', description: 'Write issue' },
+      ],
+    }),
     listTools: async () => ({
       tools: [
         { name: 'get_issue', description: 'Read issue' },
@@ -103,7 +109,7 @@ test.describe('MCP session tool policy', () => {
     expect(downstreamCalls).toBe(0);
   });
 
-  test('SSE listSessions includes toolPolicy and updateSessionToolPolicy persists changes', async () => {
+  test('SSE listSessions includes toolPolicy and setToolPolicy persists changes', async () => {
     const storage = new MemoryStorageBackend();
     _setStorageInstanceForTesting(storage);
     await storage.create(activeSession() as any);
@@ -113,7 +119,7 @@ test.describe('MCP session tool policy', () => {
 
     const update = await manager.handleRequest({
       id: 'update-policy',
-      method: 'updateSessionToolPolicy',
+      method: 'setToolPolicy',
       params: {
         sessionId: 'policy-session',
         toolPolicy: {
@@ -143,7 +149,7 @@ test.describe('MCP session tool policy', () => {
 
     const access = await manager.handleRequest({
       id: 'tool-access',
-      method: 'getSessionToolAccess',
+      method: 'getToolPolicy',
       params: { sessionId: 'policy-session' },
     } as any);
 
@@ -197,4 +203,5 @@ test.describe('MCP session tool policy', () => {
     await manager.dispose();
   });
 });
+
 

--- a/tests/mcp-tool-policy.test.ts
+++ b/tests/mcp-tool-policy.test.ts
@@ -1,0 +1,200 @@
+import { test, expect } from '@playwright/test';
+import { _setStorageInstanceForTesting } from '../src/server/storage';
+import { MemoryStorageBackend } from '../src/server/storage/memory-backend';
+import { createToolPolicyGateway } from '../src/server/mcp/tool-policy-gateway';
+import { SSEConnectionManager } from '../src/server/handlers/sse-handler';
+
+function activeSession(overrides: Record<string, unknown> = {}) {
+  return {
+    sessionId: 'policy-session',
+    userId: 'user-policy',
+    serverId: 'github',
+    serverName: 'GitHub',
+    serverUrl: 'https://example.com/mcp',
+    callbackUrl: 'https://app.local/oauth/callback',
+    transportType: 'streamable-http' as const,
+    createdAt: Date.now(),
+    status: 'active' as const,
+    ...overrides,
+  };
+}
+
+function rawClient(overrides: Record<string, unknown> = {}) {
+  return {
+    isConnected: () => true,
+    getSessionId: () => 'policy-session',
+    getServerId: () => 'github',
+    getServerName: () => 'GitHub',
+    listTools: async () => ({
+      tools: [
+        { name: 'get_issue', description: 'Read issue' },
+        { name: 'create_issue', description: 'Write issue' },
+      ],
+    }),
+    callTool: async () => ({ content: [{ type: 'text', text: 'called' }] }),
+    disconnect: async () => {},
+    ...overrides,
+  };
+}
+
+test.describe('MCP session tool policy', () => {
+  test.afterEach(() => {
+    _setStorageInstanceForTesting(null);
+  });
+
+  test('ToolPolicyGateway listTools filters tools with allowlist policy', async () => {
+    const storage = new MemoryStorageBackend();
+    _setStorageInstanceForTesting(storage);
+    await storage.create(activeSession({
+      toolPolicy: {
+        mode: 'allowlist',
+        toolIds: ['github::get_issue'],
+        updatedAt: 1780076500000,
+      },
+    }) as any);
+
+    const gateway = createToolPolicyGateway('user-policy', 'policy-session', rawClient() as any);
+
+    const result = await gateway.listTools();
+
+    expect(result.tools.map((tool) => tool.name)).toEqual(['get_issue']);
+  });
+
+  test('ToolPolicyGateway listTools filters tools with denylist policy', async () => {
+    const storage = new MemoryStorageBackend();
+    _setStorageInstanceForTesting(storage);
+    await storage.create(activeSession({
+      toolPolicy: {
+        mode: 'denylist',
+        toolIds: ['github::create_issue'],
+        updatedAt: 1780076500000,
+      },
+    }) as any);
+
+    const gateway = createToolPolicyGateway('user-policy', 'policy-session', rawClient() as any);
+
+    const result = await gateway.listTools();
+
+    expect(result.tools.map((tool) => tool.name)).toEqual(['get_issue']);
+  });
+
+  test('ToolPolicyGateway callTool rejects tools outside allowlist before downstream request', async () => {
+    const storage = new MemoryStorageBackend();
+    _setStorageInstanceForTesting(storage);
+    await storage.create(activeSession({
+      toolPolicy: {
+        mode: 'allowlist',
+        toolIds: ['github::get_issue'],
+        updatedAt: 1780076500000,
+      },
+    }) as any);
+
+    let downstreamCalls = 0;
+    const gateway = createToolPolicyGateway('user-policy', 'policy-session', rawClient({
+      callTool: async () => {
+        downstreamCalls += 1;
+        return { content: [{ type: 'text', text: 'called' }] };
+      },
+    }) as any);
+
+    await expect(gateway.callTool('create_issue', {})).rejects.toThrow(
+      'Tool "create_issue" is not allowed for this MCP session'
+    );
+    expect(downstreamCalls).toBe(0);
+  });
+
+  test('SSE listSessions includes toolPolicy and updateSessionToolPolicy persists changes', async () => {
+    const storage = new MemoryStorageBackend();
+    _setStorageInstanceForTesting(storage);
+    await storage.create(activeSession() as any);
+
+    const manager = new SSEConnectionManager({ userId: 'user-policy' }, () => {});
+    (manager as any).clients.set('policy-session', rawClient());
+
+    const update = await manager.handleRequest({
+      id: 'update-policy',
+      method: 'updateSessionToolPolicy',
+      params: {
+        sessionId: 'policy-session',
+        toolPolicy: {
+          mode: 'allowlist',
+          toolIds: ['github::get_issue'],
+        },
+      },
+    } as any);
+
+    expect((update as any).error).toBeUndefined();
+    expect((update as any).result.toolPolicy).toEqual({
+      mode: 'allowlist',
+      toolIds: ['github::get_issue'],
+      updatedAt: expect.any(Number),
+    });
+    expect((update as any).result.tools.map((tool: { name: string }) => tool.name)).toEqual(['get_issue']);
+
+    const list = await manager.handleRequest({
+      id: 'list-sessions',
+      method: 'listSessions',
+    } as any);
+
+    expect((list as any).error).toBeUndefined();
+    expect((list as any).result.sessions[0].toolPolicy).toEqual(
+      (update as any).result.toolPolicy
+    );
+
+    const access = await manager.handleRequest({
+      id: 'tool-access',
+      method: 'getSessionToolAccess',
+      params: { sessionId: 'policy-session' },
+    } as any);
+
+    expect((access as any).error).toBeUndefined();
+    expect((access as any).result.tools.map((tool: { name: string; toolId: string; allowed: boolean }) => ({
+      name: tool.name,
+      toolId: tool.toolId,
+      allowed: tool.allowed,
+    }))).toEqual([
+      { name: 'get_issue', toolId: 'github::get_issue', allowed: true },
+      { name: 'create_issue', toolId: 'github::create_issue', allowed: false },
+    ]);
+
+    await manager.dispose();
+  });
+
+  test('SSE callTool rejects blocked tools before downstream request', async () => {
+    const storage = new MemoryStorageBackend();
+    _setStorageInstanceForTesting(storage);
+    await storage.create(activeSession({
+      toolPolicy: {
+        mode: 'denylist',
+        toolIds: ['github::create_issue'],
+        updatedAt: 1780076500000,
+      },
+    }) as any);
+
+    let downstreamCalls = 0;
+    const manager = new SSEConnectionManager({ userId: 'user-policy' }, () => {});
+    (manager as any).clients.set('policy-session', rawClient({
+      callTool: async () => {
+        downstreamCalls += 1;
+        return { content: [{ type: 'text', text: 'called' }] };
+      },
+    }));
+
+    const response = await manager.handleRequest({
+      id: 'call-policy',
+      method: 'callTool',
+      params: {
+        sessionId: 'policy-session',
+        toolName: 'create_issue',
+        toolArgs: {},
+      },
+    } as any);
+
+    expect((response as any).result).toBeUndefined();
+    expect((response as any).error?.message).toBe('Tool "create_issue" is not allowed for this MCP session');
+    expect(downstreamCalls).toBe(0);
+
+    await manager.dispose();
+  });
+});
+

--- a/tests/storage/memory-backend.test.ts
+++ b/tests/storage/memory-backend.test.ts
@@ -64,6 +64,25 @@ test.describe('MemoryStorageBackend', () => {
             expect(retrieved?.serverId).toBe(session.serverId);
         });
 
+        test('should round-trip session tool policy updates', async () => {
+            const session = createMockSession();
+            await storage.create(session);
+
+            await storage.update(session.userId, session.sessionId, {
+                toolPolicy: {
+                    mode: 'allowlist',
+                    toolIds: ['github::get_issue', 'github::list_pull_requests'],
+                    updatedAt: 1780076400000,
+                },
+            });
+
+            const retrieved = await storage.get(session.userId, session.sessionId);
+            expect(retrieved?.toolPolicy).toEqual({
+                mode: 'allowlist',
+                toolIds: ['github::get_issue', 'github::list_pull_requests'],
+                updatedAt: 1780076400000,
+            });
+        });
         test('should throw if session does not exist', async () => {
             await expect(
                 storage.update('unknown', 'unknown', { status: 'active' })
@@ -97,3 +116,5 @@ test.describe('MemoryStorageBackend', () => {
         });
     });
 });
+
+

--- a/tests/storage/neon-backend.test.ts
+++ b/tests/storage/neon-backend.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { NeonStorageBackend } from '../../src/server/storage/neon-backend';
 import { createMockSession, createMockTokens } from '../test-utils';
-import { STATE_EXPIRATION_MS } from '../../src/shared/constants';
+import { DORMANT_SESSION_EXPIRATION_MS, STATE_EXPIRATION_MS } from '../../src/shared/constants';
 import type { SessionStatus } from '../../src/server/storage/types';
 
 type NeonRow = {
@@ -121,33 +121,22 @@ function createMockNeonSql() {
         }
 
         if (normalized.startsWith('update public.mcp_sessions') && normalized.includes('set server_id')) {
-            const [
-                serverId,
-                serverName,
-                serverUrl,
-                transportType,
-                callbackUrl,
-                status,
-                headers,
-                authUrl,
-                expiresAt,
-                userId,
-                sessionId,
-            ] = params;
-            const row = sessions.find((item) => item.user_id === userId && item.session_id === sessionId);
+            const whereUserId = params[params.length - 2] as string;
+            const whereSessionId = params[params.length - 1] as string;
+            const row = sessions.find((item) => item.user_id === whereUserId && item.session_id === whereSessionId);
             if (!row) {
                 return [];
             }
 
-            row.server_id = serverId as string | undefined;
-            row.server_name = serverName as string | undefined;
-            row.server_url = serverUrl as string;
-            row.transport_type = transportType as 'sse' | 'streamable-http';
-            row.callback_url = callbackUrl as string;
-            row.status = status as SessionStatus;
-            row.headers = headers as Record<string, string> | undefined;
-            row.auth_url = authUrl as string | null;
-            row.expires_at = expiresAt as string | null;
+            row.server_id = params[0] as string | undefined;
+            row.server_name = params[1] as string | undefined;
+            row.server_url = params[2] as string;
+            row.transport_type = params[3] as 'sse' | 'streamable-http';
+            row.callback_url = params[4] as string;
+            row.status = params[5] as SessionStatus;
+            row.headers = params[6] as Record<string, string> | undefined;
+            row.auth_url = params[7] as string | null;
+            row.expires_at = params[8] as string | null;
             row.updated_at = new Date().toISOString();
             return [{ id: row.id }];
         }
@@ -345,5 +334,198 @@ test.describe('NeonStorageBackend', () => {
         await storage.clearAll();
         expect(await storage.list('user-b')).toEqual([]);
         expect(mockNeon.listSessions()).toEqual([]);
+    });
+
+    // ── generateSessionId ────────────────────────────────────────────────
+    test.describe('generateSessionId', () => {
+        test('generates unique UUIDs', () => {
+            const id1 = storage.generateSessionId();
+            const id2 = storage.generateSessionId();
+            expect(id1).not.toBe(id2);
+            expect(id1).toMatch(/^sess_[a-zA-Z0-9]{21}$/);
+        });
+    });
+
+    // ── create field mapping ─────────────────────────────────────────────
+    test.describe('create', () => {
+        test('maps all Session fields to snake_case columns', async () => {
+            const session = createMockSession();
+            await storage.create(session);
+
+            const rows = mockNeon.listSessions();
+            expect(rows.length).toBe(1);
+            const row = rows[0];
+            expect(row.session_id).toBe(session.sessionId);
+            expect(row.user_id).toBe(session.userId);
+            expect(row.server_id).toBe(session.serverId);
+            expect(row.server_name).toBe(session.serverName);
+            expect(row.server_url).toBe(session.serverUrl);
+            expect(row.transport_type).toBe(session.transportType);
+            expect(row.callback_url).toBe(session.callbackUrl);
+            expect(row.status).toBe(session.status);
+        });
+
+        test('sets short expires_at for pending sessions', async () => {
+            const before = Date.now();
+            await storage.create(createMockSession({ status: 'pending' }));
+
+            const rows = mockNeon.listSessions();
+            const expiresMs = new Date(rows[0].expires_at!).getTime();
+            expect(expiresMs).toBeGreaterThanOrEqual(before + STATE_EXPIRATION_MS - 100);
+            expect(expiresMs).toBeLessThanOrEqual(Date.now() + STATE_EXPIRATION_MS + 100);
+        });
+
+        test('leaves expires_at null for active sessions', async () => {
+            await storage.create(createMockSession({ status: 'active' }));
+
+            const rows = mockNeon.listSessions();
+            expect(rows[0].expires_at).toBeNull();
+        });
+
+        test('keeps headers on session and tokens in credentials', async () => {
+            const tokens = createMockTokens();
+            const oauthState = {
+                nonce: 'nonce-1',
+                sessionId: 'test-session-123',
+                serverId: 'test-server',
+                createdAt: Date.now(),
+            };
+            const session = createMockSession({ headers: { Authorization: 'Bearer xyz' } });
+            await storage.create(session);
+            await storage.patchCredentials(session.userId, session.sessionId, { tokens, oauthState });
+
+            const sessionRows = mockNeon.listSessions();
+            const credentialRows = mockNeon.listCredentials();
+            expect((sessionRows[0] as any).tokens).toBeUndefined();
+            expect(sessionRows[0].headers).toEqual({ Authorization: 'Bearer xyz' });
+            expect(credentialRows[0].tokens).toEqual(tokens);
+            expect(credentialRows[0].oauth_state).toEqual(oauthState);
+        });
+    });
+
+    // ── get ──────────────────────────────────────────────────────────────
+    test.describe('get', () => {
+        test('maps DB row back to camelCase Session correctly', async () => {
+            const session = createMockSession();
+            await storage.create(session);
+
+            const result = await storage.get(session.userId, session.sessionId);
+            expect(result).not.toBeNull();
+            expect(result?.sessionId).toBe(session.sessionId);
+            expect(result?.serverId).toBe(session.serverId);
+            expect(result?.serverName).toBe(session.serverName);
+            expect(result?.serverUrl).toBe(session.serverUrl);
+            expect(result?.transportType).toBe(session.transportType);
+            expect(result?.callbackUrl).toBe(session.callbackUrl);
+            expect(result?.userId).toBe(session.userId);
+            expect(result?.status).toBe(session.status);
+            expect(typeof result?.createdAt).toBe('number');
+        });
+
+        test('returns null when session does not exist', async () => {
+            expect(await storage.get('ghost', 'ghost')).toBeNull();
+        });
+
+        test('does not leak sessions across userIds', async () => {
+            await storage.create(createMockSession({ sessionId: 'a', userId: 'user-a' }));
+            await storage.create(createMockSession({ sessionId: 'b', userId: 'user-b' }));
+
+            expect(await storage.get('user-a', 'b')).toBeNull();
+        });
+    });
+
+    // ── delete ───────────────────────────────────────────────────────────
+    test.describe('delete', () => {
+        test('does not remove other sessions belonging to the same userId', async () => {
+            const userId = 'multi-user';
+            await storage.create(createMockSession({ sessionId: 's1', userId }));
+            await storage.create(createMockSession({ sessionId: 's2', userId }));
+
+            await storage.delete(userId, 's1');
+
+            const remaining = await storage.listIds(userId);
+            expect(remaining).toEqual(['s2']);
+        });
+    });
+
+    // ── listIds ──────────────────────────────────────────────────────────
+    test.describe('listIds', () => {
+        test('returns only session IDs (not full objects)', async () => {
+            const userId = 'slim-user';
+            await storage.create(createMockSession({ sessionId: 'id-a', userId }));
+            await storage.create(createMockSession({ sessionId: 'id-b', userId }));
+
+            const ids = await storage.listIds(userId);
+            expect(ids.sort()).toEqual(['id-a', 'id-b']);
+        });
+    });
+
+    // ── clearCredentials ─────────────────────────────────────────────────
+    test.describe('clearCredentials', () => {
+        test('removes credentials row while session remains intact', async () => {
+            const session = createMockSession();
+            const tokens = createMockTokens();
+            await storage.create(session);
+            await storage.patchCredentials(session.userId, session.sessionId, { tokens });
+
+            expect(mockNeon.listCredentials().length).toBe(1);
+
+            await storage.clearCredentials(session.userId, session.sessionId);
+
+            const credentials = await storage.getCredentials(session.userId, session.sessionId);
+            const retrieved = await storage.get(session.userId, session.sessionId);
+            expect(credentials?.tokens).toBeUndefined();
+            expect(retrieved).not.toBeNull();
+            expect(mockNeon.listCredentials().length).toBe(0);
+        });
+    });
+
+    // ── update credential ops ────────────────────────────────────────────
+    test.describe('update', () => {
+        test('clears OAuth tokens when credentials are invalidated', async () => {
+            const session = createMockSession();
+            await storage.create(session);
+            await storage.patchCredentials(session.userId, session.sessionId, { tokens: createMockTokens() });
+
+            await storage.patchCredentials(session.userId, session.sessionId, { tokens: null });
+
+            const rows = mockNeon.listCredentials();
+            const credentials = await storage.getCredentials(session.userId, session.sessionId);
+            expect(rows[0].tokens).toBeNull();
+            expect(credentials?.tokens).toBeNull();
+        });
+
+        test('promotion to active clears expires_at', async () => {
+            const session = createMockSession({ status: 'pending' });
+            await storage.create(session);
+            expect(mockNeon.listSessions()[0].expires_at).not.toBeNull();
+
+            await storage.update(session.userId, session.sessionId, { status: 'active' });
+
+            const row = mockNeon.listSessions()[0];
+            expect(row.expires_at).toBeNull();
+        });
+    });
+
+    // ── cleanupExpired (dormant active) ──────────────────────────────────
+    test.describe('cleanupExpired', () => {
+        test('deletes dormant active sessions by updated_at', async () => {
+            await storage.create(createMockSession({
+                sessionId: 'dormant',
+                status: 'active',
+                updatedAt: Date.now() - DORMANT_SESSION_EXPIRATION_MS - 1000,
+            }));
+
+            await storage.cleanupExpired();
+
+            expect(mockNeon.listSessions()).toEqual([]);
+        });
+    });
+
+    // ── disconnect ───────────────────────────────────────────────────────
+    test.describe('disconnect', () => {
+        test('resolves cleanly (no persistent connection to close)', async () => {
+            await expect(storage.disconnect()).resolves.toBeUndefined();
+        });
     });
 });


### PR DESCRIPTION
## What is the type of this PR?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [x] Documentation
- [ ] Other

## Which area of the project does this PR affect?

- [x] server (MCP client, handlers)
- [x] client (React, Vue, SSE client)
- [x] adapters (Vercel AI, LangChain, Mastra, AG-UI)
- [x] storage (Redis, SQLite, File, Memory backends)
- [x] docs (Mintlify documentation)
- [ ] examples (Example applications)
- [ ] ci (GitHub workflows)
- [ ] Other

## Description of the change

This PR introduces per-session MCP tool policy enforcement with allowlist and denylist support across the SDK.

### Highlights

- Add `ToolPolicy` and `ToolPolicyMode` types
- Add utilities for tool policy normalization, validation, and filtering
- Introduce `ToolPolicyGateway` for runtime enforcement before tool execution
- Add `setToolPolicy` and `getToolPolicy` SSE/RPC methods
- Filter tools returned from `listTools()` based on effective session policy
- Prevent blocked tools from executing through `callTool()`
- Add tool policy support to React `useMcp` hook and SSE client
- Add optional `tool_policy` persistence support for Neon and Supabase
- Add new Tool Policy documentation pages and migration guidance
- Add tests covering allowlist/denylist enforcement and storage persistence

### Why

This enables multi-tenant and security-sensitive MCP deployments to restrict which tools are accessible or executable per session while preserving unrestricted behavior by default.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] Code follows TypeScript strict mode guidelines
- [x] Tests added/updated
- [x] Documentation updated (if user-facing change)
- [x] Build succeeds (npm run build)
- [x] Type check passes (npm run type-check)
- [x] All tests pass (npm test)
- [x] Commit messages follow conventional format

## Related Issue

Closes #
