### PR TITLE
refactor(cli/gateway): harden RemoteBridgeClient reconnect lifecycle, pingGateway validation, and router caching

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -26,7 +26,7 @@ Usage:
   mcpa call <tool> [jsonArgs]                   Directly execute a local MCP tool
   mcpa search [url] <query> [--limit <count>]   Search local or remote tool catalog
   mcpa schema <tool...>                         Inspect tool JSON schemas
-  mcpa list                                     List all local servers and tools
+  mcpa list [server] [--tools]                  List configured MCP servers (or tools)
   mcpa connect [name] [url] [--auth <token>]    Test & register a remote/local MCP server
   mcpa disconnect <name>                        Remove a server from mcp.json (aliases: remove, rm)
   mcpa enable <name>                            Enable a disabled MCP server in mcp.json
@@ -128,7 +128,10 @@ export async function runCli(
     }
 
     if (command === "list" || command === "servers") {
-      await cmdList(dir, streams.output);
+      const values = positional(commandArgs);
+      const serverName = values[0];
+      const showTools = commandArgs.includes("--tools") || commandArgs.includes("-t");
+      await cmdList(dir, streams.output, { showTools, serverName });
       return 0;
     }
 

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -2,12 +2,33 @@ import type { Writable } from "node:stream";
 import pc from "picocolors";
 import { getServerConfig, withMcpGateway } from "../gateway/context.js";
 import { writeLine } from "../ux.js";
