### PR TITLE
feat: add zma[bot] AI workflows for issue triage and PR review

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -24,10 +24,10 @@ jobs:
 
       - uses: anomalyco/opencode/github@latest
         env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
-          model: opencode/deepseek-v4-flash-free
+          model: deepseek/deepseek-v4-flash
           use_github_token: true
           prompt: |
             Review this pull request:

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -24,10 +24,10 @@ jobs:
 
       - uses: anomalyco/opencode/github@latest
         env:
-          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
-          model: deepseek/deepseek-v4-flash
+          model: opencode/deepseek-v4-flash-free
           use_github_token: true
           prompt: |
             Review this pull request:

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -24,7 +24,6 @@ jobs:
 
       - uses: anomalyco/opencode/github@latest
         env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           model: opencode/deepseek-v4-flash-free

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -1,0 +1,36 @@
+name: opencode-review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Generate zma bot token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ZMA_APP_ID }}
+          private-key: ${{ secrets.ZMA_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v6
+
+      - uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        with:
+          model: opencode/deepseek-v4-flash-free
+          use_github_token: true
+          prompt: |
+            Review this pull request:
+            - Check for code quality issues
+            - Look for potential bugs
+            - Suggest improvements

--- a/.github/workflows/opencode-triage.yml
+++ b/.github/workflows/opencode-triage.yml
@@ -39,10 +39,10 @@ jobs:
       - uses: anomalyco/opencode/github@latest
         if: steps.check.outputs.result == 'true'
         env:
-          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
-          model: deepseek/deepseek-v4-flash
+          model: opencode/deepseek-v4-flash-free
           use_github_token: true
           prompt: |
             Review this issue. If there's a clear fix or relevant docs:

--- a/.github/workflows/opencode-triage.yml
+++ b/.github/workflows/opencode-triage.yml
@@ -39,10 +39,10 @@ jobs:
       - uses: anomalyco/opencode/github@latest
         if: steps.check.outputs.result == 'true'
         env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
-          model: opencode/deepseek-v4-flash-free
+          model: deepseek/deepseek-v4-flash
           use_github_token: true
           prompt: |
             Review this issue. If there's a clear fix or relevant docs:

--- a/.github/workflows/opencode-triage.yml
+++ b/.github/workflows/opencode-triage.yml
@@ -1,0 +1,51 @@
+name: Issue Triage
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Generate zma bot token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ZMA_APP_ID }}
+          private-key: ${{ secrets.ZMA_PRIVATE_KEY }}
+
+      - name: Check account age
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const user = await github.rest.users.getByUsername({
+              username: context.payload.issue.user.login
+            });
+            const created = new Date(user.data.created_at);
+            const days = (Date.now() - created) / (1000 * 60 * 60 * 24);
+            return days >= 30;
+          result-encoding: string
+
+      - uses: actions/checkout@v6
+        if: steps.check.outputs.result == 'true'
+        with:
+          persist-credentials: false
+
+      - uses: anomalyco/opencode/github@latest
+        if: steps.check.outputs.result == 'true'
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        with:
+          model: opencode/deepseek-v4-flash-free
+          use_github_token: true
+          prompt: |
+            Review this issue. If there's a clear fix or relevant docs:
+            - Provide documentation links
+            - Add error handling guidance for code examples
+            Otherwise, do not comment.

--- a/.github/workflows/opencode-triage.yml
+++ b/.github/workflows/opencode-triage.yml
@@ -39,7 +39,6 @@ jobs:
       - uses: anomalyco/opencode/github@latest
         if: steps.check.outputs.result == 'true'
         env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           model: opencode/deepseek-v4-flash-free

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Run opencode
         uses: anomalyco/opencode/github@latest
         env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           model: opencode/deepseek-v4-flash-free

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Run opencode
         uses: anomalyco/opencode/github@latest
         env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
-          model: opencode/deepseek-v4-flash-free
+          model: deepseek/deepseek-v4-flash
           use_github_token: true

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Run opencode
         uses: anomalyco/opencode/github@latest
         env:
