### PR TITLE
feat(cli): add MCP developer CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
       - 'packages/sdk/package.json'
       - 'packages/tool-router/package.json'
       - 'packages/code-mode/package.json'
+      - 'packages/cli/package.json'
 
 concurrency:
   group: release-npm-${{ github.ref }}
@@ -65,6 +66,12 @@ jobs:
             echo 'codemode_changed=false' >> "$GITHUB_OUTPUT"
           fi
 
+          if printf '%s\n' "$CHANGED_FILES" | grep -Fxq 'packages/cli/package.json'; then
+            echo 'cli_changed=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'cli_changed=false' >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Resolve package metadata
         id: meta
         shell: bash
@@ -75,18 +82,23 @@ jobs:
           TOOL_ROUTER_VERSION=$(node -p "require('./packages/tool-router/package.json').version")
           CODEMODE_NAME=$(node -p "require('./packages/code-mode/package.json').name")
           CODEMODE_VERSION=$(node -p "require('./packages/code-mode/package.json').version")
+          CLI_NAME=$(node -p "require('./packages/cli/package.json').name")
+          CLI_VERSION=$(node -p "require('./packages/cli/package.json').version")
 
-          echo "sdk_name=$SDK_NAME" >> "$GITHUB_OUTPUT"
-          echo "sdk_version=$SDK_VERSION" >> "$GITHUB_OUTPUT"
-          echo "sdk_tag=sdk-v$SDK_VERSION" >> "$GITHUB_OUTPUT"
-
-          echo "tool_router_name=$TOOL_ROUTER_NAME" >> "$GITHUB_OUTPUT"
-          echo "tool_router_version=$TOOL_ROUTER_VERSION" >> "$GITHUB_OUTPUT"
-          echo "tool_router_tag=tool-router-v$TOOL_ROUTER_VERSION" >> "$GITHUB_OUTPUT"
-
-          echo "codemode_name=$CODEMODE_NAME" >> "$GITHUB_OUTPUT"
-          echo "codemode_version=$CODEMODE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "codemode_tag=codemode-v$CODEMODE_VERSION" >> "$GITHUB_OUTPUT"
+          {
+            echo "sdk_name=$SDK_NAME"
+            echo "sdk_version=$SDK_VERSION"
+            echo "sdk_tag=sdk-v$SDK_VERSION"
+            echo "tool_router_name=$TOOL_ROUTER_NAME"
+            echo "tool_router_version=$TOOL_ROUTER_VERSION"
+            echo "tool_router_tag=tool-router-v$TOOL_ROUTER_VERSION"
+            echo "codemode_name=$CODEMODE_NAME"
+            echo "codemode_version=$CODEMODE_VERSION"
+            echo "codemode_tag=codemode-v$CODEMODE_VERSION"
+            echo "cli_name=$CLI_NAME"
+            echo "cli_version=$CLI_VERSION"
+            echo "cli_tag=cli-v$CLI_VERSION"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Decide publish targets
         id: publish
@@ -124,11 +136,22 @@ jobs:
           fi
           echo "codemode_should_publish=$codemode_should_publish" >> "$GITHUB_OUTPUT"
 
+          cli_should_publish=false
+          if [ '${{ steps.changed.outputs.cli_changed }}' = 'true' ]; then
+            if git rev-parse -q --verify "refs/tags/${{ steps.meta.outputs.cli_tag }}" >/dev/null; then
+              cli_should_publish=false
+            else
+              cli_should_publish=true
+            fi
+          fi
+          echo "cli_should_publish=$cli_should_publish" >> "$GITHUB_OUTPUT"
+
       - name: Install root dependencies
         if: |
           steps.publish.outputs.sdk_should_publish == 'true' ||
           steps.publish.outputs.tool_router_should_publish == 'true' ||
-          steps.publish.outputs.codemode_should_publish == 'true'
+          steps.publish.outputs.codemode_should_publish == 'true' ||
+          steps.publish.outputs.cli_should_publish == 'true'
         run: npm ci
 
       - name: Build SDK package
@@ -210,3 +233,29 @@ jobs:
           name: ${{ steps.meta.outputs.codemode_tag }}
           generate_release_notes: true
           body: "Release ${{ steps.meta.outputs.codemode_name }} ${{ steps.meta.outputs.codemode_tag }}"
+
+      - name: Build CLI package
+        if: steps.publish.outputs.cli_should_publish == 'true'
+        run: npm run build -w @mcp-ts/sdk && npm run build -w @mcp-ts/cli
+
+      - name: Publish CLI package to npm
+        if: steps.publish.outputs.cli_should_publish == 'true'
+        working-directory: packages/cli
+        run: npm publish --ignore-scripts --provenance --access public
+
+      - name: Create and push CLI git tag
+        if: steps.publish.outputs.cli_should_publish == 'true'
+        run: |
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git tag -a "${{ steps.meta.outputs.cli_tag }}" -m "Release ${{ steps.meta.outputs.cli_tag }}"
+          git push origin "refs/tags/${{ steps.meta.outputs.cli_tag }}"
+
+      - name: Create CLI GitHub Release
+        if: steps.publish.outputs.cli_should_publish == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.cli_tag }}
+          name: ${{ steps.meta.outputs.cli_tag }}
+          generate_release_notes: true
+          body: "Release ${{ steps.meta.outputs.cli_name }} ${{ steps.meta.outputs.cli_tag }}"