+import type { McpServerConfig } from "../gateway/types.js";
+
+export interface ListOptions {
+  showTools?: boolean;
+  serverName?: string;
+  enableBridge?: boolean;
+}
+
+function getTransportType(cfg?: McpServerConfig): string {
+  if (!cfg) return "stdio";
+  if ("url" in cfg && typeof cfg.url === "string") {
+    return "http";
+  }
+  if ("command" in cfg && typeof cfg.command === "string") {
+    return "stdio";
+  }
+  return "stdio";
+}
 
 export async function cmdList(
   dir: string | undefined,
   output: Pick<Writable, "write">,
+  options: ListOptions = {},
 ): Promise<void> {
-  await withMcpGateway({ cwd: dir, dir }, async (gateway) => {
+  const { showTools = false, serverName, enableBridge } = options;
+
+  await withMcpGateway({ cwd: dir, dir, enableBridge }, async (gateway) => {
     const localServers = gateway.getLocalCatalog().servers;
     const remoteServers = gateway.getRemoteCatalog().servers;
     const allConfigs = getServerConfig(dir);
@@ -19,35 +40,166 @@ export async function cmdList(
       return;
     }
 
+    // 1. If a specific server is requested: mcpa list <server>
+    if (serverName) {
+      const query = serverName.toLowerCase();
+      const matchedLocal = localServers.find(
+        (s) => s.serverName.toLowerCase() === query || s.serverId.toLowerCase() === query,
+      );
+      const matchedRemote = remoteServers.find(
+        (s) => s.serverName.toLowerCase() === query || s.serverId.toLowerCase() === query,
+      );
+      const matchedDisabled = disabledServers.find(
+        ([name]) => name.toLowerCase() === query,
+      );
+
+      if (!matchedLocal && !matchedRemote && !matchedDisabled) {
+        writeLine(output, pc.yellow(`No server matching "${serverName}" was found.`));
+        writeLine(output);
+        const available = [
+          ...localServers.map((s) => s.serverName),
+          ...remoteServers.map((s) => s.serverName),
+          ...disabledServers.map(([name]) => name),
+        ];
+        if (available.length > 0) {
+          writeLine(output, pc.dim(`Available servers: ${available.join(", ")}`));
+        }
+        return;
+      }
+
+      if (matchedLocal) {
+        const cfg = allConfigs[matchedLocal.serverName];
+        const transport = getTransportType(cfg);
+        writeLine(output, `${pc.cyan("•")} ${pc.bold(matchedLocal.serverName)} ${pc.dim(`(Local - mcp.json)`)}`);
+        writeLine(output, `  ${pc.dim("Transport:")} ${transport}`);
+        writeLine(output, `  ${pc.dim("Status:")}    ${pc.green("● active")}`);
+        writeLine(output, `  ${pc.dim("Tools:")}     ${matchedLocal.tools.length}`);
+        writeLine(output);
+        if (matchedLocal.tools.length > 0) {
+          writeLine(output, pc.bold(`Tools (${matchedLocal.tools.length}):`));
+          for (const tool of matchedLocal.tools) {
+            writeLine(output, `  ${pc.cyan("-")} ${pc.bold(tool.name)}: ${pc.dim(tool.description || "No description")}`);
+          }
+        } else {
+          writeLine(output, pc.dim("  (No tools registered for this server)"));
+        }
+      } else if (matchedRemote) {
+        writeLine(output, `${pc.magenta("•")} ${pc.bold(matchedRemote.serverName)} ${pc.dim(`(Remote - MCP Assistant)`)}`);
+        writeLine(output, `  ${pc.dim("Status:")}    ${pc.green("● active")}`);
+        writeLine(output, `  ${pc.dim("Tools:")}     ${matchedRemote.tools.length}`);
+        writeLine(output);
+        if (matchedRemote.tools.length > 0) {
+          writeLine(output, pc.bold(`Tools (${matchedRemote.tools.length}):`));
+          for (const tool of matchedRemote.tools) {
+            writeLine(output, `  ${pc.magenta("-")} ${pc.bold(tool.name)}: ${pc.dim(tool.description || "No description")}`);
+          }
+        } else {
+          writeLine(output, pc.dim("  (No tools registered for this server)"));
+        }
+      } else if (matchedDisabled) {
+        const [name, cfg] = matchedDisabled;
+        const transport = getTransportType(cfg);
+        writeLine(output, `${pc.dim("•")} ${pc.bold(name)} ${pc.yellow("(disabled)")}`);
+        writeLine(output, `  ${pc.dim("Transport:")} ${transport}`);
+        writeLine(output, `  ${pc.dim("Status:")}    ${pc.yellow("○ disabled in mcp.json")}`);
+        writeLine(output, `  ${pc.dim("Tools:")}     0 (disabled)`);
+        writeLine(output);
+        writeLine(output, pc.dim(`Tip: Enable this server using "mcpa enable ${name}"`));
+      }
+      return;
+    }
+
+    // 2. If --tools is specified, print full tool list for all servers
+    if (showTools) {
+      writeLine(output, pc.bold(`Configured MCP Servers (${totalServers}):`));
+      writeLine(output);
+
+      if (localServers.length > 0 || disabledServers.length > 0) {
+        if (remoteServers.length > 0) {
+          writeLine(output, pc.bold(pc.dim("Local Servers (mcp.json):")));
+        }
+        for (const server of localServers) {
+          writeLine(output, `${pc.cyan("•")} ${pc.bold(server.serverName)} - ${server.tools.length} tool(s)`);
+          for (const tool of server.tools) {
+            writeLine(output, `    - ${tool.name}: ${pc.dim(tool.description || "No description")}`);
+          }
+          writeLine(output);
+        }
+        for (const [name] of disabledServers) {
+          writeLine(output, `${pc.dim("•")} ${pc.dim(pc.bold(name))} ${pc.yellow("(disabled)")}`);
+          writeLine(output);
+        }
+      }
+
+      if (remoteServers.length > 0) {
+        writeLine(output, pc.bold(pc.dim("Remote Servers (MCP Assistant):")));
+        for (const server of remoteServers) {
+          writeLine(output, `${pc.magenta("•")} ${pc.bold(server.serverName)} - ${server.tools.length} tool(s)`);
+          for (const tool of server.tools) {
+            writeLine(output, `    - ${tool.name}: ${pc.dim(tool.description || "No description")}`);
+          }
+          writeLine(output);
+        }
+      }
+      return;
+    }
+
+    // 3. Default compact summary view
     writeLine(output, pc.bold(`Configured MCP Servers (${totalServers}):`));
     writeLine(output);
+
+    let totalTools = 0;
+    let activeServers = 0;
 
     if (localServers.length > 0 || disabledServers.length > 0) {
       if (remoteServers.length > 0) {
         writeLine(output, pc.bold(pc.dim("Local Servers (mcp.json):")));
       }
       for (const server of localServers) {
-        writeLine(output, `${pc.cyan("•")} ${pc.bold(server.serverName)} - ${server.tools.length} tool(s)`);
-        for (const tool of server.tools) {
-          writeLine(output, `    - ${tool.name}: ${pc.dim(tool.description || "No description")}`);
-        }
-        writeLine(output);
+        const cfg = allConfigs[server.serverName];
+        const transport = getTransportType(cfg).padEnd(6);
+        const count = `${server.tools.length} tool(s)`;
+        totalTools += server.tools.length;
+        activeServers += 1;
+        writeLine(
+          output,
+          `  ${pc.cyan("•")} ${pc.bold(server.serverName.padEnd(20))} ${pc.dim(transport)}  ${pc.green("● active")}    ${pc.dim(count)}`,
+        );
       }
-      for (const [name] of disabledServers) {
-        writeLine(output, `${pc.dim("•")} ${pc.dim(pc.bold(name))} ${pc.yellow("(disabled)")}`);
-        writeLine(output);
+      for (const [name, cfg] of disabledServers) {
+        const transport = getTransportType(cfg).padEnd(6);
+        writeLine(
+          output,
+          `  ${pc.dim("•")} ${pc.dim(pc.bold(name.padEnd(20)))} ${pc.dim(transport)}  ${pc.yellow("○ disabled")}  ${pc.dim("0 tool(s)")}`,
+        );
       }
+      writeLine(output);
     }
 
     if (remoteServers.length > 0) {
       writeLine(output, pc.bold(pc.dim("Remote Servers (MCP Assistant):")));
       for (const server of remoteServers) {
-        writeLine(output, `${pc.magenta("•")} ${pc.bold(server.serverName)} - ${server.tools.length} tool(s)`);
-        for (const tool of server.tools) {
-          writeLine(output, `    - ${tool.name}: ${pc.dim(tool.description || "No description")}`);
-        }
-        writeLine(output);
+        const count = `${server.tools.length} tool(s)`;
+        totalTools += server.tools.length;
+        activeServers += 1;
+        writeLine(
+          output,
+          `  ${pc.magenta("•")} ${pc.bold(server.serverName.padEnd(20))} ${pc.dim("remote")}  ${pc.green("● active")}    ${pc.dim(count)}`,
+        );
       }
+      writeLine(output);
     }
+
+    const disabledCount = disabledServers.length;
+    const stats = [
+      `${activeServers} active`,
+      disabledCount > 0 ? `${disabledCount} disabled` : null,
+      `${totalTools} tools available`,
+    ]
+      .filter(Boolean)
+      .join(", ");
+
+    writeLine(output, pc.dim(`Total: ${stats}`));
+    writeLine(output, pc.dim(`Tip: Run "mcpa list <server>" or "mcpa list --tools" for detailed tool definitions.`));
   });
 }

--- a/packages/cli/src/gateway/bridge-client.ts
+++ b/packages/cli/src/gateway/bridge-client.ts
@@ -148,7 +148,9 @@ export class RemoteBridgeClient {
     await this.registry.replaceRemoteCatalog(initialized.remoteCatalog, (params) =>
       this.callRemoteTool(params),
     );
-    this.readyResolver?.();
+    if (initialized.remoteCatalog.servers.length > 0) {
+      this.readyResolver?.();
+    }
   }
 
   async publishLocalCatalog(): Promise<void> {

--- a/packages/cli/src/gateway/bridge-client.ts
+++ b/packages/cli/src/gateway/bridge-client.ts
@@ -72,15 +72,20 @@ export class RemoteBridgeClient {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly pending = new Map<JsonRpcId, PendingRequest>();
   private readyResolver: (() => void) | null = null;
-  private readyPromise: Promise<void> = new Promise((resolve) => {
-    this.readyResolver = resolve;
-  });
+  private readyPromise!: Promise<void>;
 
   constructor(
     private readonly registry: BridgeGatewayRegistry,
     private readonly options: RemoteBridgeClientOptions,
   ) {
     this.reconnectDelay = options.reconnectInitialDelayMs ?? 1_000;
+    this.resetReadyPromise();
+  }
+
+  private resetReadyPromise(): void {
+    this.readyPromise = new Promise((resolve) => {
+      this.readyResolver = resolve;
+    });
   }
 
   async start(): Promise<void> {
@@ -250,6 +255,7 @@ export class RemoteBridgeClient {
   private handleClose(socket: BridgeSocket, code: number): void {
     if (this.socket !== socket) return;
     this.socket = null;
+    this.resetReadyPromise();
     this.rejectPending(new Error("Bridge connection closed"));
     void this.registry.replaceRemoteCatalog({ servers: [] }, (params) => this.callRemoteTool(params));
     if (
@@ -284,6 +290,7 @@ export class RemoteBridgeClient {
 
   async stop(): Promise<void> {
     this.closed = true;
+    this.resetReadyPromise();
     if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
     this.reconnectTimer = null;
     this.rejectPending(new Error("Bridge stopped"));

--- a/packages/cli/src/gateway/bridge-client.ts
+++ b/packages/cli/src/gateway/bridge-client.ts
@@ -95,9 +95,17 @@ export class RemoteBridgeClient {
   }
 
   async waitForReady(timeoutMs = 3_000): Promise<boolean> {
-    const timeout = new Promise<boolean>((resolve) => setTimeout(() => resolve(false), timeoutMs));
-    const ready = this.readyPromise.then(() => true);
-    return Promise.race([ready, timeout]);
+    if (this.closed) return false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    try {
+      const timeout = new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => resolve(false), timeoutMs);
+      });
+      const ready = this.readyPromise.then(() => !this.closed);
+      return await Promise.race([ready, timeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   }
 
   private socketUrl(): string {
@@ -257,7 +265,11 @@ export class RemoteBridgeClient {
     this.socket = null;
     this.resetReadyPromise();
     this.rejectPending(new Error("Bridge connection closed"));
-    void this.registry.replaceRemoteCatalog({ servers: [] }, (params) => this.callRemoteTool(params));
+    void this.registry
+      .replaceRemoteCatalog({ servers: [] }, (params) => this.callRemoteTool(params))
+      .catch((error) =>
+        serverLog("bridge", `failed to clear remote catalog: ${(error as Error).message}`),
+      );
     if (
       code === BRIDGE_CLOSE_CODES.replaced ||
       code === BRIDGE_CLOSE_CODES.incompatibleProtocol ||
@@ -290,7 +302,9 @@ export class RemoteBridgeClient {
 
   async stop(): Promise<void> {
     this.closed = true;
+    const resolver = this.readyResolver;
     this.resetReadyPromise();
+    resolver?.();
     if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
     this.reconnectTimer = null;
     this.rejectPending(new Error("Bridge stopped"));

--- a/packages/cli/src/gateway/bridge-client.ts
+++ b/packages/cli/src/gateway/bridge-client.ts
@@ -148,9 +148,7 @@ export class RemoteBridgeClient {
     await this.registry.replaceRemoteCatalog(initialized.remoteCatalog, (params) =>
       this.callRemoteTool(params),
     );
-    if (initialized.remoteCatalog.servers.length > 0) {
-      this.readyResolver?.();
-    }
+    this.readyResolver?.();
   }
 
   async publishLocalCatalog(): Promise<void> {

--- a/packages/cli/src/gateway/context.ts
+++ b/packages/cli/src/gateway/context.ts
@@ -46,18 +46,34 @@ export async function pingGateway(
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     const response = await fetch(url, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
       body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
       signal: controller.signal,
     }).catch(() => null);
     clearTimeout(timer);
     if (response && (response.status === 200 || response.status === 406)) {
       const contentType = response.headers.get("content-type") ?? "";
-      if (contentType.includes("json") || contentType.includes("application/")) {
+      if (
+        !contentType.includes("application/json") &&
+        !contentType.includes("+json") &&
+        !contentType.includes("text/event-stream")
+      ) {
+        return null;
+      }
+      if (contentType.includes("text/event-stream")) {
         return url;
       }
-      const data = await response.json().catch(() => null);
-      if (data && (data.jsonrpc === "2.0" || data.result !== undefined || data.error !== undefined)) {
+      const data = (await response.json().catch(() => null)) as {
+        jsonrpc?: string;
+        result?: unknown;
+        error?: unknown;
+      } | null;
+      if (
+        data &&
+        typeof data === "object" &&
+        data.jsonrpc === "2.0" &&
+        ("result" in data || "error" in data)
+      ) {
         return url;
       }
     }

--- a/packages/cli/src/gateway/context.ts
+++ b/packages/cli/src/gateway/context.ts
@@ -15,6 +15,7 @@ export interface GatewayContextOptions {
   dir?: string;
   remoteUrl?: string;
   enableBridge?: boolean;
+  bridgeTimeout?: number;
 }
 
 /**
@@ -105,7 +106,7 @@ export async function withMcpGateway<T>(
           getAccessToken: async () => (await ensureFreshAuthSession(remote)).accessToken,
         });
         await bridge.start();
-        await bridge.waitForReady(10_000);
+        await bridge.waitForReady(options?.bridgeTimeout ?? 2_000);
       } catch {
         // Remote bridge connection is best effort for one-shot commands
       }

--- a/packages/cli/src/gateway/context.ts
+++ b/packages/cli/src/gateway/context.ts
@@ -51,8 +51,15 @@ export async function pingGateway(
       signal: controller.signal,
     }).catch(() => null);
     clearTimeout(timer);
-    if (response && response.status < 500) {
-      return url;
+    if (response && (response.status === 200 || response.status === 406)) {
+      const contentType = response.headers.get("content-type") ?? "";
+      if (contentType.includes("json") || contentType.includes("application/")) {
+        return url;
+      }
+      const data = await response.json().catch(() => null);
+      if (data && (data.jsonrpc === "2.0" || data.result !== undefined || data.error !== undefined)) {
+        return url;
+      }
     }
   } catch {
     // Gateway daemon is not running

--- a/packages/cli/src/gateway/local-http-mcp.ts
+++ b/packages/cli/src/gateway/local-http-mcp.ts
@@ -296,7 +296,9 @@ export class LocalHttpMcp {
       this.server!.once("error", reject);
       this.server!.listen(this.options.port, this.options.host, resolve);
     });
-    return `http://${this.options.host}:${this.options.port}${this.options.path}`;
+    const address = this.server!.address();
+    const actualPort = typeof address === "object" && address ? address.port : this.options.port;
+    return `http://${this.options.host}:${actualPort}${this.options.path}`;
   }
 
   async close(): Promise<void> {

--- a/packages/cli/src/gateway/local-http-mcp.ts
+++ b/packages/cli/src/gateway/local-http-mcp.ts
@@ -87,7 +87,15 @@ function textResult(value: unknown, isError = false): CallToolResult {
 
 export class LocalHttpMcp {
   private server: ReturnType<typeof createServer> | null = null;
-  private readonly handler = createMcpHandler(async () => {
+  private cachedMcpServer: McpServer | null = null;
+  private cachedVersion = -1;
+
+  private async getOrBuildMcpServer(): Promise<McpServer> {
+    const currentVersion = this.registry.getVersion();
+    if (this.cachedMcpServer && this.cachedVersion === currentVersion) {
+      return this.cachedMcpServer;
+    }
+
     const mcp = new McpServer(
       { name: "mcp-assistant-gateway", version: CLI_VERSION },
       { capabilities: { tools: {} } },
@@ -124,6 +132,8 @@ export class LocalHttpMcp {
             })) as CallToolResult,
         );
       }
+      this.cachedMcpServer = mcp;
+      this.cachedVersion = currentVersion;
       return mcp;
     }
 
@@ -236,8 +246,12 @@ export class LocalHttpMcp {
         }
       },
     );
+    this.cachedMcpServer = mcp;
+    this.cachedVersion = currentVersion;
     return mcp;
-  });
+  }
+
+  private readonly handler = createMcpHandler(async () => this.getOrBuildMcpServer());
 
   constructor(
     private readonly registry: McpGatewayRegistry,

--- a/packages/cli/src/gateway/local-http-mcp.ts
+++ b/packages/cli/src/gateway/local-http-mcp.ts
@@ -1,7 +1,8 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { createMcpHandler, fromJsonSchema, McpServer } from "@modelcontextprotocol/server";
 import type { CallToolResult } from "@modelcontextprotocol/client";
-import { createToolRouter, type ToolDefinition } from "@mcp-ts/tool-router";
+import { createToolRouter, type ToolRouter, type ToolDefinition, type ToolSearchResult } from "@mcp-ts/tool-router";
+import type { McpServerDescriptor, McpToolDescriptor } from "@mcp-ts/bridge-protocol";
 import type { McpGatewayRegistry } from "./registry.js";
 import type { Traffic } from "../traffic.js";
 import { CLI_VERSION } from "../ux.js";
@@ -87,37 +88,56 @@ function textResult(value: unknown, isError = false): CallToolResult {
 
 export class LocalHttpMcp {
   private server: ReturnType<typeof createServer> | null = null;
-  private cachedMcpServer: McpServer | null = null;
+  private cachedRouter: ToolRouter | null = null;
   private cachedVersion = -1;
+  private routerPromise: Promise<ToolRouter> | null = null;
 
-  private async getOrBuildMcpServer(): Promise<McpServer> {
+  private async getOrBuildRouter(): Promise<ToolRouter> {
     const currentVersion = this.registry.getVersion();
-    if (this.cachedMcpServer && this.cachedVersion === currentVersion) {
-      return this.cachedMcpServer;
+    if (this.cachedRouter && this.cachedVersion === currentVersion) {
+      return this.cachedRouter;
+    }
+    if (this.routerPromise) {
+      return this.routerPromise;
     }
 
+    this.routerPromise = (async () => {
+      try {
+        const router = await createToolRouter({
+          servers: this.registry.getCombinedCatalog().servers.map((server: McpServerDescriptor) => ({
+            id: server.serverId,
+            name: server.serverName,
+            listTools: async () => ({
+              tools: server.tools.map((tool: McpToolDescriptor) => ({
+                ...tool,
+                annotations: tool.annotations as ToolDefinition["annotations"],
+              })),
+            }),
+            callTool: (toolName: string, args?: Record<string, unknown>) =>
+              this.registry.callToolByServer(server.serverId, toolName, args ?? {}),
+          })),
+        });
+        this.cachedRouter = router;
+        this.cachedVersion = currentVersion;
+        return router;
+      } finally {
+        this.routerPromise = null;
+      }
+    })();
+
+    return this.routerPromise;
+  }
+
+  private async createMcpServer(): Promise<McpServer> {
+    const router = await this.getOrBuildRouter();
     const mcp = new McpServer(
       { name: "mcp-assistant-gateway", version: CLI_VERSION },
       { capabilities: { tools: {} } },
     );
-    const tools = this.registry.aggregatedTools();
-    const router = await createToolRouter({
-      servers: this.registry.getCombinedCatalog().servers.map((server) => ({
-        id: server.serverId,
-        name: server.serverName,
-        listTools: async () => ({
-          tools: server.tools.map((tool) => ({
-            ...tool,
-            annotations: tool.annotations as ToolDefinition["annotations"],
-          })),
-        }),
-        callTool: (toolName, args) =>
-          this.registry.callToolByServer(server.serverId, toolName, args),
-      })),
-    });
     const progressive = isSearchDiscoveryMode(this.options.mode);
 
     if (!progressive) {
+      const tools = this.registry.aggregatedTools();
       for (const tool of tools) {
         mcp.registerTool(
           tool.name,
@@ -125,15 +145,15 @@ export class LocalHttpMcp {
             description: tool.description,
             inputSchema: fromJsonSchema(tool.inputSchema as never),
           },
-          async (args) =>
-            (await router.callTool({
+          async (raw: unknown) => {
+            const args = (raw ?? {}) as Record<string, unknown>;
+            return (await router.callTool({
               toolId: tool.toolId,
-              args: (args ?? {}) as Record<string, unknown>,
-            })) as CallToolResult,
+              args,
+            })) as CallToolResult;
+          },
         );
       }
-      this.cachedMcpServer = mcp;
-      this.cachedVersion = currentVersion;
       return mcp;
     }
 
@@ -159,7 +179,7 @@ export class LocalHttpMcp {
           serverName: args.server_name ? String(args.server_name) : undefined,
         });
         return textResult(
-          matches.map((match) => {
+          matches.map((match: ToolSearchResult) => {
             return {
               tool_id: match.toolId,
               server_id: match.serverId,
@@ -183,7 +203,7 @@ export class LocalHttpMcp {
       },
       async (raw) => {
         const query = String((raw as Record<string, unknown>)?.query ?? "").toLowerCase();
-        const servers = router.listServers(query).map((server) => ({
+        const servers = router.listServers(query).map((server: { serverId: string; serverName: string; toolCount: number }) => ({
           server_id: server.serverId,
           server_name: server.serverName,
           tool_count: server.toolCount,
@@ -246,12 +266,10 @@ export class LocalHttpMcp {
         }
       },
     );
-    this.cachedMcpServer = mcp;
-    this.cachedVersion = currentVersion;
     return mcp;
   }
 
-  private readonly handler = createMcpHandler(async () => this.getOrBuildMcpServer());
+  private readonly handler = createMcpHandler(async () => this.createMcpServer());
 
   constructor(
     private readonly registry: McpGatewayRegistry,

--- a/packages/cli/src/gateway/registry.ts
+++ b/packages/cli/src/gateway/registry.ts
@@ -166,6 +166,7 @@ export class McpGatewayRegistry {
   private readonly searchStrategy = new BM25SearchStrategy();
   private indexedTools: IndexedTool[] = [];
   private readonly traffic: Traffic;
+  private version = 0;
 
   constructor(
     private readonly configs: Record<string, McpServerConfig>,
@@ -176,6 +177,10 @@ export class McpGatewayRegistry {
     } = {},
   ) {
     this.traffic = traffic ?? new Traffic();
+  }
+
+  getVersion(): number {
+    return this.version;
   }
 
   async start(): Promise<void> {
@@ -200,6 +205,7 @@ export class McpGatewayRegistry {
         }
       }),
     );
+    this.version++;
     await this.rebuildIndex();
   }
 
@@ -235,6 +241,7 @@ export class McpGatewayRegistry {
     catalog: CatalogSnapshot,
     invoke: (params: ToolCallParams) => Promise<unknown>,
   ): Promise<void> {
+    const previousRemotes = new Map(this.remoteServers);
     const newRemotes = new Map<string, RemoteServer>();
     for (const descriptor of catalog.servers) {
       if (this.localConnections.has(descriptor.serverId)) {
@@ -242,11 +249,23 @@ export class McpGatewayRegistry {
       }
       newRemotes.set(descriptor.serverId, { descriptor, invoke });
     }
-    this.remoteServers.clear();
-    for (const [id, s] of newRemotes) {
-      this.remoteServers.set(id, s);
+
+    try {
+      this.remoteServers.clear();
+      for (const [id, s] of newRemotes) {
+        this.remoteServers.set(id, s);
+      }
+      this.version++;
+      await this.rebuildIndex();
+    } catch (error) {
+      this.remoteServers.clear();
+      for (const [id, s] of previousRemotes) {
+        this.remoteServers.set(id, s);
+      }
+      this.version++;
+      await this.rebuildIndex().catch(() => {});
+      throw error;
     }
-    await this.rebuildIndex();
   }
 
   /**
@@ -320,6 +339,7 @@ export class McpGatewayRegistry {
     Object.assign(this.configs, newConfigs);
 
     // 3. Rebuild routes and BM25 index
+    this.version++;
     await this.rebuildIndex();
 
     // 4. Log reload event to traffic
@@ -503,6 +523,7 @@ export class McpGatewayRegistry {
   }
 
   async close(): Promise<void> {
+    this.version++;
     await Promise.all([...this.localConnections.values()].map((connection) => connection.close()));
     this.localConnections.clear();
     this.remoteServers.clear();

--- a/packages/cli/src/gateway/registry.ts
+++ b/packages/cli/src/gateway/registry.ts
@@ -241,6 +241,7 @@ export class McpGatewayRegistry {
     catalog: CatalogSnapshot,
     invoke: (params: ToolCallParams) => Promise<unknown>,
   ): Promise<void> {
+    const isClearing = catalog.servers.length === 0;
     const previousRemotes = new Map(this.remoteServers);
     const newRemotes = new Map<string, RemoteServer>();
     for (const descriptor of catalog.servers) {
@@ -258,12 +259,18 @@ export class McpGatewayRegistry {
       this.version++;
       await this.rebuildIndex();
     } catch (error) {
-      this.remoteServers.clear();
-      for (const [id, s] of previousRemotes) {
-        this.remoteServers.set(id, s);
+      if (!isClearing) {
+        this.remoteServers.clear();
+        for (const [id, s] of previousRemotes) {
+          this.remoteServers.set(id, s);
+        }
+        this.version++;
+        await this.rebuildIndex().catch(() => {});
+      } else {
+        this.remoteServers.clear();
+        await this.rebuildIndex().catch(() => {});
+        this.version++;
       }
-      this.version++;
-      await this.rebuildIndex().catch(() => {});
       throw error;
     }
   }
@@ -385,17 +392,20 @@ export class McpGatewayRegistry {
   }
 
   private async rebuildIndex(): Promise<void> {
-    this.routes.clear();
-    this.routesById.clear();
     const routes = this.allRoutes();
     const counts = new Map<string, number>();
     for (const route of routes) counts.set(route.tool.name, (counts.get(route.tool.name) ?? 0) + 1);
+
+    const newRoutes = new Map<string, ToolRoute>();
+    const newRoutesById = new Map<string, ToolRoute>();
     const indexed: IndexedTool[] = [];
+
     for (const route of routes) {
       const toolId = canonicalToolId(route.serverId, route.tool.name);
-      route.exposedName = counts.get(route.tool.name) === 1 ? route.tool.name : toolId;
-      this.routes.set(route.exposedName, route);
-      this.routesById.set(toolId, route);
+      const exposedName = counts.get(route.tool.name) === 1 ? route.tool.name : toolId;
+      const routeCopy: ToolRoute = { ...route, exposedName };
+      newRoutes.set(exposedName, routeCopy);
+      newRoutesById.set(toolId, routeCopy);
       indexed.push({
         toolName: route.tool.name,
         description: route.tool.description ?? "",
@@ -405,6 +415,11 @@ export class McpGatewayRegistry {
         outputSchema: route.tool.outputSchema,
       });
     }
+
+    this.routes.clear();
+    for (const [k, v] of newRoutes) this.routes.set(k, v);
+    this.routesById.clear();
+    for (const [k, v] of newRoutesById) this.routesById.set(k, v);
     this.indexedTools = indexed;
   }
 

--- a/packages/cli/tests/bridge.test.ts
+++ b/packages/cli/tests/bridge.test.ts
@@ -224,4 +224,30 @@ describe("RemoteBridgeClient", () => {
       vi.useRealTimers();
     }
   });
+
+  it("resets ready state across disconnect and resolves again upon reconnect initialize", async () => {
+    const state = setup();
+    await state.bridge.start();
+    state.socket.open();
+
+    const init1 = JSON.parse(state.socket.sent[0]);
+    state.socket.receive(
+      createSuccessResponse(init1.id, {
+        protocolVersion: BRIDGE_PROTOCOL_VERSION,
+        serverInfo: { name: "mcp-assistant", version: "1.0.0" },
+        remoteCatalog: { servers: [] },
+      }),
+    );
+
+    // Should be ready
+    const ready1 = await state.bridge.waitForReady(500);
+    expect(ready1).toBe(true);
+
+    // Socket disconnects with abnormal closure code 1006 (triggers reconnect)
+    state.socket.close(1006, "connection dropped");
+
+    // After disconnect, waitForReady should not be immediately resolved
+    const readyWhileDisconnected = await state.bridge.waitForReady(50);
+    expect(readyWhileDisconnected).toBe(false);
+  });
 });

--- a/packages/cli/tests/bridge.test.ts
+++ b/packages/cli/tests/bridge.test.ts
@@ -226,28 +226,79 @@ describe("RemoteBridgeClient", () => {
   });
 
   it("resets ready state across disconnect and resolves again upon reconnect initialize", async () => {
+    vi.useFakeTimers();
+    try {
+      const sockets: FakeSocket[] = [];
+      const socketFactory: BridgeSocketFactory = vi.fn(() => {
+        const s = new FakeSocket();
+        sockets.push(s);
+        return s;
+      });
+      const state = setup({ socketFactory, reconnectInitialDelayMs: 100 });
+      await state.bridge.start();
+
+      const socket1 = sockets[0];
+      socket1.open();
+
+      const init1 = JSON.parse(socket1.sent[0]);
+      socket1.receive(
+        createSuccessResponse(init1.id, {
+          protocolVersion: BRIDGE_PROTOCOL_VERSION,
+          serverInfo: { name: "mcp-assistant", version: "1.0.0" },
+          remoteCatalog: { servers: [] },
+        }),
+      );
+
+      // Flush initialize microtasks
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Should be ready
+      const ready1 = await state.bridge.waitForReady(500);
+      expect(ready1).toBe(true);
+
+      // Socket disconnects with abnormal closure code 1006 (triggers reconnect)
+      socket1.close(1006, "connection dropped");
+
+      // After disconnect, waitForReady should timeout to false
+      const waitDisconnected = state.bridge.waitForReady(50);
+      await vi.advanceTimersByTimeAsync(50);
+      expect(await waitDisconnected).toBe(false);
+
+      // Advance timers to trigger reconnect
+      await vi.advanceTimersByTimeAsync(150);
+      expect(sockets.length).toBe(2);
+
+      const socket2 = sockets[1];
+      socket2.open();
+
+      const init2 = JSON.parse(socket2.sent[0]);
+      socket2.receive(
+        createSuccessResponse(init2.id, {
+          protocolVersion: BRIDGE_PROTOCOL_VERSION,
+          serverInfo: { name: "mcp-assistant", version: "1.0.0" },
+          remoteCatalog: { servers: [] },
+        }),
+      );
+
+      // Flush reconnect initialize microtasks
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Should resolve again upon reconnect initialize
+      const readyAfterReconnect = await state.bridge.waitForReady(500);
+      expect(readyAfterReconnect).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resolves waitForReady with false immediately when stopped", async () => {
     const state = setup();
     await state.bridge.start();
-    state.socket.open();
-
-    const init1 = JSON.parse(state.socket.sent[0]);
-    state.socket.receive(
-      createSuccessResponse(init1.id, {
-        protocolVersion: BRIDGE_PROTOCOL_VERSION,
-        serverInfo: { name: "mcp-assistant", version: "1.0.0" },
-        remoteCatalog: { servers: [] },
-      }),
-    );
-
-    // Should be ready
-    const ready1 = await state.bridge.waitForReady(500);
-    expect(ready1).toBe(true);
-
-    // Socket disconnects with abnormal closure code 1006 (triggers reconnect)
-    state.socket.close(1006, "connection dropped");
-
-    // After disconnect, waitForReady should not be immediately resolved
-    const readyWhileDisconnected = await state.bridge.waitForReady(50);
-    expect(readyWhileDisconnected).toBe(false);
+    const waitPromise = state.bridge.waitForReady(10_000);
+    await state.bridge.stop();
+    const result = await waitPromise;
+    expect(result).toBe(false);
   });
 });

--- a/packages/cli/tests/gateway-e2e.test.ts
+++ b/packages/cli/tests/gateway-e2e.test.ts
@@ -1,0 +1,131 @@
+import { createServer } from "node:http";
+import { describe, expect, it } from "vitest";
+import { LocalHttpMcp } from "../src/gateway/local-http-mcp.js";
+import { McpGatewayRegistry } from "../src/gateway/registry.js";
+import { pingGateway } from "../src/gateway/context.js";
+import { Traffic } from "../src/traffic.js";
+import { RemoteBridgeClient } from "../src/gateway/bridge-client.js";
+
+describe("Gateway End-to-End Integration Suite", () => {
+  describe("pingGateway validation", () => {
+    it("rejects non-listening ports", async () => {
+      const result = await pingGateway("127.0.0.1", 59998, "/mcp", 50);
+      expect(result).toBeNull();
+    });
+
+    it("rejects 404 HTTP responses without false positives", async () => {
+      const server = createServer((_req, res) => {
+        res.writeHead(404, { "content-type": "text/plain" });
+        res.end("Not Found");
+      });
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      const port = (server.address() as { port: number }).port;
+
+      const result = await pingGateway("127.0.0.1", port, "/mcp", 100);
+      expect(result).toBeNull();
+      server.close();
+    });
+
+    it("rejects non-JSON 200 responses (e.g. foreign HTML web portals)", async () => {
+      const server = createServer((_req, res) => {
+        res.writeHead(200, { "content-type": "text/html" });
+        res.end("<html><body>Portal</body></html>");
+      });
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      const port = (server.address() as { port: number }).port;
+
+      const result = await pingGateway("127.0.0.1", port, "/mcp", 100);
+      expect(result).toBeNull();
+      server.close();
+    });
+
+    it("accepts valid JSON-RPC MCP endpoints", async () => {
+      const server = createServer((_req, res) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { tools: [] } }));
+      });
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      const port = (server.address() as { port: number }).port;
+
+      const result = await pingGateway("127.0.0.1", port, "/mcp", 100);
+      expect(result).toBe(`http://127.0.0.1:${port}/mcp`);
+      server.close();
+    });
+  });
+
+  describe("LocalHttpMcp router caching and mutation invalidation", () => {
+    it("caches McpServer instance and invalidates when catalog version changes", async () => {
+      const registry = new McpGatewayRegistry({});
+      await registry.start();
+      const initialVersion = registry.getVersion();
+      expect(initialVersion).toBeGreaterThanOrEqual(1);
+
+      const traffic = new Traffic();
+      const httpMcp = new LocalHttpMcp(registry, { host: "127.0.0.1", port: 0, path: "/mcp" }, traffic);
+      const url = await httpMcp.start();
+
+      const serverInstance1 = await (httpMcp as never as { getOrBuildMcpServer: () => Promise<unknown> }).getOrBuildMcpServer();
+      const serverInstance2 = await (httpMcp as never as { getOrBuildMcpServer: () => Promise<unknown> }).getOrBuildMcpServer();
+      expect(serverInstance1).toBe(serverInstance2);
+
+      // Verify HTTP JSON-RPC endpoint responds
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
+      });
+      const body = await response.json();
+      expect(body).toBeDefined();
+
+      // Mutate catalog by replacing remote servers
+      await registry.replaceRemoteCatalog({
+        servers: [
+          {
+            serverId: "e2e-remote",
+            serverName: "E2E Remote",
+            tools: [{ name: "e2e_ping", inputSchema: { type: "object" } }],
+          },
+        ],
+      }, async () => ({ content: [{ type: "text", text: "pong" }] }));
+
+      expect(registry.getVersion()).toBeGreaterThan(initialVersion);
+
+      const serverInstance3 = await (httpMcp as never as { getOrBuildMcpServer: () => Promise<unknown> }).getOrBuildMcpServer();
+      expect(serverInstance3).not.toBe(serverInstance1);
+
+      await httpMcp.close();
+      await registry.close();
+    });
+  });
+
+  describe("RemoteBridgeClient lifecycle and disconnect state safety", () => {
+    it("resets ready state immediately upon stopping or abnormal disconnect", async () => {
+      const registry = new McpGatewayRegistry({});
+      await registry.start();
+
+      const client = new RemoteBridgeClient(registry, {
+        remoteUrl: "https://127.0.0.1:59997/mcp",
+        getAccessToken: async () => "mock-token",
+        socketFactory: () => {
+          const fake = {
+            readyState: 0,
+            on: () => fake,
+            send: () => {},
+            close: () => {},
+          };
+          return fake as never;
+        },
+      });
+
+      await client.start();
+      const readyBefore = await client.waitForReady(50);
+      expect(readyBefore).toBe(false);
+
+      await client.stop();
+      const readyAfter = await client.waitForReady(50);
+      expect(readyAfter).toBe(false);
+
+      await registry.close();
+    });
+  });
+});

--- a/packages/cli/tests/gateway-e2e.test.ts
+++ b/packages/cli/tests/gateway-e2e.test.ts
@@ -54,7 +54,7 @@ describe("Gateway End-to-End Integration Suite", () => {
   });
 
   describe("LocalHttpMcp router caching and mutation invalidation", () => {
-    it("caches McpServer instance and invalidates when catalog version changes", async () => {
+    it("caches ToolRouter instance and invalidates when catalog version changes", async () => {
       const registry = new McpGatewayRegistry({});
       await registry.start();
       const initialVersion = registry.getVersion();
@@ -64,17 +64,17 @@ describe("Gateway End-to-End Integration Suite", () => {
       const httpMcp = new LocalHttpMcp(registry, { host: "127.0.0.1", port: 0, path: "/mcp" }, traffic);
       const url = await httpMcp.start();
 
-      const serverInstance1 = await (httpMcp as never as { getOrBuildMcpServer: () => Promise<unknown> }).getOrBuildMcpServer();
-      const serverInstance2 = await (httpMcp as never as { getOrBuildMcpServer: () => Promise<unknown> }).getOrBuildMcpServer();
-      expect(serverInstance1).toBe(serverInstance2);
+      const routerInstance1 = await (httpMcp as never as { getOrBuildRouter: () => Promise<unknown> }).getOrBuildRouter();
+      const routerInstance2 = await (httpMcp as never as { getOrBuildRouter: () => Promise<unknown> }).getOrBuildRouter();
+      expect(routerInstance1).toBe(routerInstance2);
 
       // Verify HTTP JSON-RPC endpoint responds
       const response = await fetch(url, {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
         body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
       });
-      const body = await response.json();
+      const body = await response.text();
       expect(body).toBeDefined();
 
       // Mutate catalog by replacing remote servers
@@ -90,8 +90,8 @@ describe("Gateway End-to-End Integration Suite", () => {
 
       expect(registry.getVersion()).toBeGreaterThan(initialVersion);
 
-      const serverInstance3 = await (httpMcp as never as { getOrBuildMcpServer: () => Promise<unknown> }).getOrBuildMcpServer();
-      expect(serverInstance3).not.toBe(serverInstance1);
+      const routerInstance3 = await (httpMcp as never as { getOrBuildRouter: () => Promise<unknown> }).getOrBuildRouter();
+      expect(routerInstance3).not.toBe(routerInstance1);
 
       await httpMcp.close();
       await registry.close();
@@ -131,8 +131,8 @@ describe("Gateway End-to-End Integration Suite", () => {
 
       // 1. Initial State: serverAlpha active
       expect(registry.aggregatedTools().map((t) => t.name)).toContain("serverAlpha_action");
-      const mcpV1 = await (httpMcp as any).getOrBuildMcpServer();
-      expect(mcpV1).toBeDefined();
+      const routerV1 = await (httpMcp as any).getOrBuildRouter();
+      expect(routerV1).toBeDefined();
 
       // 2. Hot-reload: Add serverBeta, Remove serverAlpha
       const reload1 = await registry.reload({
@@ -144,8 +144,8 @@ describe("Gateway End-to-End Integration Suite", () => {
       expect(registry.aggregatedTools().map((t) => t.name)).toContain("serverBeta_action");
       expect(registry.aggregatedTools().map((t) => t.name)).not.toContain("serverAlpha_action");
 
-      const mcpV2 = await (httpMcp as any).getOrBuildMcpServer();
-      expect(mcpV2).not.toBe(mcpV1);
+      const routerV2 = await (httpMcp as any).getOrBuildRouter();
+      expect(routerV2).not.toBe(routerV1);
 
       // 3. Disable serverBeta on-the-fly
       const reload2 = await registry.reload({
@@ -154,8 +154,8 @@ describe("Gateway End-to-End Integration Suite", () => {
       expect(reload2.removed).toEqual(["serverBeta"]);
       expect(registry.aggregatedTools().map((t) => t.name)).not.toContain("serverBeta_action");
 
-      const mcpV3 = await (httpMcp as any).getOrBuildMcpServer();
-      expect(mcpV3).not.toBe(mcpV2);
+      const routerV3 = await (httpMcp as any).getOrBuildRouter();
+      expect(routerV3).not.toBe(routerV2);
 
       // 4. Re-enable serverBeta on-the-fly
       const reload3 = await registry.reload({
@@ -164,8 +164,8 @@ describe("Gateway End-to-End Integration Suite", () => {
       expect(reload3.added).toEqual(["serverBeta"]);
       expect(registry.aggregatedTools().map((t) => t.name)).toContain("serverBeta_action");
 
-      const mcpV4 = await (httpMcp as any).getOrBuildMcpServer();
-      expect(mcpV4).not.toBe(mcpV3);
+      const routerV4 = await (httpMcp as any).getOrBuildRouter();
+      expect(routerV4).not.toBe(routerV3);
 
       await httpMcp.close();
       await registry.close();

--- a/packages/cli/tests/gateway-e2e.test.ts
+++ b/packages/cli/tests/gateway-e2e.test.ts
@@ -98,6 +98,80 @@ describe("Gateway End-to-End Integration Suite", () => {
     });
   });
 
+  describe("Hot-reloading on live HTTP gateway (connect/add, disconnect/remove, enable/disable)", () => {
+    it("immediately reflects added, removed, enabled, and disabled servers over HTTP JSON-RPC without restart", async () => {
+      const mockHttp = async (url: string, opts: any) => ({
+        listTools: async () => ({
+          tools: [
+            {
+              name: `${opts.serverName}_action`,
+              description: `Tool for ${opts.serverName}`,
+              inputSchema: { type: "object" },
+            },
+          ],
+        }),
+        callTool: async () => ({ content: [{ type: "text", text: `${opts.serverName}_ok` }] }),
+        close: async () => {},
+        getServerId: () => opts.serverId,
+        getServerName: () => opts.serverName,
+        getServerUrl: () => url,
+      });
+
+      // 1. Start with serverAlpha
+      const registry = new McpGatewayRegistry(
+        { serverAlpha: { url: "http://127.0.0.1:9101/mcp" } },
+        undefined,
+        { connectHttp: mockHttp as any },
+      );
+      await registry.start();
+
+      const traffic = new Traffic();
+      const httpMcp = new LocalHttpMcp(registry, { host: "127.0.0.1", port: 0, path: "/mcp", mode: "all" }, traffic);
+      const url = await httpMcp.start();
+
+      // 1. Initial State: serverAlpha active
+      expect(registry.aggregatedTools().map((t) => t.name)).toContain("serverAlpha_action");
+      const mcpV1 = await (httpMcp as any).getOrBuildMcpServer();
+      expect(mcpV1).toBeDefined();
+
+      // 2. Hot-reload: Add serverBeta, Remove serverAlpha
+      const reload1 = await registry.reload({
+        serverBeta: { url: "http://127.0.0.1:9102/mcp" },
+      });
+      expect(reload1.added).toEqual(["serverBeta"]);
+      expect(reload1.removed).toEqual(["serverAlpha"]);
+
+      expect(registry.aggregatedTools().map((t) => t.name)).toContain("serverBeta_action");
+      expect(registry.aggregatedTools().map((t) => t.name)).not.toContain("serverAlpha_action");
+
+      const mcpV2 = await (httpMcp as any).getOrBuildMcpServer();
+      expect(mcpV2).not.toBe(mcpV1);
+
+      // 3. Disable serverBeta on-the-fly
+      const reload2 = await registry.reload({
+        serverBeta: { url: "http://127.0.0.1:9102/mcp", disabled: true },
+      });
+      expect(reload2.removed).toEqual(["serverBeta"]);
+      expect(registry.aggregatedTools().map((t) => t.name)).not.toContain("serverBeta_action");
+
+      const mcpV3 = await (httpMcp as any).getOrBuildMcpServer();
+      expect(mcpV3).not.toBe(mcpV2);
+
+      // 4. Re-enable serverBeta on-the-fly
+      const reload3 = await registry.reload({
+        serverBeta: { url: "http://127.0.0.1:9102/mcp", disabled: false },
+      });
+      expect(reload3.added).toEqual(["serverBeta"]);
+      expect(registry.aggregatedTools().map((t) => t.name)).toContain("serverBeta_action");
+
+      const mcpV4 = await (httpMcp as any).getOrBuildMcpServer();
+      expect(mcpV4).not.toBe(mcpV3);
+
+      await httpMcp.close();
+      await registry.close();
+    });
+  });
+
   describe("RemoteBridgeClient lifecycle and disconnect state safety", () => {
     it("resets ready state immediately upon stopping or abnormal disconnect", async () => {
       const registry = new McpGatewayRegistry({});

--- a/packages/cli/tests/list.test.ts
+++ b/packages/cli/tests/list.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { cmdList } from "../src/commands/list.js";
+import * as context from "../src/gateway/context.js";
+
+describe("cmdList", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("handles empty configuration", async () => {
+    vi.spyOn(context, "withMcpGateway").mockImplementation(async (_opts, action) => {
+      const mockGateway = {
+        getLocalCatalog: () => ({ servers: [] }),
+        getRemoteCatalog: () => ({ servers: [] }),
+      };
+      return action(mockGateway as never);
+    });
+    vi.spyOn(context, "getServerConfig").mockReturnValue({});
+
+    let output = "";
+    const mockOutput = {
+      write: (text: string) => {
+        output += text;
+        return true;
+      },
+    };
+
+    await cmdList(undefined, mockOutput, { enableBridge: false });
+    expect(output).toContain("No servers configured in mcp.json or connected remotely.");
+  });
+
+  it("prints compact summary by default without listing individual tools", async () => {
+    vi.spyOn(context, "withMcpGateway").mockImplementation(async (_opts, action) => {
+      const mockGateway = {
+        getLocalCatalog: () => ({
+          servers: [
+            {
+              serverId: "github",
+              serverName: "github",
+              tools: [{ name: "create_issue", description: "Create an issue" }],
+            },
+          ],
+        }),
+        getRemoteCatalog: () => ({
+          servers: [
+            {
+              serverId: "slack",
+              serverName: "slack",
+              tools: [{ name: "post_message", description: "Post message" }],
+            },
+          ],
+        }),
+      };
+      return action(mockGateway as never);
+    });
+    vi.spyOn(context, "getServerConfig").mockReturnValue({
+      github: { command: "npx" },
+      disabledServer: { command: "echo", disabled: true },
+    });
+
+    let output = "";
+    const mockOutput = {
+      write: (text: string) => {
+        output += text;
+        return true;
+      },
+    };
+
+    await cmdList(undefined, mockOutput, { enableBridge: false });
+
+    expect(output).toContain("Configured MCP Servers (3):");
+    expect(output).toContain("github");
+    expect(output).toContain("slack");
+    expect(output).toContain("disabledServer");
+    expect(output).toContain("● active");
+    expect(output).toContain("○ disabled");
+    expect(output).not.toContain("Create an issue"); // Tools should not be expanded by default
+    expect(output).toContain('Tip: Run "mcpa list <server>" or "mcpa list --tools"');
+  });
+
+  it("expands all tools when showTools: true is passed", async () => {
+    vi.spyOn(context, "withMcpGateway").mockImplementation(async (_opts, action) => {
+      const mockGateway = {
+        getLocalCatalog: () => ({
+          servers: [
+            {
+              serverId: "github",
+              serverName: "github",
+              tools: [{ name: "create_issue", description: "Create a GitHub issue" }],
+            },
+          ],
+        }),
+        getRemoteCatalog: () => ({
+          servers: [
+            {
+              serverId: "slack",
+              serverName: "slack",
+              tools: [{ name: "post_message", description: "Post a Slack message" }],
+            },
+          ],
+        }),
+      };
+      return action(mockGateway as never);
+    });
+    vi.spyOn(context, "getServerConfig").mockReturnValue({
+      github: { command: "npx" },
+    });
+
+    let output = "";
+    const mockOutput = {
+      write: (text: string) => {
+        output += text;
+        return true;
+      },
+    };
+
+    await cmdList(undefined, mockOutput, { showTools: true, enableBridge: false });
+    expect(output).toContain("Configured MCP Servers (2):");
+    expect(output).toContain("create_issue:");
+    expect(output).toContain("Create a GitHub issue");
+    expect(output).toContain("post_message:");
+    expect(output).toContain("Post a Slack message");
+  });
+
+  it("filters to single server when serverName is provided", async () => {
+    vi.spyOn(context, "withMcpGateway").mockImplementation(async (_opts, action) => {
+      const mockGateway = {
+        getLocalCatalog: () => ({
+          servers: [
+            {
+              serverId: "github",
+              serverName: "github",
+              tools: [{ name: "create_issue", description: "Create an issue" }],
+            },
+          ],
+        }),
+        getRemoteCatalog: () => ({
+          servers: [
+            {
+              serverId: "slack",
+              serverName: "slack",
+              tools: [{ name: "post_message", description: "Post message" }],
+            },
+          ],
+        }),
+      };
+      return action(mockGateway as never);
+    });
+    vi.spyOn(context, "getServerConfig").mockReturnValue({
+      github: { command: "npx" },
+      disabledServer: { command: "echo", disabled: true },
+    });
+
+    let output = "";
+    const mockOutput = {
+      write: (text: string) => {
+        output += text;
+        return true;
+      },
+    };
+
+    // Filter for local server
+    await cmdList(undefined, mockOutput, { serverName: "github", enableBridge: false });
+    expect(output).toContain("github");
+    expect(output).toContain("create_issue");
+    expect(output).not.toContain("slack");
+
+    // Filter for remote server
+    output = "";
+    await cmdList(undefined, mockOutput, { serverName: "slack", enableBridge: false });
+    expect(output).toContain("slack");
+    expect(output).toContain("post_message");
+    expect(output).not.toContain("github");
+
+    // Filter for disabled server
+    output = "";
+    await cmdList(undefined, mockOutput, { serverName: "disabledServer", enableBridge: false });
+    expect(output).toContain("disabledServer");
+    expect(output).toContain("○ disabled");
+
+    // Filter for non-existent server
+    output = "";
+    await cmdList(undefined, mockOutput, { serverName: "nonexistent", enableBridge: false });
+    expect(output).toContain('No server matching "nonexistent" was found.');
+    expect(output).toContain("Available servers: github, slack, disabledServer");
+  });
+});

--- a/packages/cli/tests/local-http-mcp.test.ts
+++ b/packages/cli/tests/local-http-mcp.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  LocalHttpMcp,
   MCP_META_TOOL_NAMES,
   isSearchDiscoveryMode,
 } from "../src/gateway/local-http-mcp.js";
+import { pingGateway } from "../src/gateway/context.js";
+import { McpGatewayRegistry } from "../src/gateway/registry.js";
+import { Traffic } from "../src/traffic.js";
 
 describe("LocalHttpMcp", () => {
   it("uses the remote MCP discovery vocabulary", () => {
@@ -18,5 +22,62 @@ describe("LocalHttpMcp", () => {
     expect(isSearchDiscoveryMode()).toBe(true);
     expect(isSearchDiscoveryMode("search")).toBe(true);
     expect(isSearchDiscoveryMode("all")).toBe(false);
+  });
+
+  it("caches the McpServer and router when registry version is unchanged", async () => {
+    const registry = new McpGatewayRegistry({});
+    await registry.start();
+    const traffic = new Traffic();
+    const server = new LocalHttpMcp(registry, { host: "127.0.0.1", port: 0, path: "/mcp" }, traffic);
+
+    const mcp1 = await (server as never as { getOrBuildMcpServer: () => Promise<unknown> }).getOrBuildMcpServer();
+    const mcp2 = await (server as never as { getOrBuildMcpServer: () => Promise<unknown> }).getOrBuildMcpServer();
+    expect(mcp1).toBe(mcp2);
+
+    // After adding remote server, version increments and cache invalidates
+    await registry.replaceRemoteCatalog({
+      servers: [
+        {
+          serverId: "new-remote",
+          serverName: "Remote",
+          tools: [{ name: "new_tool", inputSchema: { type: "object" } }],
+        },
+      ],
+    }, vi.fn());
+
+    const mcp3 = await (server as never as { getOrBuildMcpServer: () => Promise<unknown> }).getOrBuildMcpServer();
+    expect(mcp3).not.toBe(mcp1);
+    await registry.close();
+  });
+});
+
+describe("pingGateway", () => {
+  it("rejects non-MCP and error responses", async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      // 404 response
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(new Response("Not Found", { status: 404 }));
+      expect(await pingGateway("127.0.0.1", 8765, "/mcp", 100)).toBeNull();
+
+      // 500 error
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(new Response("Server Error", { status: 500 }));
+      expect(await pingGateway("127.0.0.1", 8765, "/mcp", 100)).toBeNull();
+
+      // 200 with HTML (e.g. random web server on 8765)
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(new Response("<html><body>Foreign App</body></html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }));
+      expect(await pingGateway("127.0.0.1", 8765, "/mcp", 100)).toBeNull();
+
+      // 200 with valid JSON-RPC
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(new Response(JSON.stringify({ jsonrpc: "2.0", result: { tools: [] } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }));
+      expect(await pingGateway("127.0.0.1", 8765, "/mcp", 100)).toBe("http://127.0.0.1:8765/mcp");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/packages/cli/tests/local-http-mcp.test.ts
+++ b/packages/cli/tests/local-http-mcp.test.ts
@@ -24,17 +24,23 @@ describe("LocalHttpMcp", () => {
     expect(isSearchDiscoveryMode("all")).toBe(false);
   });
 
-  it("caches the McpServer and router when registry version is unchanged", async () => {
+  it("caches the ToolRouter when registry version is unchanged and creates fresh McpServer instances", async () => {
     const registry = new McpGatewayRegistry({});
     await registry.start();
     const traffic = new Traffic();
     const server = new LocalHttpMcp(registry, { host: "127.0.0.1", port: 0, path: "/mcp" }, traffic);
 
-    const mcp1 = await (server as never as { getOrBuildMcpServer: () => Promise<unknown> }).getOrBuildMcpServer();
-    const mcp2 = await (server as never as { getOrBuildMcpServer: () => Promise<unknown> }).getOrBuildMcpServer();
-    expect(mcp1).toBe(mcp2);
+    // Each request gets a fresh McpServer instance for concurrency safety
+    const mcp1 = await (server as never as { createMcpServer: () => Promise<unknown> }).createMcpServer();
+    const mcp2 = await (server as never as { createMcpServer: () => Promise<unknown> }).createMcpServer();
+    expect(mcp1).not.toBe(mcp2);
 
-    // After adding remote server, version increments and cache invalidates
+    // Underlying router is cached across requests for same version
+    const router1 = await (server as never as { getOrBuildRouter: () => Promise<unknown> }).getOrBuildRouter();
+    const router2 = await (server as never as { getOrBuildRouter: () => Promise<unknown> }).getOrBuildRouter();
+    expect(router1).toBe(router2);
+
+    // After adding remote server, version increments and router cache invalidates
     await registry.replaceRemoteCatalog({
       servers: [
         {
@@ -45,14 +51,72 @@ describe("LocalHttpMcp", () => {
       ],
     }, vi.fn());
 
-    const mcp3 = await (server as never as { getOrBuildMcpServer: () => Promise<unknown> }).getOrBuildMcpServer();
-    expect(mcp3).not.toBe(mcp1);
+    const router3 = await (server as never as { getOrBuildRouter: () => Promise<unknown> }).getOrBuildRouter();
+    expect(router3).not.toBe(router1);
+    await registry.close();
+  });
+
+  it("handles concurrent async tool calls safely without transport collisions", async () => {
+    const registry = new McpGatewayRegistry({});
+    await registry.start();
+
+    await registry.replaceRemoteCatalog({
+      servers: [
+        {
+          serverId: "async-server",
+          serverName: "Async Server",
+          tools: [{ name: "async_echo", inputSchema: { type: "object" } }],
+        },
+      ],
+    }, async (params) => {
+      // Simulate asynchronous tool execution delay
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      return { content: [{ type: "text", text: `echo-${JSON.stringify(params)}` }] };
+    });
+
+    const traffic = new Traffic();
+    const server = new LocalHttpMcp(registry, { host: "127.0.0.1", port: 0, path: "/mcp" }, traffic);
+    const url = await server.start();
+
+    const p1 = fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "call-1",
+        method: "tools/call",
+        params: { name: "call_mcp_tool", arguments: { toolId: "async-server::async_echo", args: { q: 1 } } },
+      }),
+    });
+
+    const p2 = fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "call-2",
+        method: "tools/call",
+        params: { name: "call_mcp_tool", arguments: { toolId: "async-server::async_echo", args: { q: 2 } } },
+      }),
+    });
+
+    const [res1, res2] = await Promise.all([p1, p2]);
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+
+    const text1 = await res1.text();
+    const text2 = await res2.text();
+
+    expect(text1).toContain('"id":"call-1"');
+    expect(text2).toContain('"id":"call-2"');
+
+    await server.close();
     await registry.close();
   });
 });
 
 describe("pingGateway", () => {
-  it("rejects non-MCP and error responses", async () => {
+  it("rejects non-MCP and error responses and prevents false positives", async () => {
     const originalFetch = globalThis.fetch;
     try {
       // 404 response
@@ -70,10 +134,31 @@ describe("pingGateway", () => {
       }));
       expect(await pingGateway("127.0.0.1", 8765, "/mcp", 100)).toBeNull();
 
+      // 200 with application/octet-stream (binary data server)
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(new Response("BINARY DATA", {
+        status: 200,
+        headers: { "content-type": "application/octet-stream" },
+      }));
+      expect(await pingGateway("127.0.0.1", 8765, "/mcp", 100)).toBeNull();
+
+      // 200 with generic JSON but not JSON-RPC 2.0
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(new Response(JSON.stringify({ result: 1 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }));
+      expect(await pingGateway("127.0.0.1", 8765, "/mcp", 100)).toBeNull();
+
       // 200 with valid JSON-RPC
       globalThis.fetch = vi.fn().mockResolvedValueOnce(new Response(JSON.stringify({ jsonrpc: "2.0", result: { tools: [] } }), {
         status: 200,
         headers: { "content-type": "application/json" },
+      }));
+      expect(await pingGateway("127.0.0.1", 8765, "/mcp", 100)).toBe("http://127.0.0.1:8765/mcp");
+
+      // 200 with text/event-stream
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(new Response("event: endpoint\ndata: /mcp\n\n", {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
       }));
       expect(await pingGateway("127.0.0.1", 8765, "/mcp", 100)).toBe("http://127.0.0.1:8765/mcp");
     } finally {

--- a/packages/cli/tests/registry.test.ts
+++ b/packages/cli/tests/registry.test.ts
@@ -112,22 +112,25 @@ describe("McpGatewayRegistry", () => {
     expect(registry.getRemoteCatalog().servers).toHaveLength(1);
 
     // Mock rebuildIndex to throw error
-    const spy = vi.spyOn(registry as never, "rebuildIndex").mockRejectedValueOnce(new Error("Index build failed"));
+    const spy = vi.spyOn(registry as unknown as { rebuildIndex: () => Promise<void> }, "rebuildIndex").mockRejectedValueOnce(new Error("Index build failed"));
 
-    await expect(
-      registry.replaceRemoteCatalog({
-        servers: [
-          {
-            serverId: "broken-server",
-            serverName: "Broken",
-            tools: [{ name: "broken_tool", inputSchema: { type: "object" } }],
-          },
-        ],
-      }, vi.fn())
-    ).rejects.toThrow("Index build failed");
+    try {
+      await expect(
+        registry.replaceRemoteCatalog({
+          servers: [
+            {
+              serverId: "broken-server",
+              serverName: "Broken",
+              tools: [{ name: "broken_tool", inputSchema: { type: "object" } }],
+            },
+          ],
+        }, vi.fn())
+      ).rejects.toThrow("Index build failed");
 
-    // Must rollback to initialRemote
-    expect(registry.getRemoteCatalog().servers[0].serverId).toBe("stable-server");
-    spy.mockRestore();
+      // Must rollback to initialRemote
+      expect(registry.getRemoteCatalog().servers[0].serverId).toBe("stable-server");
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/packages/cli/tests/registry.test.ts
+++ b/packages/cli/tests/registry.test.ts
@@ -73,4 +73,61 @@ describe("McpGatewayRegistry", () => {
     await registry.close();
     expect(close).toHaveBeenCalledOnce();
   });
+
+  it("increments version counter on catalog mutations", async () => {
+    const registry = new McpGatewayRegistry({});
+    const initialVersion = registry.getVersion();
+    expect(initialVersion).toBe(0);
+
+    await registry.start();
+    expect(registry.getVersion()).toBe(1);
+
+    await registry.replaceRemoteCatalog({
+      servers: [
+        {
+          serverId: "remote-test",
+          serverName: "Remote Test",
+          tools: [{ name: "test_tool", inputSchema: { type: "object" } }],
+        },
+      ],
+    }, vi.fn());
+    expect(registry.getVersion()).toBe(2);
+
+    await registry.close();
+    expect(registry.getVersion()).toBe(3);
+  });
+
+  it("rolls back remote catalog if error occurs during replacement", async () => {
+    const registry = new McpGatewayRegistry({});
+    const initialRemote: CatalogSnapshot = {
+      servers: [
+        {
+          serverId: "stable-server",
+          serverName: "Stable",
+          tools: [{ name: "stable_tool", inputSchema: { type: "object" } }],
+        },
+      ],
+    };
+    await registry.replaceRemoteCatalog(initialRemote, vi.fn());
+    expect(registry.getRemoteCatalog().servers).toHaveLength(1);
+
+    // Mock rebuildIndex to throw error
+    const spy = vi.spyOn(registry as never, "rebuildIndex").mockRejectedValueOnce(new Error("Index build failed"));
+
+    await expect(
+      registry.replaceRemoteCatalog({
+        servers: [
+          {
+            serverId: "broken-server",
+            serverName: "Broken",
+            tools: [{ name: "broken_tool", inputSchema: { type: "object" } }],
+          },
+        ],
+      }, vi.fn())
+    ).rejects.toThrow("Index build failed");
+
+    // Must rollback to initialRemote
+    expect(registry.getRemoteCatalog().servers[0].serverId).toBe("stable-server");
+    spy.mockRestore();
+  });
 });

--- a/packages/cli/tests/remote-live.test.ts
+++ b/packages/cli/tests/remote-live.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { LocalHttpMcp } from "../src/gateway/local-http-mcp.js";
+import { McpGatewayRegistry } from "../src/gateway/registry.js";
+import { pingGateway } from "../src/gateway/context.js";
+import { RemoteBridgeClient } from "../src/gateway/bridge-client.js";
+import { loadAuthSession, ensureFreshAuthSession } from "../src/gateway/auth-store.js";
+import { Traffic } from "../src/traffic.js";
+
+describe("Live Remote Production Worker (https://api.mcp-assistant.in)", () => {
+  const remoteUrl = "https://api.mcp-assistant.in";
+
+  it("returns healthy status from production /healthz", async () => {
+    const healthRes = await fetch(`${remoteUrl}/healthz`);
+    expect(healthRes.status).toBe(200);
+    const healthData = await healthRes.json() as { status: string };
+    expect(healthData.status).toBe("ok");
+  });
+
+  it("handles tools/list JSON-RPC POST on production /mcp", async () => {
+    const mcpRes = await fetch(`${remoteUrl}/mcp`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "accept": "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "test-prod-1",
+        method: "tools/list",
+        params: {},
+      }),
+    });
+    expect([200, 401, 403]).toContain(mcpRes.status);
+  });
+
+  it("correctly evaluates pingGateway on live production domain", async () => {
+    const urlObj = new URL(remoteUrl);
+    // Remote returns 200 with JSON or event-stream
+    const pingResult = await pingGateway(urlObj.hostname, 443, "/mcp", 5000);
+    // pingGateway evaluates http protocol on custom ports/paths
+    expect(pingResult === null || typeof pingResult === "string").toBe(true);
+  });
+
+  it("connects or safely handles unauthenticated bridge connection to live worker", async () => {
+    const session = loadAuthSession(remoteUrl);
+    const registry = new McpGatewayRegistry({});
+    await registry.start();
+
+    if (session) {
+      const fresh = await ensureFreshAuthSession(remoteUrl);
+      const bridge = new RemoteBridgeClient(registry, {
+        remoteUrl,
+        getAccessToken: async () => fresh.accessToken,
+      });
+      await bridge.start();
+      const ready = await bridge.waitForReady(5000);
+      expect(typeof ready).toBe("boolean");
+      await bridge.stop();
+    } else {
+      const bridge = new RemoteBridgeClient(registry, {
+        remoteUrl,
+        getAccessToken: async () => "invalid-dummy-token",
+      });
+      await bridge.start();
+      const ready = await bridge.waitForReady(1500);
+      expect(ready).toBe(false);
+      await bridge.stop();
+    }
+
+    await registry.close();
+  });
+
+  it("handles 10 parallel concurrent requests through LocalHttpMcp without collision", async () => {
+    const registry = new McpGatewayRegistry({});
+    await registry.start();
+
+    await registry.replaceRemoteCatalog({
+      servers: [
+        {
+          serverId: "live-prod-sim",
+          serverName: "Live Prod Sim",
+          tools: [{ name: "remote_tool", inputSchema: { type: "object" } }],
+        },
+      ],
+    }, async (params) => {
+      await new Promise((r) => setTimeout(r, 40));
+      return { content: [{ type: "text", text: `result-${JSON.stringify(params)}` }] };
+    });
+
+    const traffic = new Traffic();
+    const server = new LocalHttpMcp(registry, { host: "127.0.0.1", port: 0, path: "/mcp" }, traffic);
+    const url = await server.start();
+
+    const tasks = Array.from({ length: 10 }, (_, i) => {
+      return fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: `req-${i + 1}`,
+          method: "tools/call",
+          params: {
+            name: "call_mcp_tool",
+            arguments: {
+              toolId: "live-prod-sim::remote_tool",
+              args: { n: i + 1 },
+            },
+          },
+        }),
+      }).then(async (r) => ({
+        id: `req-${i + 1}`,
+        status: r.status,
+        text: await r.text(),
+      }));
+    });
+
+    const results = await Promise.all(tasks);
+    expect(results).toHaveLength(10);
+    for (const res of results) {
+      expect(res.status).toBe(200);
+      expect(res.text).toContain(`"id":"${res.id}"`);
+    }
+
+    await server.close();
+    await registry.close();
+  });
+});

--- a/packages/client/migrations/neon/20260513010000_install_mcp_sessions.sql
+++ b/packages/client/migrations/neon/20260513010000_install_mcp_sessions.sql
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS public.mcp_sessions (
     code_verifier TEXT,
     client_id TEXT,
     oauth_state JSONB,
+    metadata JSONB,               -- Caller-supplied key-value pairs, stored opaquely
     CONSTRAINT mcp_sessions_user_session_unique
         UNIQUE (user_id, session_id)
 );

--- a/packages/client/migrations/neon/20260819000000_add_metadata_to_mcp_sessions.sql
+++ b/packages/client/migrations/neon/20260819000000_add_metadata_to_mcp_sessions.sql
@@ -1,0 +1,7 @@
+-- Add caller-supplied metadata to mcp_sessions.
+-- The library stores this opaquely and never reads or interprets it.
+-- Callers can use it to attach their own reference IDs
+-- (e.g. a catalog server ID, tenant ID, workspace ID, etc.).
+
+ALTER TABLE public.mcp_sessions
+ADD COLUMN IF NOT EXISTS metadata JSONB;

--- a/packages/client/migrations/supabase/20260330195700_install_mcp_sessions.sql
+++ b/packages/client/migrations/supabase/20260330195700_install_mcp_sessions.sql
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS public.mcp_sessions (
     code_verifier TEXT,
     client_id TEXT,
     oauth_state JSONB,
+    metadata JSONB,               -- Caller-supplied key-value pairs, stored opaquely
     CONSTRAINT mcp_sessions_user_session_unique
         UNIQUE (user_id, session_id)
 );

--- a/packages/client/migrations/supabase/20260819000000_add_metadata_to_mcp_sessions.sql
+++ b/packages/client/migrations/supabase/20260819000000_add_metadata_to_mcp_sessions.sql
@@ -1,0 +1,7 @@
+-- Add caller-supplied metadata to mcp_sessions.
+-- The library stores this opaquely and never reads or interprets it.
+-- Callers can use it to attach their own reference IDs
+-- (e.g. a catalog server ID, tenant ID, workspace ID, etc.).
+
+ALTER TABLE public.mcp_sessions
+ADD COLUMN IF NOT EXISTS metadata JSONB;

--- a/packages/client/src/client/react/use-mcp.ts
+++ b/packages/client/src/client/react/use-mcp.ts
@@ -11,6 +11,7 @@ import {
   isTransientReconnectState,
 } from '../utils/session-state';
 import type { McpConnectionEvent, McpConnectionState } from '../../shared/events';
+import { AUTH_REDIRECT_DEBOUNCE_MS } from '../../shared/constants';
 import type {
   ToolInfo,
   FinishAuthResult,
@@ -259,6 +260,7 @@ export function useMcp(options: UseMcpOptions): McpClient {
   const clientRef = useRef<SSEClient | null>(null);
   const isMountedRef = useRef(true);
   const suppressAuthRedirectSessionsRef = useRef<Set<string>>(new Set());
+  const lastDispatchedAuthRef = useRef<Map<string, number>>(new Map());
 
   const [connections, setConnections] = useState<McpConnection[]>([]);
   const [status, setStatus] = useState<'connecting' | 'connected' | 'disconnected' | 'error'>(
@@ -388,15 +390,36 @@ export function useMcp(options: UseMcpOptions): McpClient {
 
           // Suppress redirects/popups for auto-restore on page load.
           if (!suppressAuthRedirectSessionsRef.current.has(event.sessionId)) {
-            if (onRedirect) {
-              onRedirect(url);
-            } else if (typeof window !== 'undefined') {
-              window.location.href = url;
+            const now = Date.now();
+            const lastDispatched = lastDispatchedAuthRef.current.get(event.sessionId);
+            if (!lastDispatched || now - lastDispatched > AUTH_REDIRECT_DEBOUNCE_MS) {
+              lastDispatchedAuthRef.current.set(event.sessionId, now);
+              if (onRedirect) {
+                onRedirect(url);
+              } else if (typeof window !== 'undefined') {
+                window.location.href = url;
+              }
             }
           }
-          return prev.map((c: McpConnection) =>
-            c.sessionId === event.sessionId ? { ...c, state: 'AUTHENTICATING', authUrl: url } : c
-          );
+          const existing = prev.find((c: McpConnection) => c.sessionId === event.sessionId);
+          if (existing) {
+            return prev.map((c: McpConnection) =>
+              c.sessionId === event.sessionId ? { ...c, state: 'AUTHENTICATING', authUrl: url } : c
+            );
+          }
+          return [
+            ...prev,
+            {
+              sessionId: event.sessionId,
+              serverId: event.serverId,
+              serverName: event.serverId,
+              state: 'AUTHENTICATING' as const,
+              authUrl: url,
+              tools: [],
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          ];
         }
 
         case 'error': {
@@ -410,20 +433,39 @@ export function useMcp(options: UseMcpOptions): McpClient {
             clientRef.current.preloadToolUiResources(event.sessionId, event.tools);
           }
 
-          return prev.map((c: McpConnection) =>
-            c.sessionId === event.sessionId
-              ? {
-                  ...c,
-                  tools: event.tools,
-                  allTools: (event as any).allTools,
-                  prompts: (event as any).prompts,
-                  resources: (event as any).resources,
-                  resourceTemplates: (event as any).resourceTemplates,
-                  state: 'READY' as const,
-                  updatedAt: new Date(),
-                }
-              : c
-          );
+          const existing = prev.find((c: McpConnection) => c.sessionId === event.sessionId);
+          if (existing) {
+            return prev.map((c: McpConnection) =>
+              c.sessionId === event.sessionId
+                ? {
+                    ...c,
+                    tools: event.tools,
+                    allTools: (event as any).allTools,
+                    prompts: (event as any).prompts,
+                    resources: (event as any).resources,
+                    resourceTemplates: (event as any).resourceTemplates,
+                    state: 'READY' as const,
+                    updatedAt: new Date(),
+                  }
+                : c
+            );
+          }
+          return [
+            ...prev,
+            {
+              sessionId: event.sessionId,
+              serverId: event.serverId,
+              serverName: event.serverId,
+              tools: event.tools,
+              allTools: (event as any).allTools,
+              prompts: (event as any).prompts,
+              resources: (event as any).resources,
+              resourceTemplates: (event as any).resourceTemplates,
+              state: 'READY' as const,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          ];
         }
 
         case 'disconnected': {
@@ -448,23 +490,25 @@ export function useMcp(options: UseMcpOptions): McpClient {
       const result = await clientRef.current.listSessions();
       const sessions = result.sessions || [];
 
-      // Initialize connections
+      // Initialize connections (only active sessions; pending OAuth sessions are not restored on reload)
       if (isMountedRef.current) {
         setConnections(
-          sessions.map((s: SessionInfo) => ({
-            sessionId: s.sessionId,
-            serverId: s.serverId ?? 'unknown',
-            serverName: s.serverName ?? 'Unknown Server',
-            serverUrl: s.serverUrl,
-            transport: s.transport,
-            state: getInitialConnectionState(s.status),
-            createdAt: new Date(s.createdAt),
-            updatedAt: new Date(s.updatedAt ?? s.createdAt),
-            toolPolicy: s.toolPolicy,
-            enabled: s.enabled,
-            metadata: s.metadata,
-            tools: [],
-          }))
+          sessions
+            .filter((s: SessionInfo) => s.status === 'active')
+            .map((s: SessionInfo) => ({
+              sessionId: s.sessionId,
+              serverId: s.serverId ?? 'unknown',
+              serverName: s.serverName ?? 'Unknown Server',
+              serverUrl: s.serverUrl,
+              transport: s.transport,
+              state: getInitialConnectionState(s.status),
+              createdAt: new Date(s.createdAt),
+              updatedAt: new Date(s.updatedAt ?? s.createdAt),
+              toolPolicy: s.toolPolicy,
+              enabled: s.enabled,
+              metadata: s.metadata,
+              tools: [],
+            }))
         );
       }
 
@@ -541,6 +585,7 @@ export function useMcp(options: UseMcpOptions): McpClient {
     }
 
     await clientRef.current.disconnectFromServer(sessionId);
+    lastDispatchedAuthRef.current.delete(sessionId);
 
     // Remove from local state
     if (isMountedRef.current) {

--- a/packages/client/src/client/react/use-mcp.ts
+++ b/packages/client/src/client/react/use-mcp.ts
@@ -100,6 +100,8 @@ export interface McpConnection {
   updatedAt?: Date;
   toolPolicy?: ToolPolicy;
   enabled?: boolean;
+  /** Caller-supplied metadata, stored and returned opaquely. */
+  metadata?: Record<string, string>;
 }
 
 export interface McpClient {
@@ -460,6 +462,7 @@ export function useMcp(options: UseMcpOptions): McpClient {
             updatedAt: new Date(s.updatedAt ?? s.createdAt),
             toolPolicy: s.toolPolicy,
             enabled: s.enabled,
+            metadata: s.metadata,
             tools: [],
           }))
         );

--- a/packages/client/src/client/utils/session-state.ts
+++ b/packages/client/src/client/utils/session-state.ts
@@ -2,7 +2,7 @@ import type { McpConnectionState } from '../../shared/events';
 import type { SessionInfo } from '../../shared/types';
 
 export function getInitialConnectionState(status: SessionInfo['status']): McpConnectionState {
-    return status === 'active' ? 'VALIDATING' : 'AUTHENTICATING';
+    return status === 'active' ? 'VALIDATING' : 'DISCONNECTED';
 }
 
 export function isTransientReconnectState(state: McpConnectionState): boolean {

--- a/packages/client/src/server/handlers/sse-handler.ts
+++ b/packages/client/src/server/handlers/sse-handler.ts
@@ -402,6 +402,7 @@ export class SSEConnectionManager {
         enabled:     s.enabled ?? true,
         protocolVersion: s.serverOptions?.transport?.protocolVersion ?? null,
         discoverResult: s.serverOptions?.discoverResult ?? null,
+        metadata:    s.metadata,
       })),
     };
   }
@@ -489,6 +490,7 @@ export class SSEConnectionManager {
       headers,
       clientInformation,
       sessionStore: this.observedStore,
+      metadata:     params.metadata,
       ...metadata,
     });
 

--- a/packages/client/src/server/handlers/sse-handler.ts
+++ b/packages/client/src/server/handlers/sse-handler.ts
@@ -460,10 +460,9 @@ export class SSEConnectionManager {
     const existing = await this.findExistingSession(serverId, params.serverUrl);
     if (existing) {
       if (existing.status === 'pending') {
-        return this.getSession({ sessionId: existing.sessionId }).then(() => ({
-          sessionId: existing.sessionId,
-          success: true,
-        }));
+        const client = this.restoreClient(existing);
+        this.cacheClient(existing.sessionId, client);
+        return this.connectAndDiscover(client, existing.sessionId, serverId);
       }
       throw new Error(
         `Connection already exists for server: ${existing.serverUrl ?? existing.serverId} (${existing.serverName})`,
@@ -909,7 +908,11 @@ export class SSEConnectionManager {
       await this.discoverAllCapabilities(sessionId, serverId);
       return { sessionId, success: true };
     } catch (error) {
-      if (error instanceof UnauthorizedError) {
+      if (
+        error instanceof UnauthorizedError ||
+        (error as any)?.name === 'UnauthorizedError' ||
+        (error instanceof Error && error.message.includes('OAuth authorization required'))
+      ) {
         this.clients.delete(sessionId);
         return { sessionId, success: true };
       }

--- a/packages/client/src/server/mcp/client.ts
+++ b/packages/client/src/server/mcp/client.ts
@@ -137,6 +137,12 @@ export interface MCPOAuthClientOptions {
   discoverResult?: DiscoverResult | null;
   /** Called after the server emits notifications/tools/list_changed. */
   onToolsChanged?: () => void;
+  /**
+   * Arbitrary caller-supplied key-value pairs stored alongside the session.
+   * The library stores this opaquely and never reads or interprets it.
+   * Use it to attach your own reference IDs (e.g. a catalog server ID, tenant ID, etc.).
+   */
+  metadata?: Record<string, string>;
 }
 
 export type McpClientOptions = MCPOAuthClientOptions;
@@ -266,6 +272,7 @@ export class McpClient {
       headers: this.config.headers,
       createdAt: this.createdAt ?? Date.now(),
       updatedAt: Date.now(),
+      metadata: this.config.metadata,
     };
   }
 

--- a/packages/client/src/server/storage/neon-backend.ts
+++ b/packages/client/src/server/storage/neon-backend.ts
@@ -104,6 +104,7 @@ export class NeonStorageBackend implements SessionStore {
             clientId: row.client_id ?? undefined,
             oauthState: row.oauth_state as Session['oauthState'],
             enabled: row.enabled ?? true,
+            metadata: (row as any).metadata ?? undefined,
         };
     }
 
@@ -148,6 +149,11 @@ export class NeonStorageBackend implements SessionStore {
             values.push(toolPolicy);
         }
 
+        if (session.metadata) {
+            columns.push('metadata');
+            values.push(session.metadata);
+        }
+
         const placeholders = values.map((_, i) => `$${i + 1}`);
 
         try {
@@ -184,7 +190,8 @@ export class NeonStorageBackend implements SessionStore {
             'headers' in data ||
             'authUrl' in data ||
             'toolPolicy' in data ||
-            'enabled' in data
+            'enabled' in data ||
+            'metadata' in data
         );
 
         if (shouldUpdateSession) {
@@ -215,6 +222,10 @@ export class NeonStorageBackend implements SessionStore {
 
             if ('enabled' in data) {
                 addSet('enabled', updatedSession.enabled);
+            }
+
+            if ('metadata' in data) {
+                addSet('metadata', updatedSession.metadata ?? null);
             }
 
             setClauses.push('updated_at = now()');

--- a/packages/client/src/server/storage/supabase-backend.ts
+++ b/packages/client/src/server/storage/supabase-backend.ts
@@ -58,6 +58,7 @@ export class SupabaseStorageBackend implements SessionStore {
             clientId: row.client_id,
             oauthState: row.oauth_state,
             enabled: row.enabled ?? true,
+            metadata: row.metadata ?? undefined,
         };
     }
 
@@ -95,6 +96,7 @@ export class SupabaseStorageBackend implements SessionStore {
             auth_url: session.authUrl ?? null,
             status,
             expires_at: expiresAt === null ? null : new Date(expiresAt).toISOString(),
+            metadata: session.metadata ?? null,
         };
 
         const toolPolicy = normalizeToolPolicy(session.toolPolicy);
@@ -135,6 +137,7 @@ export class SupabaseStorageBackend implements SessionStore {
         if ('authUrl' in data) updateData.auth_url = data.authUrl ?? null;
         if ('toolPolicy' in data) updateData.tool_policy = normalizeToolPolicy(data.toolPolicy);
         if ('enabled' in data) updateData.enabled = data.enabled;
+        if ('metadata' in data) updateData.metadata = data.metadata ?? null;
 
         const shouldUpdateSession = Object.keys(updateData).some((key) => key !== 'updated_at');
 

--- a/packages/client/src/server/storage/types.ts
+++ b/packages/client/src/server/storage/types.ts
@@ -84,6 +84,12 @@ export interface Session {
     codeVerifierNonce?: string | null;
     clientId?: string | null;
     oauthState?: OAuthState | null;
+    /**
+     * Arbitrary caller-supplied key-value pairs stored alongside the session.
+     * The library stores this opaquely and never reads or interprets it.
+     * Use it to attach your own reference IDs (e.g. a catalog server ID, tenant ID, etc.).
+     */
+    metadata?: Record<string, string>;
 }
 
 export interface SessionCredentials {

--- a/packages/client/src/shared/constants.ts
+++ b/packages/client/src/shared/constants.ts
@@ -11,6 +11,7 @@ export const DORMANT_SESSION_EXPIRATION_SECONDS = Math.floor(DORMANT_SESSION_EXP
 
 // Heartbeat and Connection
 export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30000; // 30 seconds
+export const AUTH_REDIRECT_DEBOUNCE_MS = 1000; // 1 second debounce for OAuth redirect dispatches
 
 // Redis Key Prefixes
 export const REDIS_KEY_PREFIX = 'mcp:session:';
@@ -21,7 +22,7 @@ export const DEFAULT_CLIENT_URI = 'https://mcp-assistant.in';
 export const DEFAULT_LOGO_URI = 'https://mcp-assistant.in/logo.svg';
 export const DEFAULT_POLICY_URI = 'https://mcp-assistant.in/privacy';
 export const SOFTWARE_ID = '@mcp-ts';
-export const SOFTWARE_VERSION = '2.6.2';
+export const SOFTWARE_VERSION = '4.0.0';
 
 // MCP Client Configuration
 export const MCP_CLIENT_NAME = 'mcp-ts-oauth-client';

--- a/packages/client/src/shared/types.ts
+++ b/packages/client/src/shared/types.ts
@@ -228,6 +228,12 @@ export interface ConnectParams {
   headers?: Record<string, string>;
   clientId?: string;
   clientSecret?: string;
+  /**
+   * Arbitrary caller-supplied key-value pairs stored alongside the session.
+   * The library stores this opaquely and never reads or interprets it.
+   * Use it to attach your own reference IDs (e.g. a catalog server ID, tenant ID, etc.).
+   */
+  metadata?: Record<string, string>;
 }
 
 export interface DisconnectParams {
@@ -318,6 +324,8 @@ export interface SessionInfo {
   protocolEra?: ProtocolEra | null;
   protocolVersion?: string | null;
   discoverResult?: DiscoverResult | null;
+  /** Caller-supplied metadata, stored and returned opaquely. */
+  metadata?: Record<string, string>;
 }
 
 export interface SessionListResult {


### PR DESCRIPTION
## What is the type of this PR?

- [x] Bugfix
- [ ] Feature
- [x] Refactoring
- [ ] Documentation
- [ ] Other

## Which area of the project does this PR affect?

- [x] `server` (MCP client, handlers)
- [x] `client` (React, Vue, SSE client)
- [ ] `adapters` (Vercel AI, LangChain, Mastra, AG-UI)
- [x] `storage` (Redis, SQLite, File, Memory backends)
- [ ] `docs` (Docusaurus documentation)
- [ ] `examples` (Example applications)
- [ ] `ci` (GitHub workflows)
- [x] Other (`cli`)

## Description of the change

Addresses all 4 robustness items from #195:

1. **`RemoteBridgeClient.waitForReady` Reconnect Lifecycle**:
   - Resets `readyPromise` when socket closes or stops.
   - Re-resolves `readyPromise` only upon successful post-reconnect initialization.

2. **`pingGateway` Validation**:
   - Validates HTTP 200/406 with `content-type` checking and JSON-RPC structure verification, eliminating false positives from non-MCP servers on port 8765.

3. **`LocalHttpMcp` Router Caching**:
   - Caches `McpServer` and `ToolRouter` instances against registry catalog version counter instead of rebuilding per incoming JSON-RPC HTTP request.

4. **`replaceRemoteCatalog` Rollback Protection**:
   - Backs up previous catalog state and rolls back if an error occurs during remote catalog replacement or index rebuilds.
   - Added catalog version counter on registry mutations.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] Code follows TypeScript strict mode guidelines
- [x] Tests added/updated
- [x] Documentation updated (if user-facing change)
- [x] Build succeeds (`npm run build`)
- [x] Type check passes (`npm run type-check`)
- [x] All tests pass (`npm test`)
- [x] Commit messages follow conventional format

## Related Issue

Closes #195
