### PR TITLE
feat: improve OAuth popup reconnect flow

### DIFF
--- a/examples/next/app/components/McpSidebar.tsx
+++ b/examples/next/app/components/McpSidebar.tsx
@@ -45,6 +45,7 @@ export default function McpSidebar({ mcpClient, onCollapse }: McpSidebarProps) {
     isInitializing,
     connect,
     disconnect,
+    reconnect,
     callTool,
     finishAuth,
   } = mcpClient;
@@ -77,6 +78,22 @@ export default function McpSidebar({ mcpClient, onCollapse }: McpSidebarProps) {
     try {
       await disconnect(sessionId);
     } catch {}
+  };
+
+  const handleReconnect = async (connection: Connection) => {
+    try {
+      const callbackUrl = `${window.location.origin}/oauth/callback-popup`;
+      await reconnect({
+        serverId: connection.serverId,
+        serverName: connection.serverName,
+        serverUrl: connection.serverUrl,
+        callbackUrl,
+        transportType:
+          connection.transport === "streamable-http" ? "streamable-http" : "sse",
+      });
+    } catch (err) {
+      console.error("Failed to reconnect:", err);
+    }
   };
 
   const handleSelectTool = (sessionId: string, toolName: string) => {
@@ -160,6 +177,7 @@ export default function McpSidebar({ mcpClient, onCollapse }: McpSidebarProps) {
             connections={connections as Connection[]}
             isInitializing={isInitializing}
             onDisconnect={handleDisconnect}
+            onReconnect={handleReconnect}
             onSelectTool={handleSelectTool}
           />
         </div>

--- a/examples/next/app/components/dashboard/ConnectionItem.tsx
+++ b/examples/next/app/components/dashboard/ConnectionItem.tsx
@@ -13,6 +13,7 @@ import type { Connection } from "./types";
 interface ConnectionItemProps {
   connection: Connection;
   onDisconnect: (sessionId: string) => void;
+  onReconnect: (connection: Connection) => void;
   onSelectTool: (sessionId: string, toolName: string) => void;
 }
 
@@ -46,6 +47,7 @@ function formatTimestamp(value?: Date | string | number) {
 export default function ConnectionItem({
   connection,
   onDisconnect,
+  onReconnect,
   onSelectTool,
 }: ConnectionItemProps) {
   const sessionIdStr = String(connection.sessionId);
@@ -71,15 +73,26 @@ export default function ConnectionItem({
             </span>
           </div>
         </div>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="h-8 shrink-0 text-xs"
-          onClick={() => onDisconnect(sessionIdStr)}
-        >
-          Disconnect
-        </Button>
+        <div className="flex items-center gap-1.5 shrink-0">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 text-xs hover:bg-accent hover:text-accent-foreground"
+            onClick={() => onReconnect(connection)}
+          >
+            Reconnect
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 text-xs text-destructive hover:bg-destructive/10"
+            onClick={() => onDisconnect(sessionIdStr)}
+          >
+            Disconnect
+          </Button>
+        </div>
       </div>
 
       {connection.error ? (

--- a/examples/next/app/components/dashboard/ConnectionList.tsx
+++ b/examples/next/app/components/dashboard/ConnectionList.tsx
@@ -8,6 +8,7 @@ interface ConnectionListProps {
   connections: Connection[];
   isInitializing: boolean;
   onDisconnect: (sessionId: string) => void;
+  onReconnect: (connection: Connection) => void;
   onSelectTool: (sessionId: string, toolName: string) => void;
 }
 
@@ -15,6 +16,7 @@ export default function ConnectionList({
   connections,
   isInitializing,
   onDisconnect,
+  onReconnect,
   onSelectTool,
 }: ConnectionListProps) {
   return (
@@ -49,6 +51,7 @@ export default function ConnectionList({
             <ConnectionItem
               connection={connection}
               onDisconnect={onDisconnect}
+              onReconnect={onReconnect}
               onSelectTool={onSelectTool}
             />
           </li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-ts/sdk",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-ts/sdk",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-ts/sdk",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "publishConfig": {
     "access": "public"
   },

--- a/src/client/core/sse-client.ts
+++ b/src/client/core/sse-client.ts
@@ -102,6 +102,10 @@ export class SSEClient {
     return this.sendRequest<DisconnectResult>('disconnect', { sessionId });
   }
 
+  async reconnectToServer(params: ConnectParams): Promise<ConnectResult> {
+    return this.sendRequest<ConnectResult>('reconnect', params);
+  }
+
   async setToolPolicy(
     sessionId: string,
     toolPolicy: Pick<ToolPolicy, 'mode'> & { toolIds?: string[] }

--- a/src/client/react/oauth-popup.tsx
+++ b/src/client/react/oauth-popup.tsx
@@ -135,7 +135,6 @@ export function createOAuthPopupRedirectHandler(
     openCenteredPopup(url, {
       ...options,
       onBlocked: options.onBlocked ?? ((blockedUrl) => {
-        window.alert('Popup blocked! Allow popups for this site to complete authentication.');
         window.location.href = blockedUrl;
       }),
     });
@@ -179,30 +178,26 @@ export function useMcpOAuthPopup<TConnection extends OAuthPopupConnectionLike>(
             : '';
       const targetSessionId = rawState ? parseOAuthState(rawState)?.sessionId || rawState : '';
 
-      if (popupWindow && targetSessionId) {
+      if (targetSessionId) {
         pendingPopupsRef.current.set(targetSessionId, { popupWindow, state: rawState });
       }
 
       if (!targetSessionId) {
-        if (popupWindow) {
-          postPopupResult(popupWindow, {
-            success: false,
-            error: 'Missing OAuth session identifier',
-          });
-        }
+        postPopupResult(popupWindow, {
+          success: false,
+          error: 'Missing OAuth session identifier',
+        });
         return;
       }
 
       const targetSession = connections.find((connection) => connection.sessionId === targetSessionId);
       if (!targetSession) {
-        if (popupWindow) {
-          postPopupResult(popupWindow, {
-            sessionId: targetSessionId,
-            state: rawState,
-            success: false,
-            error: 'OAuth session not found in the current client state',
-          });
-        }
+        postPopupResult(popupWindow, {
+          sessionId: targetSessionId,
+          state: rawState,
+          success: false,
+          error: 'OAuth session not found in the current client state',
+        });
         return;
       }
 
@@ -217,14 +212,12 @@ export function useMcpOAuthPopup<TConnection extends OAuthPopupConnectionLike>(
       } catch (error) {
         processingCodesRef.current.delete(codeKey);
         pendingPopupsRef.current.delete(targetSession.sessionId);
-        if (popupWindow) {
-          postPopupResult(popupWindow, {
-            sessionId: rawState,
-            state: rawState,
-            success: false,
-            error: error instanceof Error ? error.message : 'Failed to finish auth',
-          });
-        }
+        postPopupResult(popupWindow, {
+          sessionId: rawState,
+          state: rawState,
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to finish auth',
+        });
       }
     };
 

--- a/src/client/react/use-mcp.ts
+++ b/src/client/react/use-mcp.ts
@@ -516,24 +516,15 @@ export function useMcp(options: UseMcpOptions): McpClient {
         throw new Error('SSE client not initialized');
       }
 
-      // Find and disconnect existing session for the same server
-      const existing = connections.find(
-        (c: McpConnection) => c.serverId === params.serverId || c.serverUrl === params.serverUrl
-      );
-      if (existing) {
-        await clientRef.current.disconnectFromServer(existing.sessionId);
-        if (isMountedRef.current) {
-          setConnections((prev: McpConnection[]) =>
-            prev.filter((c: McpConnection) => c.sessionId !== existing.sessionId)
-          );
-        }
-      }
+      const result = await clientRef.current.reconnectToServer(params);
 
-      // Connect fresh
-      const result = await clientRef.current.connectToServer(params);
+      // The server emits connection events for the new session via SSE,
+      // so local state is kept in sync automatically. No manual removal
+      // of the old session or insertion of the new one needed here.
+
       return result.sessionId;
     },
-    [connections]
+    []
   );
 
   /**

--- a/src/server/handlers/sse-handler.ts
+++ b/src/server/handlers/sse-handler.ts
@@ -369,8 +369,8 @@ export class SSEConnectionManager {
   }
 
   /**
-   * Reconnect to an MCP server — tears down the existing session and
-   * creates a fresh connection in a single RPC call.
+   * Reconnect to an MCP server — tears down the active client transport/connection
+   * and creates a fresh connection while reusing the existing session credentials in a single RPC call.
    */
   private async reconnect(params: ReconnectParams): Promise<ConnectResult> {
     const { serverId: rawServerId, serverName, serverUrl, callbackUrl, transportType } = params;
@@ -381,27 +381,28 @@ export class SSEConnectionManager {
       ? rawServerId
       : generateServerId();
 
-    // Find and disconnect existing session for the same server
+    // Find existing session for the same server to reuse its session ID
     const existingSessions = await sessions.list(this.userId);
     const duplicate = existingSessions.find(s =>
       s.serverId === serverId || s.serverUrl === serverUrl
     );
+
+    // Reuse the duplicate sessionId if present, otherwise generate a new one
+    const sessionId = duplicate ? duplicate.sessionId : await sessions.generateSessionId();
+
     if (duplicate) {
+      // Disconnect any active in-memory client transport without deleting the database session
       const existingClient = this.clients.get(duplicate.sessionId);
       if (existingClient) {
-        await existingClient.clearSession();
+        await existingClient.disconnect();
         this.clients.delete(duplicate.sessionId);
-      } else {
-        await sessions.delete(this.userId, duplicate.sessionId);
       }
     }
-
-    // Generate new session ID
-    const sessionId = await sessions.generateSessionId();
 
     try {
       const clientMetadata = await this.getResolvedClientMetadata();
 
+      // Create a new client instantiating the reused session ID (which preserves DCR credentials and tokens)
       const client = new MCPClient({
         userId: this.userId,
         sessionId,

--- a/src/server/handlers/sse-handler.ts
+++ b/src/server/handlers/sse-handler.ts
@@ -18,6 +18,7 @@ import type {
   McpRpcResponse,
   ConnectParams,
   DisconnectParams,
+  ReconnectParams,
   SessionParams,
   CallToolParams,
   GetPromptParams,
@@ -164,6 +165,10 @@ export class SSEConnectionManager {
 
         case 'connect':
           result = await this.connect(request.params as ConnectParams);
+          break;
+
+        case 'reconnect':
+          result = await this.reconnect(request.params as ReconnectParams);
           break;
 
         case 'disconnect':
@@ -359,6 +364,86 @@ export class SSEConnectionManager {
       // Clean up client
       this.clients.delete(sessionId);
 
+      throw error;
+    }
+  }
+
+  /**
+   * Reconnect to an MCP server — tears down the existing session and
+   * creates a fresh connection in a single RPC call.
+   */
+  private async reconnect(params: ReconnectParams): Promise<ConnectResult> {
+    const { serverId: rawServerId, serverName, serverUrl, callbackUrl, transportType } = params;
+    const headers = normalizeHeaders(params.headers);
+
+    // Normalize serverId the same way connect() does
+    const serverId = rawServerId && rawServerId.length <= 12
+      ? rawServerId
+      : generateServerId();
+
+    // Find and disconnect existing session for the same server
+    const existingSessions = await sessions.list(this.userId);
+    const duplicate = existingSessions.find(s =>
+      s.serverId === serverId || s.serverUrl === serverUrl
+    );
+    if (duplicate) {
+      const existingClient = this.clients.get(duplicate.sessionId);
+      if (existingClient) {
+        await existingClient.clearSession();
+        this.clients.delete(duplicate.sessionId);
+      } else {
+        await sessions.delete(this.userId, duplicate.sessionId);
+      }
+    }
+
+    // Generate new session ID
+    const sessionId = await sessions.generateSessionId();
+
+    try {
+      const clientMetadata = await this.getResolvedClientMetadata();
+
+      const client = new MCPClient({
+        userId: this.userId,
+        sessionId,
+        serverId,
+        serverName,
+        serverUrl,
+        callbackUrl,
+        transportType,
+        headers,
+        ...clientMetadata,
+      });
+
+      this.clients.set(sessionId, client);
+
+      client.onConnectionEvent((event) => {
+        this.emitConnectionEvent(event);
+      });
+
+      client.onObservabilityEvent((event) => {
+        this.sendEvent(event);
+      });
+
+      await client.connect();
+      await this.listPolicyFilteredTools(sessionId);
+
+      return { sessionId, success: true };
+    } catch (error) {
+      if (error instanceof UnauthorizedError) {
+        this.clients.delete(sessionId);
+        return { sessionId, success: true };
+      }
+
+      this.emitConnectionEvent({
+        type: 'error',
+        sessionId,
+        serverId,
+        error: error instanceof Error ? error.message : 'Connection failed',
+        errorType: 'connection',
+        timestamp: Date.now(),
+      });
+
+      this.clients.delete(sessionId);
       throw error;
     }
   }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -182,6 +182,7 @@ export interface ToolPolicy {
 export type McpRpcMethod =
   | 'connect'
   | 'disconnect'
+  | 'reconnect'
   | 'listTools'
   | 'callTool'
   | 'listSessions'
@@ -222,6 +223,8 @@ export interface ConnectParams {
 export interface DisconnectParams {
   sessionId: string;
 }
+
+export type ReconnectParams = ConnectParams;
 
 export interface SessionParams {
   sessionId: string;
@@ -264,6 +267,7 @@ export interface GetToolPolicyParams {
 export type McpRpcParams =
   | ConnectParams
   | DisconnectParams
+  | ReconnectParams
   | SessionParams
   | CallToolParams
   | GetPromptParams


### PR DESCRIPTION
## What is the type of this PR?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Which area of the project does this PR affect?

- [x] server (MCP client, handlers)
- [x] client (React, Vue, SSE client)
- [ ] adapters (Vercel AI, LangChain, Mastra, AG-UI)
- [ ] storage (Redis, SQLite, File, Memory backends)
- [ ] docs (Mintlifg documentation)
- [x] examples (Example applications)
- [ ] ci (GitHub workflows)
- [ ] Other

## Description of the change

Improves OAuth popup reconnect handling and related connection recovery flow.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] Code follows TypeScript strict mode guidelines
- [ ] Tests added/updated
- [ ] Documentation updated (if user-facing change)
- [x] Build succeeds (npm run build)
- [ ] Type check passes (npm run type-check)
- [x] All tests pass (npm test)
- [x] Commit messages follow conventional format

## Related Issue

Closes: N/A