--- a/README.md
+++ b/README.md
@@ -90,7 +90,23 @@ If you already use a managed service/platform such as Smithery, Klavis Strata, C
 | **[@mcp-ts/sdk](packages/sdk)** | Core TypeScript/JavaScript SDK for client applications. | `npm i @mcp-ts/sdk` |
 | **[@mcp-ts/tool-router](packages/tool-router)** | ToolRouter for dynamic tool discovery across many MCP servers. | `npm i @mcp-ts/tool-router` |
 | **[@mcp-ts/codemode](packages/code-mode)** | CodeMode: sandboxed program execution for tool calling. | `npm i @mcp-ts/codemode` |
+| **[@mcp-ts/cli](packages/cli)** | Explore, search, benchmark, and generate typed wrappers for remote MCP servers. | `npx @mcp-ts/cli --help` |
 | **[mcpassistant-gateway](packages/local-gateway)** | Python bridge for local MCP support in remote apps. | `pip install mcpassistant-gateway` |
+
+---
+
+### Developer CLI
+
+Use the CLI to inspect a Streamable HTTP MCP endpoint without building an application first:
+
+```bash
+npx @mcp-ts/cli connect https://api.example.com/mcp
+npx @mcp-ts/cli search https://api.example.com/mcp "send email"
+npx @mcp-ts/cli bench https://api.example.com/mcp
+npx @mcp-ts/cli codegen https://api.example.com/mcp --out ./src/mcp-tools.ts
+```
+
+The `connect` REPL supports `search`, `schema`, and `call` commands. See the [CLI package README](packages/cli) for details.
 
 ---
 
@@ -577,4 +593,3 @@ Contributions are welcome! Please read [CONTRIBUTING.md](packages/sdk/CONTRIBUTI
 <p align="center">
   <em>Thanks for visiting @mcp-ts!</em>
 </p>
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,7 @@
       "workspaces": [
         "packages/*",
         "mcp"
-      ],
-      "dependencies": {
-        "quickjs-emscripten": "^0.31.0"
-      }
+      ]
     },
     "mcp": {
       "name": "@mcp-ts/mcp",
@@ -509,7 +506,7 @@
       "version": "20.19.43",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
       "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -667,7 +664,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "mcp/node_modules/zod": {
@@ -1677,7 +1674,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1694,7 +1690,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1711,7 +1706,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1728,7 +1722,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1745,7 +1738,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1762,7 +1754,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1779,7 +1770,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1796,7 +1786,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1813,7 +1802,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1830,7 +1818,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1847,7 +1834,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1864,7 +1850,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1881,7 +1866,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1898,7 +1882,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1915,7 +1898,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1932,7 +1914,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1949,7 +1930,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1966,7 +1946,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1983,7 +1962,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2000,7 +1978,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2017,7 +1994,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2034,7 +2010,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2051,7 +2026,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2068,7 +2042,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2085,7 +2058,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2102,7 +2074,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3085,6 +3056,10 @@
         "node": ">=20"
       }
     },
