### PR TITLE
fix: preserve SEP-2243 Mcp-Param headers through tools/call

### DIFF
--- a/packages/sdk/src/server/mcp/oauth-client.ts
+++ b/packages/sdk/src/server/mcp/oauth-client.ts
@@ -1,4 +1,4 @@
-import { CallToolResultSchema, GetPromptResultSchema, ReadResourceResultSchema } from "@modelcontextprotocol/core";
+import { GetPromptResultSchema, ReadResourceResultSchema } from "@modelcontextprotocol/core";
 import { Client, StreamableHTTPClientTransport, SSEClientTransport, UnauthorizedError as SDKUnauthorizedError, ProtocolError, ListToolsResult, CallToolRequest, CallToolResult, ListPromptsResult, GetPromptRequest, GetPromptResult, ListResourcesResult, ListResourceTemplatesResult, ReadResourceRequest, ReadResourceResult } from "@modelcontextprotocol/client";
 import type { Tool, Prompt, Resource, ResourceTemplateType, Implementation, OAuthTokens, OAuthClientProvider, StoredOAuthClientInformation, OAuthClientInformationMixed, ClientOptions, DiscoverResult, ProtocolEra } from "@modelcontextprotocol/client";
 import { nanoid } from 'nanoid';
@@ -878,7 +878,7 @@ export class MCPClient {
 
     try {
       const result = await this.withRetry(() =>
-        this.client!.request(request, CallToolResultSchema)
+        this.client!.callTool(request.params)
       );
 
       this._onObservabilityEvent.fire({


### PR DESCRIPTION
## Summary

`MCPClient.callTool` was sending `tools/call` through the raw `this.client.request(request, CallToolResultSchema)` path, which bypasses the official `@modelcontextprotocol/client` v2's SEP-2243 (protocol revision 2026-07-28) `Mcp-Param-*` header mirroring. Tools with `x-mcp-header` annotations (e.g. GitHub MCP `issue_write`'s `owner`/`repo`) failed with:

```
header mismatch: missing Mcp-Param-owner header for parameter "owner"
```

## Change

Route the call through `this.client.callTool(request.params)` so the official client's header-mirroring (`_resolveXMcpHeaderScan` → `buildMcpParamHeaders`) and the `HEADER_MISMATCH` (-32020) evict-refetch-retry recovery run.

## References

Closes #183