-          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
-          model: deepseek/deepseek-v4-flash
+          model: opencode/deepseek-v4-flash-free
           use_github_token: true

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,42 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, ' /oc') ||
+      startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /opencode') ||
+      startsWith(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Generate zma bot token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ZMA_APP_ID }}
+          private-key: ${{ secrets.ZMA_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        with:
+          model: opencode/deepseek-v4-flash-free
+          use_github_token: true

--- a/docs/zma-bot-setup.md
+++ b/docs/zma-bot-setup.md
@@ -44,7 +44,7 @@ Go to **Repo → Settings → Secrets and variables → Actions**, add:
 |---|---|
 | `ZMA_APP_ID` | The app ID copied in Step 1.6 |
 | `ZMA_PRIVATE_KEY` | The **entire contents** of the `.pem` file (including `-----BEGIN RSA PRIVATE KEY-----` … `-----END RSA PRIVATE KEY-----`) |
-| `DEEPSEEK_API_KEY` | A DeepSeek API key (from platform.deepseek.com) for the underlying engine |
+| `OPENCODE_API_KEY` | A free OpenCode Zen API key (from opencode.ai/auth) for the free `opencode/deepseek-v4-flash-free` model |
 
 > `ZMA_PRIVATE_KEY` is multiline — paste the full PEM. A common failure is a
 > truncated key that omits the trailing newline.

--- a/docs/zma-bot-setup.md
+++ b/docs/zma-bot-setup.md
@@ -1,0 +1,65 @@
+# zma[bot] — automated bot setup
+
+The AI workflows in this repo run on the opencode engine but post as a
+custom bot identity, **`zma[bot]`** (Zon Labs MCP Assistant), instead of
+the default `github-actions[bot]`.
+
+This is achieved with a GitHub App named **`ZMA`**. GitHub automatically
+renders its account as `zma[bot]`. The workflows mint a short-lived token
+for that app (`actions/create-github-app-token@v1`) and pass it to the
+opencode action as `GITHUB_TOKEN`, so every review, comment, and triage
+response is authored by `zma[bot]`.
+
+## Step 1 — Create the GitHub App
+
+1. Go to **GitHub → Settings → Developer settings → GitHub Apps → New GitHub App**
+   (https://github.com/settings/apps/new)
+2. Fill in:
+   - **GitHub App name:** `ZMA`  (displays as `zma[bot]`)
+   - **Homepage URL:** `https://github.com/zonlabs`
+   - **Description:** e.g. "Zon Labs MCP Assistant bot — automated issue triage and PR review"
+   - **Webhook:** Disable (no webhook needed; workflows are event-driven)
+3. **Repository permissions** (must be granted):
+   - `Contents` → **Read**
+   - `Issues` → **Read & write**
+   - `Pull requests` → **Read & write**
+   - `Metadata` → **Read** (always)
+4. Leave "Subscribe to events" empty (no webhook).
+5. Click **Create GitHub App**.
+6. On the app page:
+   - Copy the **App ID** (top of page).
+   - Click **Generate a private key** → downloads a `.pem` file. Keep it safe — it can only be downloaded once.
+
+## Step 2 — Install the app on the repo
+
+1. On the app page, go to **Install App** (left sidebar) → **Install** next to `zonlabs`.
+2. Select the **mcp-ts** repository (or "All repositories" if you want it org-wide).
+3. Confirm the permissions shown and **Install**.
+
+## Step 3 — Add repo secrets
+
+Go to **Repo → Settings → Secrets and variables → Actions**, add:
+
+| Secret name | Value |
+|---|---|
+| `ZMA_APP_ID` | The app ID copied in Step 1.6 |
+| `ZMA_PRIVATE_KEY` | The **entire contents** of the `.pem` file (including `-----BEGIN RSA PRIVATE KEY-----` … `-----END RSA PRIVATE KEY-----`) |
+| `OPENCODE_API_KEY` | An opencode API key for the underlying engine (same key the obot repo workflows use) |
+
+> `ZMA_PRIVATE_KEY` is multiline — paste the full PEM. A common failure is a
+> truncated key that omits the trailing newline.
+
+## How it works
+
+- `.github/workflows/opencode.yml` — responds to `/oc` and `/opencode` comments (and `@` mentions) on issues/PRs
+- `.github/workflows/opencode-triage.yml` — triages newly opened issues from accounts older than 30 days
+- `.github/workflows/opencode-review.yml` — reviews every opened/synced PR for quality, bugs, and improvements
+
+All three mint a `zma[bot]` token and feed it to `anomalyco/opencode/github@latest`, so the
+engine is opencode but the identity shown to contributors is `zma[bot]`.
+
+## Troubleshooting
+
+- **Workflow fails with "Could not get token"** → check `ZMA_APP_ID` / `ZMA_PRIVATE_KEY` are set correctly (full PEM, no stray whitespace).
+- **Comments still posted by `github-actions[bot]`** → the `GITHUB_TOKEN` env wasn't picked up; verify `use_github_token: true` is set and the `app-token` step ID matches.
+- **App can't comment** → confirm `Issues` and `Pull requests` permissions are **Read & write** and the app is installed on this repo.

--- a/docs/zma-bot-setup.md
+++ b/docs/zma-bot-setup.md
@@ -44,7 +44,7 @@ Go to **Repo → Settings → Secrets and variables → Actions**, add:
 |---|---|
 | `ZMA_APP_ID` | The app ID copied in Step 1.6 |
 | `ZMA_PRIVATE_KEY` | The **entire contents** of the `.pem` file (including `-----BEGIN RSA PRIVATE KEY-----` … `-----END RSA PRIVATE KEY-----`) |
-| `OPENCODE_API_KEY` | An opencode API key for the underlying engine (same key the obot repo workflows use) |
+| `DEEPSEEK_API_KEY` | A DeepSeek API key (from platform.deepseek.com) for the underlying engine |
 
 > `ZMA_PRIVATE_KEY` is multiline — paste the full PEM. A common failure is a
 > truncated key that omits the trailing newline.

--- a/docs/zma-bot-setup.md
+++ b/docs/zma-bot-setup.md
@@ -44,7 +44,9 @@ Go to **Repo → Settings → Secrets and variables → Actions**, add:
 |---|---|
 | `ZMA_APP_ID` | The app ID copied in Step 1.6 |
 | `ZMA_PRIVATE_KEY` | The **entire contents** of the `.pem` file (including `-----BEGIN RSA PRIVATE KEY-----` … `-----END RSA PRIVATE KEY-----`) |
-| `OPENCODE_API_KEY` | A free OpenCode Zen API key (from opencode.ai/auth) for the free `opencode/deepseek-v4-flash-free` model |
+
+> No API key is required: the free `opencode/deepseek-v4-flash-free` model runs
+> without authentication, so no `OPENCODE_API_KEY` secret is needed.
 
 > `ZMA_PRIVATE_KEY` is multiline — paste the full PEM. A common failure is a
 > truncated key that omits the trailing newline.


### PR DESCRIPTION
## Summary

Add AI-powered automation to this repo running on the opencode engine, but posting as a custom bot identity **zma[bot]** (GitHub App named ZMA) instead of the default github-actions[bot].

## Changes

Three workflows, mirrored from obot's setup:

- **opencode.yml** - responds to /oc and /opencode slash commands on issues and PRs
- **opencode-triage.yml** - triages newly opened issues from accounts older than 30 days
- **opencode-review.yml** - reviews every opened/synced/reopened PR for code quality, bugs, and improvements

Each workflow mints a short-lived token for the ZMA GitHub App via actions/create-github-app-token@v1 (from the ZMA_APP_ID and ZMA_PRIVATE_KEY secrets) and passes it to anomalyco/opencode/github@latest as GITHUB_TOKEN with use_github_token: true. This makes every automated comment, review, and triage response authored by zma[bot].

Plus docs/zma-bot-setup.md with the exact manual setup steps (create app, permissions, install, secrets).

## Required before these workflows run

The workflows reference three repo secrets. They are inert until set:

- ZMA_APP_ID - the GitHub App ID
- ZMA_PRIVATE_KEY - full PEM private key of the ZMA app
- OPENCODE_API_KEY - opencode API key for the underlying engine

Full instructions are in docs/zma-bot-setup.md.

## Notes

- Engine stays opencode (anomalyco/opencode/github@latest, model opencode/deepseek-v4-flash-free) - same as the obot repo.
- Only the identity changes to zma[bot].