### PR TITLE
feat(codemode): Add QuickJS sandbox runtime with automatic runtime detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3478,6 +3478,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-CIP+NDRYDDqbT3cTiN8Bon1wsZ7IgISVYCJHYsPc86oxszpepVMPXFfttyQgn1u1okg1HPnCnM7Xv1LrCO/VmQ==",
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -4403,8 +4409,11 @@
     },
     "packages/code-mode": {
       "name": "@mcp-ts/codemode",
-      "version": "0.2.5",
+      "version": "0.2.8",
       "license": "MIT",
+      "dependencies": {
+        "quickjs-emscripten": "^0.23.0"
+      },
       "devDependencies": {
         "@types/node": "^25.0.10",
         "tsup": "^8.5.1",
@@ -4435,7 +4444,7 @@
     },
     "packages/sdk": {
       "name": "@mcp-ts/sdk",
-      "version": "2.5.2",
+      "version": "2.6.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3482,7 +3482,8 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-CIP+NDRYDDqbT3cTiN8Bon1wsZ7IgISVYCJHYsPc86oxszpepVMPXFfttyQgn1u1okg1HPnCnM7Xv1LrCO/VmQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -4411,9 +4412,6 @@
       "name": "@mcp-ts/codemode",
       "version": "0.2.8",
       "license": "MIT",
-      "dependencies": {
-        "quickjs-emscripten": "^0.23.0"
-      },
       "devDependencies": {
         "@types/node": "^25.0.10",
         "tsup": "^8.5.1",
@@ -4423,7 +4421,8 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "isolated-vm": "^6.1.2"
+        "isolated-vm": "^6.1.2",
+        "quickjs-emscripten": "^0.23.0"
       },
       "peerDependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/code-mode/package.json
+++ b/packages/code-mode/package.json
@@ -31,11 +31,10 @@
     "test:quickjs": "npm run build && node --test test/quickjs.test.mjs",
     "type-check": "tsc --noEmit"
   },
-  "dependencies": {
-    "quickjs-emscripten": "^0.23.0"
-  },
+  "dependencies": {},
   "optionalDependencies": {
-    "isolated-vm": "^6.1.2"
+    "isolated-vm": "^6.1.2",
+    "quickjs-emscripten": "^0.23.0"
   },
   "peerDependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/code-mode/package.json
+++ b/packages/code-mode/package.json
@@ -28,6 +28,7 @@
     "postbuild": "node -e \"var fs=require('fs'),cp=require('child_process');['../../../mcp-server/scripts/resolve-local-pkg.cjs'].forEach(function(f){fs.existsSync(f)&&cp.execSync('node '+f,{cwd:__dirname,stdio:'inherit'})})\"",
     "prepublishOnly": "npm run build",
     "test": "npm run build && node --test test/*.test.mjs",
+    "test:quickjs": "npm run build && node --test test/quickjs.test.mjs",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/code-mode/package.json
+++ b/packages/code-mode/package.json
@@ -30,7 +30,9 @@
     "test": "npm run build && node --test test/*.test.mjs",
     "type-check": "tsc --noEmit"
   },
-  "dependencies": {},
+  "dependencies": {
+    "quickjs-emscripten": "^0.23.0"
+  },
   "optionalDependencies": {
     "isolated-vm": "^6.1.2"
   },

--- a/packages/code-mode/package.json
+++ b/packages/code-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-ts/codemode",
-  "version": "0.2.8",
+  "version": "0.3.0-b.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/code-mode/src/index.ts
+++ b/packages/code-mode/src/index.ts
@@ -1,5 +1,5 @@
 // Runtime
-export { createCodeModeRuntime, IsolatedVmCodeModeRuntime } from "./runtime/runtime.js";
+export { createCodeModeRuntime, IsolatedVmCodeModeRuntime, BaseCodeModeRuntime } from "./runtime/runtime.js";
 // Error types and classification
 export { CodemodeError, classifyError } from "./runtime/errors.js";
 

--- a/packages/code-mode/src/index.ts
+++ b/packages/code-mode/src/index.ts
@@ -1,5 +1,5 @@
 // Runtime
-export { createCodeModeRuntime, IsolatedVmCodeModeRuntime, BaseCodeModeRuntime } from "./runtime/runtime.js";
+export { createCodeModeRuntime, IsolatedVmCodeModeRuntime, BaseCodeModeRuntime, QuickJsCodeModeRuntime } from "./runtime/runtime.js";
 // Error types and classification
 export { CodemodeError, classifyError } from "./runtime/errors.js";
 

--- a/packages/code-mode/src/runtime/base-runtime.ts
+++ b/packages/code-mode/src/runtime/base-runtime.ts
@@ -1,0 +1,203 @@
+import type {
+  CodeModeLimits,
+  CodeModeLogEntry,
+  CodeModeResult,
+  CodeModeRunOptions,
+  CodeModeRuntime,
+  CodeModeRuntimeOptions,
+  CodeModeToolCall,
+  IndexedTool,
+  ToolSearchResult,
+  ToolServer,
+} from "../types.js";
+import { CodemodeError, classifyError } from "./errors.js";
+import { estimateJsonBytes, resolveLimits } from "./limits.js";
+import {
+  indexServers,
+  listServersFromIndex,
+  normalizeServerId,
+  resolveTool,
+  searchToolIndex,
+} from "./tool-index.js";
+import {
+  generateAllInterfaces,
+  generateInterfaceMap,
+  generateBootstrapCode,
+  generateNamespaceBridgeCode,
+  toolToTypeScriptInterface,
+} from "./sandbox-bridge.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function extractToolErrorText(result: Record<string, unknown>): string | undefined {
+  const content = result.content;
+  if (typeof content === "string") {
+    return content.replace(/^Error:\s*/i, "");
+  }
+  if (Array.isArray(content) && content.length > 0) {
+    const first = content[0];
+    if (isRecord(first) && typeof first.text === "string") return first.text.replace(/^Error:\s*/i, "");
+    if (typeof first === "string") return first.replace(/^Error:\s*/i, "");
+    return JSON.stringify(first);
+  }
+  if (isRecord(content)) {
+    const maybeError = (content as Record<string, unknown>).error ?? (content as Record<string, unknown>).message;
+    if (typeof maybeError === "string") return maybeError;
+    return JSON.stringify(content);
+  }
+  return undefined;
+}
+
+export abstract class BaseCodeModeRuntime implements CodeModeRuntime {
+  protected servers: Map<string, ToolServer>;
+  protected indexedTools: IndexedTool[] = [];
+  protected initialized = false;
+  protected maxSearchResults: number;
+
+  constructor(protected options: CodeModeRuntimeOptions) {
+    this.maxSearchResults = options.maxSearchResults ?? 10;
+    this.servers = new Map<string, ToolServer>();
+    for (const server of options.servers) {
+      this.servers.set(normalizeServerId(server.serverId), server);
+    }
+  }
+
+  protected async ensureInitialized(): Promise<void> {
+    if (!this.initialized) {
+      this.indexedTools = await indexServers(this.options.servers);
+      this.initialized = true;
+    }
+  }
+
+  async searchTools(query: string, limit?: number): Promise<ToolSearchResult[]> {
+    await this.ensureInitialized();
+    return searchToolIndex(this.indexedTools, query, limit ?? this.maxSearchResults);
+  }
+
+  listServers(): Array<{ serverId: string; serverName: string; toolCount: number }> {
+    return listServersFromIndex(this.indexedTools);
+  }
+
+  getToolInterfaces(toolNames: string[]): string {
+    const interfaces: string[] = [];
+    const notFound: string[] = [];
+
+    for (const name of toolNames) {
+      let tool: IndexedTool | undefined;
+      if (name.includes(".")) {
+        const [serverId, ...rest] = name.split(".");
+        const toolName = rest.join(".");
+        tool = resolveTool(this.indexedTools, toolName, serverId);
+      } else {
+        tool = resolveTool(this.indexedTools, name);
+      }
+
+      if (tool) {
+        interfaces.push(toolToTypeScriptInterface(tool));
+      } else {
+        notFound.push(`// Tool '${name}' not found`);
+      }
+    }
+
+    if (interfaces.length === 0 && notFound.length > 0) {
+      return notFound.join("\n");
+    }
+    let result = interfaces.join("\n\n");
+    if (notFound.length > 0) {
+      result += "\n\n" + notFound.join("\n");
+    }
+    return result;
+  }
+
+  abstract run(
+    code: string,
+    input?: unknown,
+    options?: CodeModeRunOptions,
+  ): Promise<CodeModeResult>;
+
+  protected async hostCallTool(
+    serverId: string,
+    toolName: string,
+    argsJson: string,
+    toolCalls: CodeModeToolCall[],
+    activeToolCallsRef: { value: number },
+    totalToolCallsRef: { value: number },
+    limits: Required<CodeModeLimits>,
+  ): Promise<string> {
+    if (totalToolCallsRef.value >= limits.maxToolCalls) {
+      return JSON.stringify({ success: true, result: { error: `maxToolCalls ${limits.maxToolCalls} exceeded.`, isError: true } });
+    }
+    if (activeToolCallsRef.value >= limits.maxConcurrentToolCalls) {
+      return JSON.stringify({ success: true, result: { error: `maxConcurrentToolCalls ${limits.maxConcurrentToolCalls} exceeded.`, isError: true } });
+    }
+
+    activeToolCallsRef.value += 1;
+    totalToolCallsRef.value += 1;
+    const callStartedAt = Date.now();
+    const call: CodeModeToolCall = {
+      id: `call_${totalToolCallsRef.value}`,
+      serverId,
+      toolName,
+      args: null as unknown as Record<string, unknown>,
+      startedAt: callStartedAt,
+      durationMs: 0,
+      ok: false,
+    };
+    toolCalls.push(call);
+
+    try {
+      const args = JSON.parse(argsJson);
+      call.args = args;
+
+      let server = this.servers.get(normalizeServerId(serverId));
+      if (!server) {
+        const tool = resolveTool(this.indexedTools, toolName, serverId);
+        if (!tool) throw new Error(`Tool "${toolName}" was not found on server "${serverId}".`);
+        server = this.servers.get(tool.serverId);
+        if (!server) throw new Error(`Server "${tool.serverId}" is no longer registered.`);
+      }
+
+      const result = await server.callTool(toolName, args);
+      if (isRecord(result) && result.isError === true) {
+        call.ok = false;
+        call.error = extractToolErrorText(result) || "MCP tool returned an error";
+      } else {
+        call.ok = true;
+      }
+      return JSON.stringify({ success: true, result });
+    } catch (error) {
+      call.ok = false;
+      call.error = error instanceof Error ? error.message : String(error);
+      return JSON.stringify({ success: true, result: { error: call.error, isError: true } });
+    } finally {
+      call.durationMs = Date.now() - callStartedAt;
+      activeToolCallsRef.value -= 1;
+    }
+  }
+
+  protected hostSearchTools(query: string, limit: number): string {
+    const results = searchToolIndex(this.indexedTools, query, limit);
+    return JSON.stringify(results);
+  }
+
+  protected hostGetToolSchema(serverId: string, toolName: string): string {
+    const tool = resolveTool(this.indexedTools, toolName, serverId);
+    if (!tool) {
+      return JSON.stringify({ error: `Tool "${toolName}" not found on server "${serverId}".` });
+    }
+    return JSON.stringify(tool);
+  }
+
+  protected hostLog(
+    level: CodeModeLogEntry["level"],
+    args: unknown[],
+    logs: CodeModeLogEntry[],
+    limits: Required<CodeModeLimits>,
+  ): void {
+    if (logs.length < limits.maxLogEntries) {
+      logs.push({ level, args });
+    }
+  }
+}