+    "node_modules/@mcp-ts/cli": {
+      "resolved": "packages/cli",
+      "link": true
+    },
     "node_modules/@mcp-ts/codemode": {
       "resolved": "packages/code-mode",
       "link": true
@@ -3650,7 +3625,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3664,7 +3638,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3678,7 +3651,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3692,7 +3664,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3706,7 +3677,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3720,7 +3690,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3734,7 +3703,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3748,7 +3716,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3762,7 +3729,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3776,7 +3742,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3790,7 +3755,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3804,7 +3768,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3818,7 +3781,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3832,7 +3794,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3846,7 +3807,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3860,7 +3820,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3874,7 +3833,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3888,7 +3846,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3902,7 +3859,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3916,7 +3872,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3930,7 +3885,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3944,7 +3898,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3958,7 +3911,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3972,7 +3924,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3986,7 +3937,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4165,7 +4115,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/gensync": {
@@ -5621,7 +5571,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5781,7 +5731,7 @@
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
       "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6398,7 +6348,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8334,7 +8283,7 @@
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -9315,7 +9264,7 @@
       "version": "7.3.6",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
@@ -9390,7 +9339,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -10336,6 +10284,27 @@
       "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
+      }
+    },
+    "packages/cli": {
+      "name": "@mcp-ts/cli",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@mcp-ts/sdk": "^3.0.2",
+        "@modelcontextprotocol/client": "^2.0.0"
+      },
+      "bin": {
+        "mcp-ts": "dist/bin/mcp-ts.js"
+      },
+      "devDependencies": {
+        "@types/node": "^25.0.10",
+        "tsup": "^8.5.1",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.10"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "packages/code-mode": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "mcp"
   ],
   "scripts": {
-    "build": "npm run build --workspace packages/sdk --workspace packages/code-mode"
+    "build": "npm run build --workspace packages/sdk --workspace packages/code-mode --workspace packages/cli"
   }
 }

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 MCP Assistant
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,14 @@
+# @mcp-ts/cli
+
+Explore a remote MCP server without writing an application first.
+
+```bash
+npx @mcp-ts/cli connect https://api.example.com/mcp
+npx @mcp-ts/cli search https://api.example.com/mcp "send email"
+npx @mcp-ts/cli bench https://api.example.com/mcp
+npx @mcp-ts/cli codegen https://api.example.com/mcp --out ./src/mcp-tools.ts
+```
+
+The interactive `connect` command supports `search`, `schema`, and `call` commands. `search` uses the SDK's BM25-backed `ToolRouter`; `bench` compares the estimated context cost of its `all`, `search`, and `groups` exposure strategies. `codegen` produces dependency-free TypeScript wrappers from the server's JSON schemas.
+
+The CLI currently connects to Streamable HTTP endpoints that do not require an interactive OAuth flow.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@mcp-ts/cli",
+  "version": "0.1.0",
+  "description": "Explore, search, benchmark, and generate typed wrappers for remote MCP servers.",
+  "type": "module",
+  "bin": { "mcp-ts": "./dist/bin/mcp-ts.js" },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" } },
+  "files": ["dist", "README.md", "LICENSE"],
+  "scripts": {
+    "build": "tsup",
+    "prepublishOnly": "npm run build",
+    "test": "npm run build && vitest run",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@mcp-ts/sdk": "^3.0.2",
+    "@modelcontextprotocol/client": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.10",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.10"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zonlabs/mcp-ts.git",
+    "directory": "packages/cli"
+  },
+  "engines": { "node": ">=20.0.0" },
+  "publishConfig": { "access": "public" }
+}