--- a/packages/code-mode/src/runtime/quickjs-runtime.ts
+++ b/packages/code-mode/src/runtime/quickjs-runtime.ts
@@ -184,8 +184,13 @@ export class QuickJsCodeModeRuntime extends BaseCodeModeRuntime {
       });
       timeoutPromise.catch(() => {});
 
-      // User code execution — the last expression is the return value
-      const userResult = await Promise.race([ctx.evalCodeAsync(code), timeoutPromise]);
+      // User code execution — wrap in IIFE only if code starts with `return` (Issue 2)
+      let codeToExecute = code;
+      if (code.trimStart().startsWith("return")) {
+        const codeBody = code.replace(/^\s*return\b\s*/, "");
+        codeToExecute = `(function() { return ${codeBody} })()`;
+      }
+      const userResult = await Promise.race([ctx.evalCodeAsync(codeToExecute), timeoutPromise]);
       if (userResult.error) {
         const errHandle = userResult.error;
         const errMsg = ctx.dump(errHandle);

--- a/packages/code-mode/src/runtime/quickjs-runtime.ts
+++ b/packages/code-mode/src/runtime/quickjs-runtime.ts
@@ -1,0 +1,233 @@
+import type {
+  CodeModeLogEntry,
+  CodeModeResult,
+  CodeModeRunOptions,
+  CodeModeToolCall,
+} from "../types.js";
+import { CodemodeError, classifyError } from "./errors.js";
+import { estimateJsonBytes, resolveLimits } from "./limits.js";
+import { resolveTool } from "./tool-index.js";
+import {
+  generateAllInterfaces,
+  generateInterfaceMap,
+  generateBootstrapCode,
+  generateNamespaceBridgeCode,
+} from "./sandbox-bridge.js";
+import { BaseCodeModeRuntime } from "./base-runtime.js";
+
+export class QuickJsCodeModeRuntime extends BaseCodeModeRuntime {
+  async run(
+    code: string,
+    input: unknown = {},
+    runOptions: CodeModeRunOptions = {},
+  ): Promise<CodeModeResult> {
+    await this.ensureInitialized();
+
+    const startedAt = Date.now();
+    const limits = resolveLimits({
+      ...this.options.limits,
+      timeoutMs: runOptions.timeoutMs ?? this.options.limits?.timeoutMs,
+    });
+    const logs: CodeModeLogEntry[] = [];
+    const toolCalls: CodeModeToolCall[] = [];
+    const activeToolCallsRef = { value: 0 };
+    const totalToolCallsRef = { value: 0 };
+
+    const { newAsyncContext } = await importQuickJs();
+    const ctx = await newAsyncContext();
+
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      ctx.runtime.setMemoryLimit(limits.memoryLimitMb * 1024 * 1024);
+      const deadline = Date.now() + limits.timeoutMs;
+      ctx.runtime.setInterruptHandler(() => Date.now() >= deadline);
+
+      const hostCallTool = async (
+        serverId: string,
+        toolName: string,
+        argsJson: string,
+      ): Promise<string> => {
+        return this.hostCallTool(serverId, toolName, argsJson, toolCalls, activeToolCallsRef, totalToolCallsRef, limits);
+      };
+
+      const hostSearchTools = async (query: string, limit: number): Promise<string> => {
+        return this.hostSearchTools(query, limit);
+      };
+
+      const hostGetToolSchema = async (serverId: string, toolName: string): Promise<string> => {
+        return this.hostGetToolSchema(serverId, toolName);
+      };
+
+      const hostCallToolRaw = async (
+        serverId: string,
+        toolName: string,
+        argsJson: string,
+      ): Promise<string> => {
+        const tool = resolveTool(this.indexedTools, toolName, serverId);
+        if (!tool) {
+          return JSON.stringify({ success: true, result: { error: `Tool "${toolName}" was not found on server "${serverId}".`, isError: true } });
+        }
+
+        const server = this.servers.get(tool.serverId);
+        if (!server) {
+          return JSON.stringify({ success: true, result: { error: `Server "${tool.serverId}" is no longer registered.`, isError: true } });
+        }
+
+        try {
+          const result = server.callToolRaw
+            ? await server.callToolRaw(toolName, JSON.parse(argsJson))
+            : await server.callTool(toolName, JSON.parse(argsJson));
+          return JSON.stringify({ success: true, result });
+        } catch (error) {
+          const errorMsg = error instanceof Error ? error.message : String(error);
+          return JSON.stringify({ success: true, result: { error: errorMsg, isError: true } });
+        }
+      };
+
+      const hostLog = (level: CodeModeLogEntry["level"], args: unknown[]) => {
+        this.hostLog(level, args, logs, limits);
+      };
+
+      // Register asyncified host functions
+      const logRef = ctx.newAsyncifiedFunction("__logRef", async (...hostArgs) => {
+        const msgs = hostArgs.map((a) => ctx.getString(a));
+        hostLog("log", msgs);
+      });
+      ctx.setProp(ctx.global, "__logRef", logRef);
+
+      const errorRef = ctx.newAsyncifiedFunction("__errorRef", async (...hostArgs) => {
+        const msgs = hostArgs.map((a) => ctx.getString(a));
+        hostLog("error", msgs);
+      });
+      ctx.setProp(ctx.global, "__errorRef", errorRef);
+
+      const warnRef = ctx.newAsyncifiedFunction("__warnRef", async (...hostArgs) => {
+        const msgs = hostArgs.map((a) => ctx.getString(a));
+        hostLog("warn", msgs);
+      });
+      ctx.setProp(ctx.global, "__warnRef", warnRef);
+
+      const infoRef = ctx.newAsyncifiedFunction("__infoRef", async (...hostArgs) => {
+        const msgs = hostArgs.map((a) => ctx.getString(a));
+        hostLog("info", msgs);
+      });
+      ctx.setProp(ctx.global, "__infoRef", infoRef);
+
+      const callToolRef = ctx.newAsyncifiedFunction("__callToolRef", async (serverId, toolName, argsJson) => {
+        const s = ctx.getString(serverId);
+        const t = ctx.getString(toolName);
+        const a = ctx.getString(argsJson);
+        const result = await hostCallTool(s, t, a);
+        return ctx.newString(result);
+      });
+      ctx.setProp(ctx.global, "__callToolRef", callToolRef);
+
+      const callToolRawRef = ctx.newAsyncifiedFunction("__callToolRawRef", async (serverId, toolName, argsJson) => {
+        const s = ctx.getString(serverId);
+        const t = ctx.getString(toolName);
+        const a = ctx.getString(argsJson);
+        const result = await hostCallToolRaw(s, t, a);
+        return ctx.newString(result);
+      });
+      ctx.setProp(ctx.global, "__callToolRawRef", callToolRawRef);
+
+      const searchToolsRef = ctx.newAsyncifiedFunction("__searchToolsRef", async (query, limit) => {
+        const q = ctx.getString(query);
+        const l = ctx.getNumber(limit);
+        const result = await hostSearchTools(q, l);
+        return ctx.newString(result);
+      });
+      ctx.setProp(ctx.global, "__searchToolsRef", searchToolsRef);
+
+      const getToolSchemaRef = ctx.newAsyncifiedFunction("__getToolSchemaRef", async (serverId, toolName) => {
+        const s = ctx.getString(serverId);
+        const t = ctx.getString(toolName);
+        const result = await hostGetToolSchema(s, t);
+        return ctx.newString(result);
+      });
+      ctx.setProp(ctx.global, "__getToolSchemaRef", getToolSchemaRef);
+
+      // Input — serialize to JSON string, parse inside QuickJS
+      const inputHandle = ctx.newString(JSON.stringify(input));
+      ctx.setProp(ctx.global, "__input", inputHandle);
+
+      // Generate interfaces
+      const interfacesString = generateAllInterfaces(this.indexedTools);
+      const interfaceMap = generateInterfaceMap(this.indexedTools);
+      const interfaceMapJson = JSON.stringify(interfaceMap);
+
+      // Bootstrap: console, callTool, searchTools, interfaces
+      const bootstrapCode = generateBootstrapCode(interfacesString, interfaceMapJson, true);
+      const bootstrapResult = await ctx.evalCodeAsync(bootstrapCode);
+      if (bootstrapResult.error) {
+        const errMsg = ctx.dump(bootstrapResult.error);
+        throw new Error(`Bootstrap failed: ${errMsg?.message ?? String(errMsg)}`);
+      }
+
+      // Namespace bridging: server.tool(args) functions
+      const namespaceBridgeCode = generateNamespaceBridgeCode(this.indexedTools, this.servers, true);
+      if (namespaceBridgeCode.trim()) {
+        const nsResult = await ctx.evalCodeAsync(namespaceBridgeCode);
+        if (nsResult.error) {
+          const errMsg = ctx.dump(nsResult.error);
+          throw new Error(`Namespace bridge failed: ${errMsg?.message ?? String(errMsg)}`);
+        }
+      }
+
+      // Host-side timeout safety net
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(
+          () => reject(CodemodeError.timeout(`QuickJS execution timeout after ${limits.timeoutMs}ms`)),
+          limits.timeoutMs,
+        );
+      });
+      timeoutPromise.catch(() => {});
+
+      // User code execution — the last expression is the return value
+      const userResult = await Promise.race([ctx.evalCodeAsync(code), timeoutPromise]);
+      if (userResult.error) {
+        const errHandle = userResult.error;
+        const errMsg = ctx.dump(errHandle);
+        const message = errMsg?.message ?? String(errMsg);
+        const stack = errMsg?.stack;
+        const errorDetail = stack ? `${message}\n${stack}` : message;
+        throw new Error(errorDetail);
+      }
+
+      const raw = ctx.dump(userResult.value);
+
+      if (estimateJsonBytes(raw) > limits.maxResultBytes) {
+        throw CodemodeError.resultTooLarge(`Result too large: maxResultBytes ${limits.maxResultBytes} exceeded.`);
+      }
+
+      return {
+        value: raw,
+        logs,
+        toolCalls,
+        durationMs: Date.now() - startedAt,
+      };
+    } catch (error) {
+      return {
+        logs,
+        toolCalls,
+        durationMs: Date.now() - startedAt,
+        error: classifyError(error),
+      };
+    } finally {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      ctx.dispose();
+    }
+  }
+}
+
+async function importQuickJs(): Promise<typeof import("quickjs-emscripten")> {
+  try {
+    return await import("quickjs-emscripten");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `quickjs-emscripten is required to run codemode sandboxes but could not be loaded: ${message}`,
+    );
+  }
+}