--- a/packages/cli/src/bin/mcp-ts.ts
+++ b/packages/cli/src/bin/mcp-ts.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { runCli } from "../cli.js";
+
+process.exitCode = await runCli(process.argv.slice(2));

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,177 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { createInterface } from "node:readline/promises";
+import type { Readable, Writable } from "node:stream";
+import { benchmarkStrategies, createRouter, generateWrappers, resolveTool, searchTools } from "./core.js";
+import { connectRemote } from "./client.js";
+
+const HELP = `mcp-ts — explore remote MCP servers
+
+Usage:
+  mcp-ts connect <url>
+  mcp-ts search <url> <query> [--limit <count>]
+  mcp-ts bench <url>
+  mcp-ts codegen <url> --out <file>
+
+Connect REPL commands:
+  search <query>             Search the remote tool catalog
+  schema <tool|server::tool> Show a tool's JSON schemas
+  call <tool> <json>         Call a tool with a JSON object
+  help                       Show REPL commands
+  exit                       Disconnect and exit`;
+
+function writeLine(output: Pick<Writable, "write">, value = ""): void {
+  output.write(`${value}\n`);
+}
+
+function option(args: string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+function positional(args: string[]): string[] {
+  const values: string[] = [];
+  for (let index = 0; index < args.length; index++) {
+    if (args[index].startsWith("--")) index += 1;
+    else values.push(args[index]);
+  }
+  return values;
+}
+
+async function printSearch(
+  output: Pick<Writable, "write">,
+  router: Awaited<ReturnType<typeof createRouter>>,
+  query: string,
+  limit = 10
+): Promise<void> {
+  const results = await searchTools(router, query, limit);
+  if (results.length === 0) {
+    writeLine(output, "No matching tools.");
+    return;
+  }
+  results.forEach((result, index) => {
+    writeLine(
+      output,
+      `${index + 1}. ${result.name} (server: ${result.serverName}, ~${result.estimatedTokens} tokens)`
+    );
+  });
+}
+
+async function runRepl(endpoint: string, input: Readable, output: Writable): Promise<void> {
+  const client = await connectRemote(endpoint);
+  try {
+    const router = await createRouter(client);
+    const catalog = await router.listTools({ limit: Number.MAX_SAFE_INTEGER });
+    writeLine(output, `Connected — ${catalog.totalCount} tools discovered`);
+    writeLine(output, 'Type "help" for commands.');
+
+    const terminal = Boolean((output as Writable & { isTTY?: boolean }).isTTY);
+    const readline = createInterface({ input, output, terminal });
+    try {
+      while (true) {
+        const line = (await readline.question("> ")).trim();
+        if (!line) continue;
+        const [command, ...rest] = line.split(/\s+/);
+        if (command === "exit" || command === "quit") break;
+        if (command === "help") {
+          writeLine(output, HELP.split("Connect REPL commands:\n")[1]);
+          continue;
+        }
+        if (command === "search") {
+          await printSearch(output, router, rest.join(" "));
+          continue;
+        }
+        if (command === "schema") {
+          const tool = resolveTool(router, rest[0] ?? "");
+          if (!tool) throw new Error(`Tool "${rest[0] ?? ""}" was not found`);
+          writeLine(output, JSON.stringify({ inputSchema: tool.inputSchema, outputSchema: tool.outputSchema }, null, 2));
+          continue;
+        }
+        if (command === "call") {
+          const reference = rest.shift() ?? "";
+          const tool = resolveTool(router, reference);
+          if (!tool) throw new Error(`Tool "${reference}" was not found`);
+          const parsed = JSON.parse(rest.join(" ") || "{}") as unknown;
+          if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+            throw new Error("Tool arguments must be a JSON object");
+          }
+          const args = parsed as Record<string, unknown>;
+          const result = await router.callTool(tool.name, args, tool.serverId);
+          writeLine(output, JSON.stringify(result, null, 2));
+          continue;
+        }
+        writeLine(output, `Unknown command: ${command}`);
+      }
+    } finally {
+      readline.close();
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+export async function runCli(
+  args: string[],
+  streams: { input: Readable; output: Writable; error: Writable } = {
+    input: process.stdin,
+    output: process.stdout,
+    error: process.stderr
+  }
+): Promise<number> {
+  const [command, ...commandArgs] = args;
+  if (!command || command === "help" || command === "--help" || command === "-h") {
+    writeLine(streams.output, HELP);
+    return 0;
+  }
+
+  try {
+    if (!["connect", "search", "bench", "codegen"].includes(command)) {
+      throw new Error(`Unknown command: ${command}`);
+    }
+    const values = positional(commandArgs);
+    const endpoint = values[0];
+    if (!endpoint) throw new Error(`${command} requires an MCP endpoint URL`);
+    if (command === "connect") {
+      await runRepl(endpoint, streams.input, streams.output);
+      return 0;
+    }
+
+    const searchQuery = command === "search" ? values.slice(1).join(" ") : undefined;
+    const searchLimit = Number(option(commandArgs, "--limit") ?? 10);
+    const codegenOut = option(commandArgs, "--out");
+    if (command === "search" && !searchQuery) throw new Error("search requires a query");
+    if (command === "search" && (!Number.isInteger(searchLimit) || searchLimit < 1 || searchLimit > 100)) {
+      throw new Error("--limit must be an integer between 1 and 100");
+    }
+    if (command === "codegen" && !codegenOut) throw new Error("codegen requires --out <file>");
+
+    const client = await connectRemote(endpoint);
+    try {
+      if (command === "search") {
+        await printSearch(streams.output, await createRouter(client), searchQuery!, searchLimit);
+        return 0;
+      }
+      if (command === "bench") {
+        writeLine(streams.output, "Strategy  Tools  Estimated tokens");
+        for (const result of await benchmarkStrategies(client)) {
+          writeLine(streams.output, `${result.strategy.padEnd(8)}  ${String(result.exposedTools).padStart(5)}  ${String(result.estimatedTokens).padStart(16)}`);
+        }
+        return 0;
+      }
+      if (command === "codegen") {
+        const { tools } = await client.listTools();
+        const target = resolve(codegenOut!);
+        await mkdir(dirname(target), { recursive: true });
+        await writeFile(target, generateWrappers(tools), "utf8");
+        writeLine(streams.output, `Generated ${tools.length} tool wrappers in ${target}`);
+        return 0;
+      }
+      return 0;
+    } finally {
+      await client.close();
+    }
+  } catch (error) {
+    writeLine(streams.error, error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -1,0 +1,70 @@
+import {
+  Client,
+  StreamableHTTPClientTransport,
+  type Tool
+} from "@modelcontextprotocol/client";
+import type { ToolClient } from "@mcp-ts/sdk/shared";
+
+function serverIdFor(url: URL): string {
+  const path = url.pathname.replace(/[^a-zA-Z0-9]+/g, "_").replace(/^_|_$/g, "");
+  return `${url.hostname}${path ? `_${path}` : ""}`.toLowerCase();
+}
+
+export class RemoteToolClient implements ToolClient {
+  private readonly client = new Client({ name: "@mcp-ts/cli", version: "0.1.0" });
+  private readonly transport: StreamableHTTPClientTransport;
+  private connected = false;
+  private cachedTools: Tool[] | undefined;
+  private readonly serverId: string;
+
+  constructor(private readonly endpoint: URL) {
+    this.serverId = serverIdFor(endpoint);
+    this.transport = new StreamableHTTPClientTransport(endpoint);
+  }
+
+  async connect(): Promise<void> {
+    await this.client.connect(this.transport);
+    this.connected = true;
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  async listTools(): Promise<{ tools: Tool[] }> {
+    if (!this.cachedTools) {
+      const { tools } = await this.client.listTools();
+      this.cachedTools = tools;
+    }
+    return { tools: this.cachedTools };
+  }
+
+  async callTool(name: string, args: Record<string, unknown>): Promise<unknown> {
+    return this.client.callTool({ name, arguments: args });
+  }
+
+  getServerId(): string { return this.serverId; }
+  getServerName(): string { return this.endpoint.hostname; }
+  getServerUrl(): string { return this.endpoint.toString(); }
+  getSessionId(): string { return `cli:${this.serverId}`; }
+
+  async close(): Promise<void> {
+    this.connected = false;
+    await this.client.close();
+  }
+}
+
+export async function connectRemote(endpoint: string): Promise<RemoteToolClient> {
+  const url = new URL(endpoint);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("MCP endpoint must use http:// or https://");
+  }
+  const client = new RemoteToolClient(url);
+  try {
+    await client.connect();
+    return client;
+  } catch (error) {
+    await client.close().catch(() => undefined);
+    throw error;
+  }
+}

--- a/packages/cli/src/core.ts
+++ b/packages/cli/src/core.ts
@@ -1,0 +1,183 @@
+import type { Tool } from "@modelcontextprotocol/client";
+import {
+  ToolRouter,
+  type IndexedTool,
+  type ToolClient,
+  type ToolRouterStrategy,
+  type ToolSummary
+} from "@mcp-ts/sdk/shared";
+import { estimateToolTokens, estimateToolsTokens } from "./token-estimator.js";
+
+export interface SearchResult extends ToolSummary {
+  estimatedTokens: number;
+}
+
+export interface StrategyBenchmark {
+  strategy: ToolRouterStrategy;
+  exposedTools: number;
+  estimatedTokens: number;
+}
+
+export async function createRouter(
+  client: ToolClient,
+  strategy: ToolRouterStrategy = "search"
+): Promise<ToolRouter> {
+  const router = new ToolRouter([client], { strategy });
+  await router.listTools({ limit: 1 });
+  return router;
+}
+
+export async function searchTools(
+  router: ToolRouter,
+  query: string,
+  limit = 10
+): Promise<SearchResult[]> {
+  const results = await router.searchTools(query, limit);
+  return results.map((result) => {
+    const tool = router.getToolSchema(result.name, result.serverId);
+    return { ...result, estimatedTokens: tool ? estimateToolTokens(tool) : 0 };
+  });
+}
+
+export function resolveTool(router: ToolRouter, reference: string): IndexedTool | undefined {
+  const separator = reference.indexOf("::");
+  if (separator > 0) {
+    return router.getToolSchema(reference.slice(separator + 2), reference.slice(0, separator));
+  }
+  return router.getToolSchema(reference);
+}
+
+export async function benchmarkStrategies(client: ToolClient): Promise<StrategyBenchmark[]> {
+  const router = await createRouter(client, "all");
+  const strategies: ToolRouterStrategy[] = ["all", "search", "groups"];
+  const benchmarks: StrategyBenchmark[] = [];
+  for (const strategy of strategies) {
+    router.setStrategy(strategy);
+    const exposed = await router.getFilteredTools();
+    benchmarks.push({
+      strategy,
+      exposedTools: exposed.length,
+      estimatedTokens: estimateToolsTokens(exposed)
+    });
+  }
+  return benchmarks;
+}
+
+type JsonSchema = {
+  type?: string | string[];
+  enum?: unknown[];
+  const?: unknown;
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  items?: JsonSchema;
+  additionalProperties?: boolean | JsonSchema;
+  anyOf?: JsonSchema[];
+  oneOf?: JsonSchema[];
+  allOf?: JsonSchema[];
+};
+
+function literal(value: unknown): string {
+  if (value === null) return "null";
+  if (["string", "number", "boolean"].includes(typeof value)) return JSON.stringify(value);
+  return "unknown";
+}
+
+function schemaToType(schema: unknown): string {
+  if (!schema || typeof schema !== "object") return "unknown";
+  const value = schema as JsonSchema;
+  if (value.const !== undefined) return literal(value.const);
+  if (value.enum?.length) return value.enum.map(literal).join(" | ");
+  if (value.oneOf?.length) return value.oneOf.map(schemaToType).join(" | ");
+  if (value.anyOf?.length) return value.anyOf.map(schemaToType).join(" | ");
+  if (value.allOf?.length) return value.allOf.map(schemaToType).join(" & ");
+  if (Array.isArray(value.type)) {
+    return value.type.map((type) => schemaToType({ ...value, type })).join(" | ");
+  }
+
+  switch (value.type) {
+    case "string": return "string";
+    case "integer":
+    case "number": return "number";
+    case "boolean": return "boolean";
+    case "null": return "null";
+    case "array": return `Array<${schemaToType(value.items)}>`;
+    case "object": {
+      const required = new Set(value.required ?? []);
+      const properties = Object.entries(value.properties ?? {}).map(
+        ([name, property]) => `${JSON.stringify(name)}${required.has(name) ? "" : "?"}: ${schemaToType(property)};`
+      );
+      if (value.additionalProperties && value.additionalProperties !== true) {
+        properties.push(`[key: string]: ${schemaToType(value.additionalProperties)};`);
+      } else if (value.additionalProperties === true) {
+        properties.push("[key: string]: unknown;");
+      }
+      return `{ ${properties.join(" ")} }`;
+    }
+    default: return "unknown";
+  }
+}
+
+function words(value: string): string[] {
+  return value.split(/[^a-zA-Z0-9]+/).filter(Boolean);
+}
+
+function pascalCase(value: string): string {
+  const result = words(value).map((word) => word[0].toUpperCase() + word.slice(1)).join("");
+  return /^[0-9]/.test(result) ? `Tool${result}` : result || "Tool";
+}
+
+function camelCase(value: string): string {
+  const pascal = pascalCase(value);
+  return pascal[0].toLowerCase() + pascal.slice(1);
+}
+
+function uniqueName(base: string, used: Set<string>): string {
+  let candidate = base;
+  let suffix = 2;
+  while (used.has(candidate)) candidate = `${base}${suffix++}`;
+  used.add(candidate);
+  return candidate;
+}
+
+function jsDoc(description: string | undefined, indent = ""): string {
+  if (!description) return "";
+  const safe = description.replace(/\*\//g, "*\\/").split("\n");
+  return `${indent}/**\n${safe.map((line) => `${indent} * ${line}`).join("\n")}\n${indent} */\n`;
+}
+
+export function generateWrappers(tools: Tool[]): string {
+  const typeNames = new Set<string>();
+  const methodNames = new Set(["constructor", "callTool"]);
+  const definitions: string[] = [];
+  const methods: string[] = [];
+
+  for (const tool of tools) {
+    const typeBase = uniqueName(pascalCase(tool.name), typeNames);
+    const methodName = uniqueName(camelCase(tool.name), methodNames);
+    const inputType = `${typeBase}Input`;
+    const outputType = `${typeBase}Output`;
+    definitions.push(
+      `${jsDoc(tool.description)}export type ${inputType} = ${schemaToType(tool.inputSchema)};`,
+      `export type ${outputType} = ${schemaToType(tool.outputSchema)};`
+    );
+    methods.push(
+      `${jsDoc(tool.description, "  ")}  async ${methodName}(input: ${inputType}): Promise<${outputType}> {\n` +
+        `    return this.callTool(${JSON.stringify(tool.name)}, input) as Promise<${outputType}>;\n` +
+        "  }"
+    );
+  }
+
+  return [
+    "// Generated by @mcp-ts/cli. Do not edit manually.",
+    "",
+    "export type McpToolCaller = (name: string, args: unknown) => Promise<unknown>;",
+    "",
+    ...definitions.flatMap((definition) => [definition, ""]),
+    "export class McpTools {",
+    "  constructor(private readonly callTool: McpToolCaller) {}",
+    "",
+    methods.join("\n\n"),
+    "}",
+    ""
+  ].join("\n");
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,11 @@
+export { connectRemote, RemoteToolClient } from "./client.js";
+export {
+  benchmarkStrategies,
+  createRouter,
+  generateWrappers,
+  resolveTool,
+  searchTools,
+  type SearchResult,
+  type StrategyBenchmark
+} from "./core.js";
+export { estimateTextTokens, estimateToolTokens, estimateToolsTokens } from "./token-estimator.js";

--- a/packages/cli/src/token-estimator.ts
+++ b/packages/cli/src/token-estimator.ts
@@ -1,0 +1,50 @@
+import type { Tool } from "@modelcontextprotocol/client";
+
+const CALIBRATION_DIVISOR = 3.6;
+
+function classifyCharacter(character: string): number {
+  const code = character.charCodeAt(0);
+  if (
+    code <= 0x20 ||
+    character === "{" ||
+    character === "}" ||
+    character === "[" ||
+    character === "]" ||
+    character === ":" ||
+    character === ","
+  ) return 1;
+  if (code >= 0x21 && code <= 0x2f) return 1.5;
+  if (code >= 0x30 && code <= 0x39) return 2;
+  if (code >= 0x41 && code <= 0x5a) return 3.5;
+  if (code >= 0x61 && code <= 0x7a) return 4;
+  return 2.5;
+}
+
+function stringify(value: unknown): string {
+  const seen = new WeakSet<object>();
+  return JSON.stringify(value, (_key, nestedValue: unknown) => {
+    if (!nestedValue || typeof nestedValue !== "object") return nestedValue;
+    if (seen.has(nestedValue)) return "[Circular]";
+    seen.add(nestedValue);
+    return nestedValue;
+  });
+}
+
+export function estimateTextTokens(text: string): number {
+  let weightedLength = 0;
+  for (const character of text) weightedLength += 1 / classifyCharacter(character);
+  return Math.ceil(weightedLength / (1 / CALIBRATION_DIVISOR));
+}
+
+export function estimateToolTokens(tool: Pick<Tool, "name" | "description" | "inputSchema">): number {
+  const parts = [tool.name];
+  if (tool.description) parts.push(tool.description);
+  if (tool.inputSchema) parts.push(stringify(tool.inputSchema));
+  return estimateTextTokens(parts.join(" "));
+}
+
+export function estimateToolsTokens(
+  tools: Array<Pick<Tool, "name" | "description" | "inputSchema">>
+): number {
+  return tools.reduce((total, tool) => total + estimateToolTokens(tool), 0);
+}

--- a/packages/cli/tests/core.test.ts
+++ b/packages/cli/tests/core.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import type { ToolClient } from "@mcp-ts/sdk/shared";
+import type { Tool } from "@modelcontextprotocol/client";
+import { benchmarkStrategies, createRouter, generateWrappers, resolveTool, searchTools } from "../src/core.js";
+
+const tools: Tool[] = [
+  {
+    name: "send_email",
+    description: "Send an email message",
+    inputSchema: {
+      type: "object",
+      properties: {
+        to: { type: "string" },
+        subject: { type: "string" },
+        urgent: { type: "boolean" }
+      },
+      required: ["to", "subject"]
+    },
+    outputSchema: {
+      type: "object",
+      properties: { messageId: { type: "string" } },
+      required: ["messageId"]
+    }
+  },
+  {
+    name: "list_events",
+    description: "List calendar events",
+    inputSchema: { type: "object", properties: { date: { type: "string" } } }
+  }
+];
+
+function fakeClient(): ToolClient {
+  return {
+    isConnected: () => true,
+    listTools: async () => ({ tools }),
+    callTool: async (name, args) => ({ name, args }),
+    getServerId: () => "example",
+    getServerName: () => "Example Server",
+    getServerUrl: () => "https://example.test/mcp",
+    getSessionId: () => "cli:example"
+  };
+}
+
+test("searches the catalog and reports schema token estimates", async () => {
+  const router = await createRouter(fakeClient());
+  const results = await searchTools(router, "email message", 5);
+  assert.equal(results[0].name, "send_email");
+  assert.equal(results[0].serverId, "example");
+  assert.ok(results[0].estimatedTokens > 0);
+  assert.equal(resolveTool(router, "example::send_email")?.name, "send_email");
+});
+
+test("routes an explicit tool call to the connected client", async () => {
+  const router = await createRouter(fakeClient());
+  const result = await router.callTool("send_email", { to: "dev@example.test" }, "example");
+  assert.deepEqual(result, {
+    name: "send_email",
+    args: { to: "dev@example.test" }
+  });
+});
+
+test("benchmarks all ToolRouter exposure strategies", async () => {
+  const results = await benchmarkStrategies(fakeClient());
+  assert.deepEqual(results.map((result) => result.strategy), ["all", "search", "groups"]);
+  assert.equal(results[0].exposedTools, 2);
+  assert.ok(results[1].exposedTools > 0);
+  assert.equal(results[2].exposedTools, 2);
+  assert.ok(results.every((result) => result.estimatedTokens > 0));
+});
+
+test("generates typed wrappers from tool schemas", () => {
+  const generated = generateWrappers([
+    ...tools,
+    { name: "constructor", inputSchema: { type: "object" } },
+    { name: "call_tool", inputSchema: { type: "object" } }
+  ]);
+  assert.match(generated, /export type SendEmailInput = \{ "to": string; "subject": string; "urgent"\?: boolean; \};/);
+  assert.match(generated, /export type SendEmailOutput = \{ "messageId": string; \};/);
+  assert.match(generated, /async sendEmail\(input: SendEmailInput\): Promise<SendEmailOutput>/);
+  assert.match(generated, /this\.callTool\("send_email", input\)/);
+  assert.match(generated, /async constructor2\(/);
+  assert.match(generated, /async callTool2\(/);
+});

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: { index: "src/index.ts", "bin/mcp-ts": "src/bin/mcp-ts.ts" },
+  format: ["esm"],
+  clean: true,
+  dts: true,
+  platform: "node",
+  target: "node20",
+  bundle: true,
+  minify: false,
+  sourcemap: true,
+  external: ["@mcp-ts/sdk", "@modelcontextprotocol/client"]
+});

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+    testTimeout: 30_000
+  }
+});


### PR DESCRIPTION
## What is the type of this PR?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [x] Documentation
- [ ] Other

## Which area of the project does this PR affect?

- [ ] `server` (MCP client, handlers)
- [ ] `client` (React, Vue, SSE client)
- [ ] `adapters` (Vercel AI, LangChain, Mastra, AG-UI)
- [ ] `storage` (Redis, SQLite, File, Memory backends)
- [x] `docs` (Docusaurus documentation)
- [ ] `examples` (Example applications)
- [x] `ci` (GitHub workflows)
- [x] Other: new `@mcp-ts/cli` workspace

## Description of the change

Adds a publishable `@mcp-ts/cli` package with a `mcp-ts` binary for direct Streamable HTTP MCP exploration:

- `connect`: interactive REPL with `search`, `schema`, and explicit `call` commands
- `search`: BM25-backed ToolRouter results with per-schema token estimates
- `bench`: context estimates for the SDK `all`, `search`, and `groups` strategies
- `codegen`: dependency-free TypeScript wrappers and JSDoc generated from remote tool schemas

The package reuses the SDK ToolRouter, includes focused tests, updates root documentation, and extends the existing release workflow so versioned CLI manifests publish through the same provenance/tag/release path as the other npm packages.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Validation

- clean `npm ci` on Node 24
- `npm run build -w @mcp-ts/sdk`
- `npm run type-check -w @mcp-ts/cli`
- `npm test -w @mcp-ts/cli` (4 passed)
- root `npm run build`
- `actionlint .github/workflows/release.yml`
- `npm pack -w @mcp-ts/cli --dry-run --json`
- live read-only `connect`, `search`, `bench`, and `codegen` smoke against `https://mcp.grep.app`
- generated TypeScript passed `tsc --noEmit`

## Checklist

- [x] Code follows TypeScript strict mode guidelines
- [x] Tests added/updated
- [x] Documentation updated (user-facing change)
- [x] Build succeeds (`npm run build`)
- [x] Type check passes (`npm run type-check`)
- [ ] All repository tests pass (`npm test`)
- [x] Commit messages follow conventional format

## Related Issue

Closes #73