--- a/packages/code-mode/src/runtime/runtime.ts
+++ b/packages/code-mode/src/runtime/runtime.ts
@@ -17,6 +17,7 @@ import {
 } from "./sandbox-bridge.js";
 import { BaseCodeModeRuntime } from "./base-runtime.js";
 export { BaseCodeModeRuntime } from "./base-runtime.js";
+export { QuickJsCodeModeRuntime } from "./quickjs-runtime.js";
 
 export class IsolatedVmCodeModeRuntime extends BaseCodeModeRuntime {
   async run(
@@ -220,13 +221,25 @@ export class IsolatedVmCodeModeRuntime extends BaseCodeModeRuntime {
 export async function createCodeModeRuntime(
   options: CodeModeRuntimeOptions & { runtime?: 'isolated-vm' | 'quickjs' },
 ): Promise<CodeModeRuntime> {
-  const runtimeType = options.runtime ?? 'isolated-vm';
+  const runtimeType = options.runtime ?? await tryDetectRuntime();
   if (runtimeType === 'quickjs') {
-    throw new Error("QuickJS runtime not yet implemented");
+    const { QuickJsCodeModeRuntime } = await import("./quickjs-runtime.js");
+    const runtime = new QuickJsCodeModeRuntime(options);
+    await runtime.searchTools("", 1);
+    return runtime;
   }
   const runtime = new IsolatedVmCodeModeRuntime(options);
   await runtime.searchTools("", 1);
   return runtime;
+}
+
+export async function tryDetectRuntime(): Promise<'isolated-vm' | 'quickjs'> {
+  try {
+    await import("isolated-vm");
+    return 'isolated-vm';
+  } catch {
+    return 'quickjs';
+  }
 }
 
 async function loadIsolatedVm(): Promise<typeof import("isolated-vm").default> {

--- a/packages/code-mode/src/runtime/runtime.ts
+++ b/packages/code-mode/src/runtime/runtime.ts
@@ -5,112 +5,20 @@ import type {
   CodeModeRuntime,
   CodeModeRuntimeOptions,
   CodeModeToolCall,
-  IndexedTool,
-  ToolSearchResult,
-  ToolServer,
 } from "../types.js";
 import { CodemodeError, classifyError } from "./errors.js";
 import { estimateJsonBytes, resolveLimits } from "./limits.js";
-import {
-  indexServers,
-  listServersFromIndex,
-  normalizeServerId,
-  resolveTool,
-  searchToolIndex,
-} from "./tool-index.js";
+import { resolveTool } from "./tool-index.js";
 import {
   generateAllInterfaces,
-  generateBootstrapCode,
   generateInterfaceMap,
+  generateBootstrapCode,
   generateNamespaceBridgeCode,
-  toolToTypeScriptInterface,
 } from "./sandbox-bridge.js";
+import { BaseCodeModeRuntime } from "./base-runtime.js";
+export { BaseCodeModeRuntime } from "./base-runtime.js";
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function extractToolErrorText(result: Record<string, unknown>): string | undefined {
-  const content = result.content;
-  if (typeof content === "string") {
-    return content.replace(/^Error:\s*/i, "");
-  }
-  if (Array.isArray(content) && content.length > 0) {
-    const first = content[0];
-    if (isRecord(first) && typeof first.text === "string") return first.text.replace(/^Error:\s*/i, "");
-    if (typeof first === "string") return first.replace(/^Error:\s*/i, "");
-    return JSON.stringify(first);
-  }
-  if (isRecord(content)) {
-    const maybeError = (content as Record<string, unknown>).error ?? (content as Record<string, unknown>).message;
-    if (typeof maybeError === "string") return maybeError;
-    return JSON.stringify(content);
-  }
-  return undefined;
-}
-
-export class IsolatedVmCodeModeRuntime implements CodeModeRuntime {
-  private servers: Map<string, ToolServer>;
-  private indexedTools: IndexedTool[] = [];
-  private initialized = false;
-  private maxSearchResults: number;
-
-  constructor(private options: CodeModeRuntimeOptions) {
-    this.maxSearchResults = options.maxSearchResults ?? 10;
-    this.servers = new Map<string, ToolServer>();
-    for (const server of options.servers) {
-      this.servers.set(normalizeServerId(server.serverId), server);
-    }
-  }
-
-  private async ensureInitialized(): Promise<void> {
-    if (!this.initialized) {
-      this.indexedTools = await indexServers(this.options.servers);
-      this.initialized = true;
-    }
-  }
-
-  async searchTools(query: string, limit?: number): Promise<ToolSearchResult[]> {
-    await this.ensureInitialized();
-    return searchToolIndex(this.indexedTools, query, limit ?? this.maxSearchResults);
-  }
-
-  listServers(): Array<{ serverId: string; serverName: string; toolCount: number }> {
-    return listServersFromIndex(this.indexedTools);
-  }
-
-  getToolInterfaces(toolNames: string[]): string {
-    const interfaces: string[] = [];
-    const notFound: string[] = [];
-
-    for (const name of toolNames) {
-      // name can be "serverId.toolName" or just "toolName"
-      let tool: IndexedTool | undefined;
-      if (name.includes(".")) {
-        const [serverId, ...rest] = name.split(".");
-        const toolName = rest.join(".");
-        tool = resolveTool(this.indexedTools, toolName, serverId);
-      } else {
-        tool = resolveTool(this.indexedTools, name);
-      }
-
-      if (tool) {
-        interfaces.push(toolToTypeScriptInterface(tool));
-      } else {
-        notFound.push(`// Tool '${name}' not found`);
-      }
-    }
-
-    if (interfaces.length === 0 && notFound.length > 0) {
-      return notFound.join("\n");
-    }
-    let result = interfaces.join("\n\n");
-    if (notFound.length > 0) {
-      result += "\n\n" + notFound.join("\n");
-    }
-    return result;
-  }
-
+export class IsolatedVmCodeModeRuntime extends BaseCodeModeRuntime {
   async run(
     code: string,
     input: unknown = {},
@@ -125,8 +33,8 @@ export class IsolatedVmCodeModeRuntime implements CodeModeRuntime {
     });
     const logs: CodeModeLogEntry[] = [];
     const toolCalls: CodeModeToolCall[] = [];
-    let activeToolCalls = 0;
-    let totalToolCalls = 0;
+    const activeToolCallsRef = { value: 0 };
+    const totalToolCallsRef = { value: 0 };
 
     const ivm = await loadIsolatedVm();
     const isolate = new ivm.Isolate({ memoryLimit: limits.memoryLimitMb });
@@ -141,68 +49,15 @@ export class IsolatedVmCodeModeRuntime implements CodeModeRuntime {
       toolName: string,
       argsJson: string,
     ): Promise<string> => {
-      if (totalToolCalls >= limits.maxToolCalls) {
-        return JSON.stringify({ success: true, result: { error: `maxToolCalls ${limits.maxToolCalls} exceeded.`, isError: true } });
-      }
-      if (activeToolCalls >= limits.maxConcurrentToolCalls) {
-        return JSON.stringify({ success: true, result: { error: `maxConcurrentToolCalls ${limits.maxConcurrentToolCalls} exceeded.`, isError: true } });
-      }
-
-      activeToolCalls += 1;
-      totalToolCalls += 1;
-      const callStartedAt = Date.now();
-      const call: CodeModeToolCall = {
-        id: `call_${totalToolCalls}`,
-        serverId,
-        toolName,
-        args: null as unknown as Record<string, unknown>,
-        startedAt: callStartedAt,
-        durationMs: 0,
-        ok: false,
-      };
-      toolCalls.push(call);
-
-      try {
-        const args = JSON.parse(argsJson);
-        call.args = args;
-
-        let server = this.servers.get(normalizeServerId(serverId));
-        if (!server) {
-          const tool = resolveTool(this.indexedTools, toolName, serverId);
-          if (!tool) throw new Error(`Tool "${toolName}" was not found on server "${serverId}".`);
-          server = this.servers.get(tool.serverId);
-          if (!server) throw new Error(`Server "${tool.serverId}" is no longer registered.`);
-        }
-
-        const result = await server.callTool(toolName, args);
-        if (isRecord(result) && result.isError === true) {
-          call.ok = false;
-          call.error = extractToolErrorText(result) || "MCP tool returned an error";
-        } else {
-          call.ok = true;
-        }
-        return JSON.stringify({ success: true, result });
-      } catch (error) {
-        call.ok = false;
-        call.error = error instanceof Error ? error.message : String(error);
-        return JSON.stringify({ success: true, result: { error: call.error, isError: true } });
-      } finally {
-        call.durationMs = Date.now() - callStartedAt;
-        activeToolCalls -= 1;
-      }
+      return this.hostCallTool(serverId, toolName, argsJson, toolCalls, activeToolCallsRef, totalToolCallsRef, limits);
     };
 
     const hostSearchTools = async (query: string, limit: number): Promise<string> => {
-      const results = searchToolIndex(this.indexedTools, query, limit);
-      return JSON.stringify(results);
+      return this.hostSearchTools(query, limit);
     };
 
     const hostGetToolSchema = async (serverId: string, toolName: string): Promise<string> => {
-      const tool = resolveTool(this.indexedTools, toolName, serverId);
-      if (!tool) {
-        return JSON.stringify({ error: `Tool "${toolName}" not found on server "${serverId}".` });
-      }
-      return JSON.stringify(tool);
+      return this.hostGetToolSchema(serverId, toolName);
     };
 
     const hostCallToolRaw = async (
@@ -232,9 +87,7 @@ export class IsolatedVmCodeModeRuntime implements CodeModeRuntime {
     };
 
     const hostLog = (level: CodeModeLogEntry["level"], args: unknown[]) => {
-      if (logs.length < limits.maxLogEntries) {
-        logs.push({ level, args });
-      }
+      this.hostLog(level, args, logs, limits);
     };
 
     try {
@@ -365,10 +218,13 @@ export class IsolatedVmCodeModeRuntime implements CodeModeRuntime {
 }
 
 export async function createCodeModeRuntime(
-  options: CodeModeRuntimeOptions,
+  options: CodeModeRuntimeOptions & { runtime?: 'isolated-vm' | 'quickjs' },
 ): Promise<CodeModeRuntime> {
+  const runtimeType = options.runtime ?? 'isolated-vm';
+  if (runtimeType === 'quickjs') {
+    throw new Error("QuickJS runtime not yet implemented");
+  }
   const runtime = new IsolatedVmCodeModeRuntime(options);
-  // Eagerly initialize tool index
   await runtime.searchTools("", 1);
   return runtime;
 }

--- a/packages/code-mode/src/runtime/sandbox-bridge.ts
+++ b/packages/code-mode/src/runtime/sandbox-bridge.ts
@@ -149,6 +149,7 @@ export function generateInterfaceMap(tools: IndexedTool[]): Record<string, strin
 export function generateNamespaceBridgeCode(
   tools: IndexedTool[],
   _servers: Map<string, ToolServer>,
+  asyncPattern?: boolean,
 ): string {
   const parts: string[] = [];
   const namespaces = new Set<string>();
@@ -162,9 +163,13 @@ export function generateNamespaceBridgeCode(
       parts.push(`globalThis.${sanitizedServer} = globalThis.${sanitizedServer} || {};`);
     }
 
+    const callPattern = asyncPattern
+      ? `__callToolRef(${JSON.stringify(tool.serverId)}, ${JSON.stringify(tool.toolName)}, JSON.stringify(args || {}))`
+      : `__callToolRef.applySyncPromise(undefined, [${JSON.stringify(tool.serverId)}, ${JSON.stringify(tool.toolName)}, JSON.stringify(args || {})])`;
+
     parts.push(`
       globalThis.${sanitizedServer}.${sanitizedTool} = function(args) {
-        var resultJson = __callToolRef.applySyncPromise(undefined, [${JSON.stringify(tool.serverId)}, ${JSON.stringify(tool.toolName)}, JSON.stringify(args || {})]);
+        var resultJson = ${callPattern};
         var parsed = JSON.parse(resultJson);
         if (!parsed.success) throw new Error(parsed.error);
         return parsed.result;
@@ -184,48 +189,101 @@ export function generateNamespaceBridgeCode(
 export function generateBootstrapCode(
   interfacesString: string,
   interfaceMapJson: string,
+  quickjs?: boolean,
 ): string {
+  const stringifyHelper = `function(a) { return typeof a === "object" && a !== null ? JSON.stringify(a, null, 2) : String(a); }`;
+
+  const callConsole = (level: string, ref: string) => {
+    return `${ref}(...args.map(${stringifyHelper}))`;
+  };
+
+  if (quickjs) {
+    return `
+"use strict";
+
+globalThis.console = {
+  log: function(...args) { ${callConsole("log", "__logRef")} },
+  error: function(...args) { ${callConsole("error", "__errorRef")} },
+  warn: function(...args) { ${callConsole("warn", "__warnRef")} },
+  info: function(...args) { ${callConsole("info", "__infoRef")} },
+};
+
+globalThis.callTool = function(serverId, toolName, args) {
+  var resultJson = __callToolRef(serverId, toolName, JSON.stringify(args || {}));
+  var parsed = JSON.parse(resultJson);
+  if (!parsed.success) throw new Error(parsed.error);
+  return parsed.result;
+};
+
+globalThis.callToolRaw = function(serverId, toolName, args) {
+  var resultJson = __callToolRawRef(serverId, toolName, JSON.stringify(args || {}));
+  var parsed = JSON.parse(resultJson);
+  if (!parsed.success) throw new Error(parsed.error);
+  return parsed.result;
+};
+
+globalThis.searchTools = function(query, limit) {
+  var resultJson = __searchToolsRef(query || "", limit || 10);
+  return JSON.parse(resultJson);
+};
+
+globalThis.getToolSchema = function(serverId, toolName) {
+  var resultJson = __getToolSchemaRef(serverId, toolName);
+  return JSON.parse(resultJson);
+};
+
+globalThis.__interfaces = ${JSON.stringify(interfacesString)};
+const __interfaceMap = ${interfaceMapJson};
+globalThis.__getToolInterface = function(toolName) {
+  return __interfaceMap[toolName] || null;
+};
+
+var __inputParsed = JSON.parse(typeof __input === "string" ? __input : "null");
+globalThis.input = typeof __inputParsed === "undefined" || __inputParsed === null ? undefined : __inputParsed;
+`;
+  }
+
   return `
-    "use strict";
+"use strict";
 
-    const __stringify = (a) => typeof a === "object" && a !== null ? JSON.stringify(a, null, 2) : String(a);
-    globalThis.console = {
-      log: (...args) => __logRef.applySync(undefined, args.map(__stringify)),
-      error: (...args) => __errorRef.applySync(undefined, args.map(__stringify)),
-      warn: (...args) => __warnRef.applySync(undefined, args.map(__stringify)),
-      info: (...args) => __infoRef.applySync(undefined, args.map(__stringify)),
-    };
+const __stringify = (a) => typeof a === "object" && a !== null ? JSON.stringify(a, null, 2) : String(a);
+globalThis.console = {
+  log: (...args) => __logRef.applySync(undefined, args.map(__stringify)),
+  error: (...args) => __errorRef.applySync(undefined, args.map(__stringify)),
+  warn: (...args) => __warnRef.applySync(undefined, args.map(__stringify)),
+  info: (...args) => __infoRef.applySync(undefined, args.map(__stringify)),
+};
 
-    globalThis.callTool = function(serverId, toolName, args) {
-      var resultJson = __callToolRef.applySyncPromise(undefined, [serverId, toolName, JSON.stringify(args || {})]);
-      var parsed = JSON.parse(resultJson);
-      if (!parsed.success) throw new Error(parsed.error);
-      return parsed.result;
-    };
+globalThis.callTool = function(serverId, toolName, args) {
+  var resultJson = __callToolRef.applySyncPromise(undefined, [serverId, toolName, JSON.stringify(args || {})]);
+  var parsed = JSON.parse(resultJson);
+  if (!parsed.success) throw new Error(parsed.error);
+  return parsed.result;
+};
 
-    globalThis.callToolRaw = function(serverId, toolName, args) {
-      var resultJson = __callToolRawRef.applySyncPromise(undefined, [serverId, toolName, JSON.stringify(args || {})]);
-      var parsed = JSON.parse(resultJson);
-      if (!parsed.success) throw new Error(parsed.error);
-      return parsed.result;
-    };
+globalThis.callToolRaw = function(serverId, toolName, args) {
+  var resultJson = __callToolRawRef.applySyncPromise(undefined, [serverId, toolName, JSON.stringify(args || {})]);
+  var parsed = JSON.parse(resultJson);
+  if (!parsed.success) throw new Error(parsed.error);
+  return parsed.result;
+};
 
-    globalThis.searchTools = function(query, limit) {
-      var resultJson = __searchToolsRef.applySyncPromise(undefined, [query || "", limit || 10]);
-      return JSON.parse(resultJson);
-    };
+globalThis.searchTools = function(query, limit) {
+  var resultJson = __searchToolsRef.applySyncPromise(undefined, [query || "", limit || 10]);
+  return JSON.parse(resultJson);
+};
 
-    globalThis.getToolSchema = function(serverId, toolName) {
-      var resultJson = __getToolSchemaRef.applySyncPromise(undefined, [serverId, toolName]);
-      return JSON.parse(resultJson);
-    };
+globalThis.getToolSchema = function(serverId, toolName) {
+  var resultJson = __getToolSchemaRef.applySyncPromise(undefined, [serverId, toolName]);
+  return JSON.parse(resultJson);
+};
 
-    globalThis.__interfaces = ${JSON.stringify(interfacesString)};
-    const __interfaceMap = ${interfaceMapJson};
-    globalThis.__getToolInterface = function(toolName) {
-      return __interfaceMap[toolName] || null;
-    };
+globalThis.__interfaces = ${JSON.stringify(interfacesString)};
+const __interfaceMap = ${interfaceMapJson};
+globalThis.__getToolInterface = function(toolName) {
+  return __interfaceMap[toolName] || null;
+};
 
-    globalThis.input = typeof __input !== "undefined" ? __input : undefined;
-  `;
+globalThis.input = typeof __input !== "undefined" ? __input : undefined;
+`;
 }

--- a/packages/code-mode/test/quickjs.test.mjs
+++ b/packages/code-mode/test/quickjs.test.mjs
@@ -169,12 +169,12 @@ function fakeMcpEnvelopeSource(serverId = "docs") {
   };
 }
 
-const QUIX_RUNTIME = 'quickjs';
+const QUICKJS_RUNTIME = 'quickjs';
 
 test("basic execution: 1 + 2 returns 3", { skip: !hasQuickJs }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { source } = fakeSource();
-  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUICKJS_RUNTIME });
 
   const result = await runtime.run(`1 + 2`);
 
@@ -185,7 +185,7 @@ test("basic execution: 1 + 2 returns 3", { skip: !hasQuickJs }, async () => {
 test("namespace bridge: github.get_issue(args) works without await", { skip: !hasQuickJs }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { calls, source } = fakeSource();
-  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUICKJS_RUNTIME });
 
   const result = await runtime.run(`
     var issue = github.get_issue({ issue_number: 42 });
@@ -201,7 +201,7 @@ test("namespace bridge: github.get_issue(args) works without await", { skip: !ha
 test("callTool() escape hatch works without await", { skip: !hasQuickJs }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { calls, source } = fakeSource();
-  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUICKJS_RUNTIME });
 
   const result = await runtime.run(`
     var issue = callTool("github", "get_issue", { issue_number: 7 });
@@ -216,7 +216,7 @@ test("callTool() escape hatch works without await", { skip: !hasQuickJs }, async
 test("input passthrough works", { skip: !hasQuickJs }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { source } = fakeSource();
-  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUICKJS_RUNTIME });
 
   const result = await runtime.run(`
     ({ doubled: input.value * 2 })
@@ -229,7 +229,7 @@ test("input passthrough works", { skip: !hasQuickJs }, async () => {
 test("console output is captured", { skip: !hasQuickJs }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { source } = fakeSource();
-  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUICKJS_RUNTIME });
 
   const result = await runtime.run(`
     console.log("hello");
@@ -249,7 +249,7 @@ test("console output is captured", { skip: !hasQuickJs }, async () => {
 test("tool calls are tracked in result", { skip: !hasQuickJs }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { source } = fakeSource();
-  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUICKJS_RUNTIME });
 
   const result = await runtime.run(`
     github.get_issue({ issue_number: 1 });
@@ -268,7 +268,7 @@ test("tool calls are tracked in result", { skip: !hasQuickJs }, async () => {
 test("searchTools() inside sandbox returns results", { skip: !hasQuickJs }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { source } = fakeSource();
-  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUICKJS_RUNTIME });
 
   const result = await runtime.run(`
     var tools = searchTools("issue");
@@ -284,7 +284,7 @@ test("searchTools() inside sandbox returns results", { skip: !hasQuickJs }, asyn
 test("__interfaces contains TypeScript definitions", { skip: !hasQuickJs }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { source } = fakeSource();
-  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUICKJS_RUNTIME });
 
   const result = await runtime.run(`__interfaces`);
 
@@ -298,7 +298,7 @@ test("__interfaces contains TypeScript definitions", { skip: !hasQuickJs }, asyn
 test("__getToolInterface() returns specific tool interface", { skip: !hasQuickJs }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { source } = fakeSource();
-  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUICKJS_RUNTIME });
 
   const result = await runtime.run(`
     var iface = __getToolInterface("github.get_issue");
@@ -314,7 +314,7 @@ test("multi-source: github.get_issue() vs exa.web_search()", { skip: !hasQuickJs
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const github = fakeSource();
   const exa = fakeExaSource();
-  const runtime = await createCodeModeRuntime({ servers: [github.source, exa.source], runtime: QUIX_RUNTIME });
+  const runtime = await createCodeModeRuntime({ servers: [github.source, exa.source], runtime: QUICKJS_RUNTIME });
 
   const result = await runtime.run(`
     var issue = github.get_issue({ issue_number: 1 });
@@ -332,7 +332,7 @@ test("multi-source: github.get_issue() vs exa.web_search()", { skip: !hasQuickJs
 test("error handling: isError tool does not crash sandbox", { skip: !hasQuickJs }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { source } = fakeMcpEnvelopeSource();
-  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUICKJS_RUNTIME });
 
   const result = await runtime.run(`
     try {
@@ -353,7 +353,7 @@ test("error handling: isError tool does not crash sandbox", { skip: !hasQuickJs 
 test("MCP envelopes are normalized to script-friendly values", { skip: !hasQuickJs }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { source } = fakeMcpEnvelopeSource();
-  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUICKJS_RUNTIME });
 
   const result = await runtime.run(`
     ({
@@ -390,7 +390,7 @@ test("MCP envelopes are normalized to script-friendly values", { skip: !hasQuick
 test("error envelope: single text content preserves isError", { skip: !hasQuickJs }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { source } = fakeMcpEnvelopeSource();
-  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUICKJS_RUNTIME });
 
   const result = await runtime.run(`
     var r = callTool("docs", "error_single_text", { query: "x" });
@@ -405,7 +405,7 @@ test("error envelope: single text content preserves isError", { skip: !hasQuickJ
 test("error envelope: JSON text content is parsed and isError preserved", { skip: !hasQuickJs }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { source } = fakeMcpEnvelopeSource();
-  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUICKJS_RUNTIME });
 
   const result = await runtime.run(`
     var r = callTool("docs", "error_json_text", { query: "x" });
@@ -423,7 +423,7 @@ test("error envelope: JSON text content is parsed and isError preserved", { skip
 test("error envelope: toolCalls[].ok is false with error message", { skip: !hasQuickJs }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { source } = fakeMcpEnvelopeSource();
-  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUICKJS_RUNTIME });
 
   const result = await runtime.run(`
     callTool("docs", "error_single_text", { query: "x" });
@@ -442,7 +442,7 @@ test("error envelope: toolCalls[].ok is false with error message", { skip: !hasQ
 test("error envelope: successful and failed calls are both tracked", { skip: !hasQuickJs }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { source } = fakeMcpEnvelopeSource();
-  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUICKJS_RUNTIME });
 
   const result = await runtime.run(`
     docs.plain_text_search({ query: "ok" });
@@ -458,10 +458,40 @@ test("error envelope: successful and failed calls are both tracked", { skip: !ha
   assert.equal(result.toolCalls[1].error, "resource not found");
 });
 
+test("auto-detect runtime when no runtime option specified", { skip: !hasQuickJs }, async () => {
+  const { createCodeModeRuntime } = await import("../dist/index.js");
+  const { source } = fakeSource();
+  const runtime = await createCodeModeRuntime({ servers: [source] });
+
+  const result = await runtime.run(`1 + 2`);
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.value, 3);
+});
+
+test("getToolSchema inside sandbox returns tool definition", { skip: !hasQuickJs }, async () => {
+  const { createCodeModeRuntime } = await import("../dist/index.js");
+  const { source } = fakeSource();
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUICKJS_RUNTIME });
+
+  const result = await runtime.run(`
+    var schema = getToolSchema("github", "get_issue");
+    schema
+  `);
+
+  assert.equal(result.error, undefined);
+  assert.ok(result.value !== null && typeof result.value === "object");
+  assert.equal(result.value.toolName, "get_issue");
+  assert.equal(result.value.serverId, "github");
+  assert.ok(result.value.inputSchema !== undefined);
+  assert.equal(result.value.inputSchema.type, "object");
+  assert.ok(result.value.inputSchema.properties.issue_number !== undefined);
+});
+
 test("timeout: infinite loop is interrupted", { skip: !hasQuickJs }, async () => {
   const { createCodeModeRuntime } = await import("../dist/index.js");
   const { source } = fakeSource();
-  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUICKJS_RUNTIME });
 
   const result = await runtime.run("while(true) {}", {}, { timeoutMs: 100 });
 

--- a/packages/code-mode/test/quickjs.test.mjs
+++ b/packages/code-mode/test/quickjs.test.mjs
@@ -1,0 +1,459 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const hasQuickJs = await import("quickjs-emscripten").then(
+  () => true,
+  () => false
+);
+
+function fakeSource(serverId = "github", tools = undefined) {
+  const calls = [];
+  return {
+    calls,
+    source: {
+      serverId,
+      serverName: serverId,
+      listTools: async () => ({
+        tools: tools ?? [
+          {
+            name: "get_issue",
+            description: "Get a GitHub issue by number",
+            inputSchema: {
+              type: "object",
+              properties: {
+                issue_number: { type: "number", description: "Issue number" }
+              },
+              required: ["issue_number"]
+            }
+          },
+          {
+            name: "create_issue",
+            description: "Create a new GitHub issue",
+            inputSchema: {
+              type: "object",
+              properties: {
+                title: { type: "string", description: "Issue title" },
+                body: { type: "string", description: "Issue body" }
+              },
+              required: ["title"]
+            }
+          }
+        ]
+      }),
+      callTool: async (name, args) => {
+        calls.push({ name, args });
+        return { name, args };
+      }
+    }
+  };
+}
+
+function fakeExaSource() {
+  const calls = [];
+  return {
+    calls,
+    source: {
+      serverId: "exa",
+      serverName: "exa",
+      listTools: async () => ({
+        tools: [
+          {
+            name: "web_search",
+            description: "Search the web for information",
+            inputSchema: {
+              type: "object",
+              properties: {
+                query: { type: "string", description: "Search query" }
+              },
+              required: ["query"]
+            }
+          }
+        ]
+      }),
+      callTool: async (name, args) => {
+        calls.push({ name, args });
+        return { results: [{ title: "Result 1", url: "https://example.com" }] };
+      }
+    }
+  };
+}
+
+function fakeMcpEnvelopeSource(serverId = "docs") {
+  const calls = [];
+  return {
+    calls,
+    source: {
+      serverId,
+      serverName: serverId,
+      listTools: async () => ({
+        tools: [
+          {
+            name: "structured_search",
+            description: "Returns structuredContent",
+            inputSchema: { type: "object", properties: { query: { type: "string" } } }
+          },
+          {
+            name: "json_text_search",
+            description: "Returns JSON text content",
+            inputSchema: { type: "object", properties: { query: { type: "string" } } }
+          },
+          {
+            name: "plain_text_search",
+            description: "Returns plain text content",
+            inputSchema: { type: "object", properties: { query: { type: "string" } } }
+          },
+          {
+            name: "multipart_search",
+            description: "Returns multipart content",
+            inputSchema: { type: "object", properties: { query: { type: "string" } } }
+          },
+          {
+            name: "error_single_text",
+            description: "Returns isError with single text content",
+            inputSchema: { type: "object", properties: { query: { type: "string" } } }
+          },
+          {
+            name: "error_json_text",
+            description: "Returns isError with JSON text content",
+            inputSchema: { type: "object", properties: { query: { type: "string" } } }
+          }
+        ]
+      }),
+      callTool: async (name, args) => {
+        calls.push({ name, args });
+        if (name === "structured_search") {
+          return {
+            structuredContent: {
+              items: [{ title: "Structured result" }]
+            },
+            content: [{ type: "text", text: "{\"ignored\":true}" }],
+            isError: false
+          };
+        }
+        if (name === "json_text_search") {
+          return {
+            content: [{ type: "text", text: JSON.stringify({ items: [{ title: "JSON text result" }] }) }],
+            isError: false
+          };
+        }
+        if (name === "plain_text_search") {
+          return {
+            content: [{ type: "text", text: "plain text result" }],
+            isError: false
+          };
+        }
+        if (name === "multipart_search") {
+          return {
+            content: [
+              { type: "text", text: "first" },
+              { type: "text", text: "second" }
+            ],
+            isError: true
+          };
+        }
+        if (name === "error_single_text") {
+          return {
+            content: [{ type: "text", text: "resource not found" }],
+            isError: true
+          };
+        }
+        if (name === "error_json_text") {
+          return {
+            content: [{ type: "text", text: JSON.stringify({ error: "invalid input", code: 400 }) }],
+            isError: true
+          };
+        }
+        throw new Error(`Unknown tool ${name}`);
+      }
+    }
+  };
+}
+
+const QUIX_RUNTIME = 'quickjs';
+
+test("basic execution: 1 + 2 returns 3", { skip: !hasQuickJs }, async () => {
+  const { createCodeModeRuntime } = await import("../dist/index.js");
+  const { source } = fakeSource();
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+
+  const result = await runtime.run(`1 + 2`);
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.value, 3);
+});
+
+test("namespace bridge: github.get_issue(args) works without await", { skip: !hasQuickJs }, async () => {
+  const { createCodeModeRuntime } = await import("../dist/index.js");
+  const { calls, source } = fakeSource();
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+
+  const result = await runtime.run(`
+    var issue = github.get_issue({ issue_number: 42 });
+    issue
+  `);
+
+  assert.equal(result.error, undefined);
+  assert.deepEqual(result.value, { name: "get_issue", args: { issue_number: 42 } });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].name, "get_issue");
+});
+
+test("callTool() escape hatch works without await", { skip: !hasQuickJs }, async () => {
+  const { createCodeModeRuntime } = await import("../dist/index.js");
+  const { calls, source } = fakeSource();
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+
+  const result = await runtime.run(`
+    var issue = callTool("github", "get_issue", { issue_number: 7 });
+    issue
+  `);
+
+  assert.equal(result.error, undefined);
+  assert.deepEqual(result.value, { name: "get_issue", args: { issue_number: 7 } });
+  assert.equal(calls.length, 1);
+});
+
+test("input passthrough works", { skip: !hasQuickJs }, async () => {
+  const { createCodeModeRuntime } = await import("../dist/index.js");
+  const { source } = fakeSource();
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+
+  const result = await runtime.run(`
+    ({ doubled: input.value * 2 })
+  `, { value: 21 });
+
+  assert.equal(result.error, undefined);
+  assert.deepEqual(result.value, { doubled: 42 });
+});
+
+test("console output is captured", { skip: !hasQuickJs }, async () => {
+  const { createCodeModeRuntime } = await import("../dist/index.js");
+  const { source } = fakeSource();
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+
+  const result = await runtime.run(`
+    console.log("hello");
+    console.warn("caution");
+    console.error("fail");
+    "done"
+  `);
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.value, "done");
+  assert.equal(result.logs.length, 3);
+  assert.equal(result.logs[0].level, "log");
+  assert.equal(result.logs[1].level, "warn");
+  assert.equal(result.logs[2].level, "error");
+});
+
+test("tool calls are tracked in result", { skip: !hasQuickJs }, async () => {
+  const { createCodeModeRuntime } = await import("../dist/index.js");
+  const { source } = fakeSource();
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+
+  const result = await runtime.run(`
+    github.get_issue({ issue_number: 1 });
+    github.create_issue({ title: "test" });
+    "done"
+  `);
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.toolCalls.length, 2);
+  assert.equal(result.toolCalls[0].toolName, "get_issue");
+  assert.equal(result.toolCalls[0].ok, true);
+  assert.equal(result.toolCalls[1].toolName, "create_issue");
+  assert.equal(result.toolCalls[1].ok, true);
+});
+
+test("searchTools() inside sandbox returns results", { skip: !hasQuickJs }, async () => {
+  const { createCodeModeRuntime } = await import("../dist/index.js");
+  const { source } = fakeSource();
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+
+  const result = await runtime.run(`
+    var tools = searchTools("issue");
+    tools.map(t => ({ serverId: t.serverId, toolName: t.toolName }))
+  `);
+
+  assert.equal(result.error, undefined);
+  assert.ok(Array.isArray(result.value));
+  assert.ok(result.value.length > 0);
+  assert.equal(result.value[0].serverId, "github");
+});
+
+test("__interfaces contains TypeScript definitions", { skip: !hasQuickJs }, async () => {
+  const { createCodeModeRuntime } = await import("../dist/index.js");
+  const { source } = fakeSource();
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+
+  const result = await runtime.run(`__interfaces`);
+
+  assert.equal(result.error, undefined);
+  assert.ok(typeof result.value === "string");
+  assert.ok(result.value.includes("namespace github"));
+  assert.ok(result.value.includes("get_issueInput"));
+  assert.ok(result.value.includes("issue_number"));
+});
+
+test("__getToolInterface() returns specific tool interface", { skip: !hasQuickJs }, async () => {
+  const { createCodeModeRuntime } = await import("../dist/index.js");
+  const { source } = fakeSource();
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+
+  const result = await runtime.run(`
+    var iface = __getToolInterface("github.get_issue");
+    iface
+  `);
+
+  assert.equal(result.error, undefined);
+  assert.ok(typeof result.value === "string");
+  assert.ok(result.value.includes("github.get_issue(args)"));
+});
+
+test("multi-source: github.get_issue() vs exa.web_search()", { skip: !hasQuickJs }, async () => {
+  const { createCodeModeRuntime } = await import("../dist/index.js");
+  const github = fakeSource();
+  const exa = fakeExaSource();
+  const runtime = await createCodeModeRuntime({ servers: [github.source, exa.source], runtime: QUIX_RUNTIME });
+
+  const result = await runtime.run(`
+    var issue = github.get_issue({ issue_number: 1 });
+    var search = exa.web_search({ query: "hello" });
+    ({ issue, search })
+  `);
+
+  assert.equal(result.error, undefined);
+  assert.deepEqual(result.value.issue, { name: "get_issue", args: { issue_number: 1 } });
+  assert.deepEqual(result.value.search, { results: [{ title: "Result 1", url: "https://example.com" }] });
+  assert.equal(github.calls.length, 1);
+  assert.equal(exa.calls.length, 1);
+});
+
+test("error handling: isError tool does not crash sandbox", { skip: !hasQuickJs }, async () => {
+  const { createCodeModeRuntime } = await import("../dist/index.js");
+  const { source } = fakeMcpEnvelopeSource();
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+
+  const result = await runtime.run(`
+    try {
+      var r = callTool("docs", "error_single_text", { query: "x" });
+      ({ caught: r.isError ? true : false, error: r.isError ? (r.content || "unknown") : String(r) })
+    } catch (e) {
+      ({ caught: true, error: String(e) })
+    }
+  `);
+
+  assert.equal(result.error, undefined);
+  assert.ok(result.value.caught, "sandbox should detect the error");
+  assert.equal(result.toolCalls.length, 1);
+  assert.equal(result.toolCalls[0].ok, false);
+  assert.equal(result.toolCalls[0].error, "resource not found");
+});
+
+test("MCP envelopes are normalized to script-friendly values", { skip: !hasQuickJs }, async () => {
+  const { createCodeModeRuntime } = await import("../dist/index.js");
+  const { source } = fakeMcpEnvelopeSource();
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+
+  const result = await runtime.run(`
+    ({
+      structured: docs.structured_search({ query: "a" }),
+      jsonText: callTool("docs", "json_text_search", { query: "b" }),
+      plainText: docs.plain_text_search({ query: "c" }),
+      multipart: callTool("docs", "multipart_search", { query: "d" })
+    })
+  `);
+
+  assert.equal(result.error, undefined);
+  assert.deepEqual(result.value.structured, {
+    structuredContent: { items: [{ title: "Structured result" }] },
+    content: [{ type: "text", text: JSON.stringify({ ignored: true }) }],
+    isError: false
+  });
+  assert.deepEqual(result.value.jsonText, {
+    content: [{ type: "text", text: JSON.stringify({ items: [{ title: "JSON text result" }] }) }],
+    isError: false
+  });
+  assert.deepEqual(result.value.plainText, {
+    content: [{ type: "text", text: "plain text result" }],
+    isError: false
+  });
+  assert.deepEqual(result.value.multipart, {
+    content: [
+      { type: "text", text: "first" },
+      { type: "text", text: "second" }
+    ],
+    isError: true
+  });
+});
+
+test("error envelope: single text content preserves isError", { skip: !hasQuickJs }, async () => {
+  const { createCodeModeRuntime } = await import("../dist/index.js");
+  const { source } = fakeMcpEnvelopeSource();
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+
+  const result = await runtime.run(`
+    var r = callTool("docs", "error_single_text", { query: "x" });
+    r
+  `);
+
+  assert.equal(result.error, undefined);
+  assert.ok(result.value !== null && typeof result.value === "object");
+  assert.equal(result.value.isError, true);
+});
+
+test("error envelope: JSON text content is parsed and isError preserved", { skip: !hasQuickJs }, async () => {
+  const { createCodeModeRuntime } = await import("../dist/index.js");
+  const { source } = fakeMcpEnvelopeSource();
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+
+  const result = await runtime.run(`
+    var r = callTool("docs", "error_json_text", { query: "x" });
+    r
+  `);
+
+  assert.equal(result.error, undefined);
+  assert.ok(result.value !== null && typeof result.value === "object");
+  assert.equal(result.value.isError, true);
+  assert.ok(Array.isArray(result.value.content));
+  assert.equal(result.value.content[0].type, "text");
+  assert.equal(result.value.content[0].text, JSON.stringify({ error: "invalid input", code: 400 }));
+});
+
+test("error envelope: toolCalls[].ok is false with error message", { skip: !hasQuickJs }, async () => {
+  const { createCodeModeRuntime } = await import("../dist/index.js");
+  const { source } = fakeMcpEnvelopeSource();
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+
+  const result = await runtime.run(`
+    callTool("docs", "error_single_text", { query: "x" });
+    "done"
+  `);
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.value, "done");
+  assert.equal(result.toolCalls.length, 1);
+  assert.equal(result.toolCalls[0].ok, false);
+  assert.equal(result.toolCalls[0].error, "resource not found");
+  assert.equal(result.toolCalls[0].serverId, "docs");
+  assert.equal(result.toolCalls[0].toolName, "error_single_text");
+});
+
+test("error envelope: successful and failed calls are both tracked", { skip: !hasQuickJs }, async () => {
+  const { createCodeModeRuntime } = await import("../dist/index.js");
+  const { source } = fakeMcpEnvelopeSource();
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+
+  const result = await runtime.run(`
+    docs.plain_text_search({ query: "ok" });
+    callTool("docs", "error_single_text", { query: "fail" });
+    "done"
+  `);
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.value, "done");
+  assert.equal(result.toolCalls.length, 2);
+  assert.equal(result.toolCalls[0].ok, true);
+  assert.equal(result.toolCalls[1].ok, false);
+  assert.equal(result.toolCalls[1].error, "resource not found");
+});

--- a/packages/code-mode/test/quickjs.test.mjs
+++ b/packages/code-mode/test/quickjs.test.mjs
@@ -457,3 +457,18 @@ test("error envelope: successful and failed calls are both tracked", { skip: !ha
   assert.equal(result.toolCalls[1].ok, false);
   assert.equal(result.toolCalls[1].error, "resource not found");
 });
+
+test("timeout: infinite loop is interrupted", { skip: !hasQuickJs }, async () => {
+  const { createCodeModeRuntime } = await import("../dist/index.js");
+  const { source } = fakeSource();
+  const runtime = await createCodeModeRuntime({ servers: [source], runtime: QUIX_RUNTIME });
+
+  const result = await runtime.run("while(true) {}", {}, { timeoutMs: 100 });
+
+  assert.notEqual(result.error, undefined, "Expected an error from infinite loop");
+  assert.ok(
+    result.error.message.toLowerCase().includes("timeout") ||
+      result.error.message.toLowerCase().includes("interrupt"),
+    `Expected error message about timeout/interrupt, got: ${result.error.message}`,
+  );
+});

--- a/packages/code-mode/tsup.config.ts
+++ b/packages/code-mode/tsup.config.ts
@@ -13,6 +13,6 @@ export default defineConfig({
   bundle: true,
   minify: false,
   sourcemap: true,
-  external: ["isolated-vm", "@modelcontextprotocol/sdk", "zod", "ai"],
+  external: ["isolated-vm", "quickjs-emscripten", "@modelcontextprotocol/sdk", "zod", "ai"],
   config: false
 });


### PR DESCRIPTION
## What is the type of this PR?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Description

Adds a new QuickJS-based sandbox runtime (`QuickJsCodeModeRuntime`) as an alternative to the existing `isolated-vm` runtime. Key changes:

- **`base-runtime.ts`** — Extracts shared tool-indexing, host-side tool calling, search, schema, and logging logic into `BaseCodeModeRuntime` (abstract base class)
- **`quickjs-runtime.ts`** — New `QuickJsCodeModeRuntime` using `quickjs-emscripten` with QuickJS Asyncify for sync-style tool calls inside the sandbox
- **`runtime.ts`** — Refactors `IsolatedVmCodeModeRuntime` to extend `BaseCodeModeRuntime`; adds `tryDetectRuntime()` for auto-fallback when `isolated-vm` isn't available
- **`sandbox-bridge.ts`** — Adds `quickjs` parameter to `generateBootstrapCode()` and `asyncPattern` to `generateNamespaceBridgeCode()`
- **Tests** — 16 QuickJS test cases covering basic execution, namespace bridge, `callTool`, input passthrough, console capture, tool call tracking, search, interfaces, error handling, MCP envelopes, and timeout
- **`createCodeModeRuntime()`** factory now accepts `runtime: 'isolated-vm' | 'quickjs'` option; defaults to auto-detect

## Checklist

- [x] Code follows TypeScript strict mode guidelines
- [x] Tests added/updated
- [x] Build succeeds (`npm run build`)
- [x] All tests pass (`npm test`)